### PR TITLE
6.2.24: the stable release, with NuGet lock files and every CI restore held to them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,14 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
+      # --locked-mode: restore exactly the graph recorded in packages.lock.json
+      # and fail if it would resolve anything else. The lock files are committed
+      # beside each project (RestorePackagesWithLockFile in
+      # source/Tools/Directory.Build.props); a package bump without its lock
+      # file update fails here rather than building against a different graph
+      # than the one reviewed.
       - name: Restore
-        run: dotnet restore hmailserver/source/Tools/ControlPanel/ControlPanel.csproj
+        run: dotnet restore hmailserver/source/Tools/ControlPanel/ControlPanel.csproj --locked-mode
 
       - name: Build (Release, warnings as errors)
         run: dotnet build hmailserver/source/Tools/ControlPanel/ControlPanel.csproj -c Release --no-restore -warnaserror
@@ -66,7 +72,7 @@ jobs:
 
       - name: Restore tests
         shell: bash
-        run: dotnet restore hmailserver/source/Tools/ControlPanel.Tests/ControlPanel.Tests.csproj
+        run: dotnet restore hmailserver/source/Tools/ControlPanel.Tests/ControlPanel.Tests.csproj --locked-mode
 
       - name: Test with coverage
         shell: bash
@@ -103,8 +109,11 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
+      - name: Restore (locked to packages.lock.json)
+        run: dotnet restore "hmailserver/source/Tools/hMailServer Tools.sln" --locked-mode
+
       - name: Build tools solution (Release)
-        run: dotnet build "hmailserver/source/Tools/hMailServer Tools.sln" -c Release -warnaserror
+        run: dotnet build "hmailserver/source/Tools/hMailServer Tools.sln" -c Release --no-restore -warnaserror
 
       - name: Publish smoke check
         shell: pwsh

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -93,11 +93,15 @@ jobs:
       # covering those tools was the one being switched off for ignoring the
       # config. The test projects are not built here and stay unscanned:
       # fixtures, not shipped code.
+      # RestoreLockedMode: the implicit restore inside these builds is held to
+      # the committed packages.lock.json files, the same way ci.yml's explicit
+      # restores are, so the code that is analysed is built against the graph
+      # that was reviewed.
       - name: Build Control Panel
-        run: dotnet build hmailserver/source/Tools/ControlPanel/ControlPanel.csproj -c Release
+        run: dotnet build hmailserver/source/Tools/ControlPanel/ControlPanel.csproj -c Release -p:RestoreLockedMode=true
 
       - name: Build the setup and migration tools
-        run: dotnet build "hmailserver/source/Tools/hMailServer Tools.sln" -c Release
+        run: dotnet build "hmailserver/source/Tools/hMailServer Tools.sln" -c Release -p:RestoreLockedMode=true
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -41,14 +41,14 @@ than a wording problem.
 
 ### Contents and totals
 
-842 items. The counts are the point of this table — they say where the fork is
+843 items. The counts are the point of this table — they say where the fork is
 strong and where it is thin far more honestly than any prose summary.
 
 | Section | ✅ | 🔄 | ⬜ | ⏸️ |
 |---|--:|--:|--:|--:|
 | **Urgent — the OpenSSF gold badge** | | | | |
 | [What stands between here and gold](#what-stands-between-here-and-gold) | 3 | – | 6 | 3 |
-| [Housekeeping that fell out of the badge work](#housekeeping-that-fell-out-of-the-badge-work) | 2 | – | 1 | 1 |
+| [Housekeeping that fell out of the badge work](#housekeeping-that-fell-out-of-the-badge-work) | 3 | – | 1 | 1 |
 | [Dated items — the forcing functions](#dated-items--the-forcing-functions) | 2 | – | 4 | 1 |
 | [Defects found by the audit](#defects-found-by-the-audit) | 30 | – | – | – |
 | **The next generation** | | | | |
@@ -78,7 +78,7 @@ strong and where it is thin far more honestly than any prose summary.
 | [Future-proofing: standards and protocols](#future-proofing-standards-and-protocols) | 8 | – | – | 2 |
 | [Future-proofing: platform and supply chain](#future-proofing-platform-and-supply-chain) | 5 | 1 | 2 | 2 |
 | [Future-proofing: deployment and operations](#future-proofing-deployment-and-operations) | 6 | 2 | 1 | – |
-| **Total** | **736** | **13** | **73** | **20** |
+| **Total** | **737** | **13** | **73** | **20** |
 
 Three things stand out and are worth naming rather than leaving to be inferred.
 **Storage, the administration surface and the core protocol layer are the
@@ -168,6 +168,7 @@ small change rather than a project.
 |:-:|---|---|
 | ✅ | **Interop manifest drift** | **Closed 22 August 2026.** Regenerating `Interop.hMailServer.dll` after a COM API change without updating its SHA-256 in `hmailserver/docs/third-party-binaries.json` failed the binary-provenance check twice on 21 August alone, after two different people had each done the first half correctly. Two steps that must always happen together are now one step: `build/regenerate-interop.ps1` runs TlbImp and rewrites the manifest entry's hash and size in place, refuses to run from a type library older than the IDL's last commit or its uncommitted edits (an mtime alone is not evidence - git bumps it on every checkout, which is how the first version of that guard refused a current library), and prefers the intermediate `.tlb` MIDL just wrote over a stale staged copy. `RELEASE.md` step 8 and `Interop/README.md` point at it. Verified by running it against a fresh Release build: manifest and disk agreed afterwards. |
 | ⏸️ | **Repository setting: Code quality** | **Tested 22 August 2026 and settled.** The CI coverage upload needs the *Code quality* repository setting, and with the setting configured and *no languages* the upload does succeed (`PATCH /repos/{o}/{r}/code-quality/setup`, `{"state":"configured","languages":[]}`; CI run 32552896421). But the setting being on at all re-exposes the 1,482 stale findings of the managed buildless scan that was switched off on 21 August for ignoring the repository's analysis configuration — and with no languages configured nothing ever re-scans them closed. There is no API to dismiss findings. So the setting stays off, the cobertura build artifact is the coverage record, and `fail-on-error: false` stays with the reasoning written beside it. Revisit only if GitHub adds per-rule filtering or a dismissal API to the feature. |
+| ✅ | **The five Scorecard findings on the code-scanning page** | **Cleared 4 September 2026, one by code and four with the reason written on the dismissal.** Pinned-Dependencies was the only one code could fix: NuGet lock files (`packages.lock.json`, `RestorePackagesWithLockFile` in `source/Tools/Directory.Build.props`) beside all nine SDK-style projects, and every restore in CI - the two explicit ones in `ci.yml`, the tools build, and the implicit ones inside the CodeQL builds - held to them with locked mode, so a package bump without its lock-file update fails the build instead of quietly resolving a different graph. Branch-Protection and Code-Review both require a second reviewer, which one maintainer cannot supply, and are dismissed pointing at the `bus_factor` and `two_person_review` rows above; required status checks (eight of them, strict) were added to the master ruleset anyway, because a red CI should not be mergeable, with the announced admin bypass kept for emergencies. Maintained warns only that the repository is younger than 90 days, which stops being true on 10 September. SAST counts commits inside a 30-commit window that still holds pre-workflow direct pushes; every pull request since 22 August is analysed and the old ones leave the window as new ones land. |
 | ✅ | **Repository setting: automatic dependency submission** | **Closed 4 September 2026 by making it work rather than switching it off.** GitHub's own NuGet submission job was red on every push because it restores every project on a Linux runner and the first `net10.0-windows` project fails with NETSDK1100. A one-property `Directory.Build.props` under `source/Tools` (`EnableWindowsTargeting=true`, inert on Windows) lets the restore complete, so the dependency graph now receives the transitive NuGet packages the manifests alone do not show. The setting stays on. |
 | ⬜ | **Organisation setting: require 2FA** | The maintainer account uses a passkey; the org-wide requirement is still off (the API refused it — it would eject any member without 2FA, and the org has a second, read-only member). Enable it in *Authentication security* once that member is confirmed enrolled. |
 

--- a/hmailserver/installation/section_setup_64.iss
+++ b/hmailserver/installation/section_setup_64.iss
@@ -1,7 +1,7 @@
 [Setup]
-OutputBaseFilename=hMailServer-6.2.23-alpha2-x64
-AppVerName=hMailServer 6.2.23-alpha2-x64
+OutputBaseFilename=hMailServer-6.2.24-x64
+AppVerName=hMailServer 6.2.24-x64
 ArchitecturesInstallIn64BitMode=x64
 ArchitecturesAllowed=x64
-AppVersion=6.2.23-alpha2
-VersionInfoVersion=6.2.23.0
+AppVersion=6.2.24
+VersionInfoVersion=6.2.24.0

--- a/hmailserver/source/Server/Common/Application/Version.h
+++ b/hmailserver/source/Server/Common/Application/Version.h
@@ -2,6 +2,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 #pragma once
-                                              #define HMAILSERVER_VERSION "6.2.23"
-                                              #define HMAILSERVER_VERSION_NUMERIC 6,2,23,33
-                                              #define HMAILSERVER_BUILD 33
+                                              #define HMAILSERVER_VERSION "6.2.24"
+                                              #define HMAILSERVER_VERSION_NUMERIC 6,2,24,34
+                                              #define HMAILSERVER_BUILD 34

--- a/hmailserver/source/Tools/ControlPanel.Core/packages.lock.json
+++ b/hmailserver/source/Tools/ControlPanel.Core/packages.lock.json
@@ -1,0 +1,6 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net10.0-windows7.0": {}
+  }
+}

--- a/hmailserver/source/Tools/ControlPanel.Tests/packages.lock.json
+++ b/hmailserver/source/Tools/ControlPanel.Tests/packages.lock.json
@@ -1,0 +1,115 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net10.0-windows7.0": {
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "27jXSV/0DbVqF5jDrAxuQFZ9oaz6gmG03p8ttxAFk+X0M4woFYj7MoWDLCna5EGLb0CE6OE7X6ZH3Wt5smTtaA=="
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[18.9.0, )",
+        "resolved": "18.9.0",
+        "contentHash": "xIzVXa/VpKXqDWzyC/5Hw8JbFY5u9k3Jc53CpcjBiOXvkQGio484LD9FNwOiGUSMDcYL3Rcw9sNgGi5WrswlPQ==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "18.9.0",
+          "Microsoft.TestPlatform.TestHost": "18.9.0"
+        }
+      },
+      "System.Management": {
+        "type": "Direct",
+        "requested": "[10.0.11, )",
+        "resolved": "10.0.11",
+        "contentHash": "xyNn8KGbWI88LoUwg3rB8qcpFFST6dr8Ro/qS8GBu2GOwR0v7J82kVFHTiiPtvEKS79VbMTxs/sIKQ+Cq1Zs1g==",
+        "dependencies": {
+          "System.CodeDom": "10.0.11"
+        }
+      },
+      "xunit": {
+        "type": "Direct",
+        "requested": "[2.9.3, )",
+        "resolved": "2.9.3",
+        "contentHash": "TlXQBinK35LpOPKHAqbLY4xlEen9TBafjs0V5KnA4wZsoQLQJiirCR4CbIXvOH8NzkW4YeJKP5P/Bnrodm0h9Q==",
+        "dependencies": {
+          "xunit.analyzers": "1.18.0",
+          "xunit.assert": "2.9.3",
+          "xunit.core": "[2.9.3]"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[4.0.0, )",
+        "resolved": "4.0.0",
+        "contentHash": "kzLFyBYUnoidpGOXvpNOfIo8C92gVgVR6X8ncHwhcrDYugiOut5rrhDkr0L3cWHd7J2pKXf6LgaeXoBBDlx1ag=="
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "18.9.0",
+        "contentHash": "MtegCIKGuG0r/LCdIjoR1HgzCGIUBhR3aNdbtQpts5vMXQuqBDZ2Jsd2uFKoHFM2XrQV6ZrDf3F5oLi3SLTp8w=="
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "18.9.0",
+        "contentHash": "Fz/qXC52VXXopzHj7v2reCKcCqSxkTDCkEDfkNAH0vni/7qK/KLMiEYtRmnUanxO2F2g2zZZ60qCpxF0AF7URA=="
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "18.9.0",
+        "contentHash": "Oq+Pma/J86aZL72t71bcESvDszDsTjUfl6PIsuDdPoKTHZfNMhKamCfLD5fKx51W/u0KozXtJo2/3fnt0sgPxg==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "18.9.0"
+        }
+      },
+      "System.CodeDom": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "v40pNeBoZTYsiVxz+PzyZmmIr2JIhpK4VsFpQqZSZCXa51PDlNXIN2ESm8kDU0voZYVfLhxF9HvmBsxCJmkiRg=="
+      },
+      "xunit.abstractions": {
+        "type": "Transitive",
+        "resolved": "2.0.3",
+        "contentHash": "pot1I4YOxlWjIb5jmwvvQNbTrZ3lJQ+jUGkGjWE3hEFM0l5gOnBWS+H3qsex68s5cO52g+44vpGzhAt+42vwKg=="
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.18.0",
+        "contentHash": "OtFMHN8yqIcYP9wcVIgJrq01AfTxijjAqVDy/WeQVSyrDC1RzBWeQPztL49DN2syXRah8TYnfvk035s7L95EZQ=="
+      },
+      "xunit.assert": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "/Kq28fCE7MjOV42YLVRAJzRF0WmEqsmflm0cfpMjGtzQ2lR5mYVj1/i0Y8uDAOLczkL3/jArrwehfMD0YogMAA=="
+      },
+      "xunit.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "BiAEvqGvyme19wE0wTKdADH+NloYqikiU0mcnmiNyXaF9HyHmE6sr/3DC5vnBkgsWaE6yPyWszKSPSApWdRVeQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]",
+          "xunit.extensibility.execution": "[2.9.3]"
+        }
+      },
+      "xunit.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "kf3si0YTn2a8J8eZNb+zFpwfoyvIrQ7ivNk5ZYA5yuYk1bEtMe4DxJ2CF/qsRgmEnDr7MnW1mxylBaHTZ4qErA==",
+        "dependencies": {
+          "xunit.abstractions": "2.0.3"
+        }
+      },
+      "xunit.extensibility.execution": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "yMb6vMESlSrE3Wfj7V6cjQ3S4TXdXpRqYeNEI3zsX31uTsGMJjEw6oD5F5u1cHnMptjhEECnmZSsPxB6ChZHDQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]"
+        }
+      },
+      "hMailCP.Core": {
+        "type": "Project"
+      }
+    }
+  }
+}

--- a/hmailserver/source/Tools/ControlPanel/ControlPanel.csproj
+++ b/hmailserver/source/Tools/ControlPanel/ControlPanel.csproj
@@ -12,7 +12,7 @@
     <RootNamespace>hMailServer.ControlPanel</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>app.ico</ApplicationIcon>
-    <Version>6.2.23-alpha2</Version>
+    <Version>6.2.24</Version>
     <!-- MSBuild inserts the platform name into the output path for any
          platform other than AnyCPU, so building ControlPanel.sln (x64) and
          running `dotnet build ControlPanel.csproj` (AnyCPU) produce two

--- a/hmailserver/source/Tools/ControlPanel/packages.lock.json
+++ b/hmailserver/source/Tools/ControlPanel/packages.lock.json
@@ -1,0 +1,178 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net10.0-windows7.0": {
+      "LiveChartsCore.SkiaSharpView.WPF": {
+        "type": "Direct",
+        "requested": "[2.0.5, )",
+        "resolved": "2.0.5",
+        "contentHash": "CffAGQ6VjBAfmrLJ0/dUGNR9hZDhEfw4Z9JSTUVjc+vRQBYI+i/AmJuN2BMGI1pDI2n9y1cLSk5vAnuuF8V/qw==",
+        "dependencies": {
+          "LiveChartsCore.SkiaSharpView": "2.0.5",
+          "SkiaSharp.HarfBuzz": "3.119.0",
+          "SkiaSharp.Views.WPF": "3.119.0"
+        }
+      },
+      "QRCoder": {
+        "type": "Direct",
+        "requested": "[1.8.0, )",
+        "resolved": "1.8.0",
+        "contentHash": "RuvX3PEXU6pbY/I5ItAk800jm62r+YnoPLgyS2WTgwxkOnGkOfU9ORiipHUF0LkLyqM8rlroUCA319JjRYfRFQ=="
+      },
+      "System.Management": {
+        "type": "Direct",
+        "requested": "[10.0.11, )",
+        "resolved": "10.0.11",
+        "contentHash": "xyNn8KGbWI88LoUwg3rB8qcpFFST6dr8Ro/qS8GBu2GOwR0v7J82kVFHTiiPtvEKS79VbMTxs/sIKQ+Cq1Zs1g=="
+      },
+      "System.ServiceProcess.ServiceController": {
+        "type": "Direct",
+        "requested": "[10.0.11, )",
+        "resolved": "10.0.11",
+        "contentHash": "khROyIQ3GAZy5MbCabfmlbvxf9nuvdveFP2XbRCteZ9Lq8OFEvImmrjV6acl1LegRu/9T6VMxi9Lr+KZu29VHg=="
+      },
+      "WPF-UI": {
+        "type": "Direct",
+        "requested": "[4.3.0, )",
+        "resolved": "4.3.0",
+        "contentHash": "SIHhc8lIrhEQ/1cLFZN6Dtf8cqsLm4myBULj9obnacd9TyDs2vizhKYzRzTlcPEcnzb3L4EstvPN3M6kcXbJCA==",
+        "dependencies": {
+          "WPF-UI.Abstractions": "4.3.0"
+        }
+      },
+      "HarfBuzzSharp": {
+        "type": "Transitive",
+        "resolved": "8.3.1.1",
+        "contentHash": "tLZN66oe/uiRPTZfrCU4i8ScVGwqHNh5MHrXj0yVf4l7Mz0FhTGnQ71RGySROTmdognAs0JtluHkL41pIabWuQ==",
+        "dependencies": {
+          "HarfBuzzSharp.NativeAssets.Win32": "8.3.1.1",
+          "HarfBuzzSharp.NativeAssets.macOS": "8.3.1.1"
+        }
+      },
+      "HarfBuzzSharp.NativeAssets.macOS": {
+        "type": "Transitive",
+        "resolved": "8.3.1.1",
+        "contentHash": "jbtCsgftcaFLCA13tVKo5iWdElJScrulLTKJre36O4YQTIlwDtPPqhRZNk+Y0vv4D1gxbscasGRucUDfS44ofQ=="
+      },
+      "HarfBuzzSharp.NativeAssets.Win32": {
+        "type": "Transitive",
+        "resolved": "8.3.1.1",
+        "contentHash": "UsJtQsfAJoFDZrXc4hCUfRPMqccfKZ0iumJ/upcUjz/cmsTgVFGNEL5yaJWmkqsuFYdMWbj/En5/kS4PFl9hBA=="
+      },
+      "LiveChartsCore": {
+        "type": "Transitive",
+        "resolved": "2.0.5",
+        "contentHash": "cbGiOyGxO+fsWLvrQ4R6Rd8QHfkRGyhxyD6nBSk8/ZwKKtU+vWSqlC4ESgwKSUbrzvK8ooU/yfFJpjHXzPd+vA=="
+      },
+      "LiveChartsCore.SkiaSharpView": {
+        "type": "Transitive",
+        "resolved": "2.0.5",
+        "contentHash": "YgRhisuVev2RocHqq7d9juSBGBlMLKYQA5ijEuD/sWeV39dCBInBK4RSfqBYTuNNWs5Fe+NA+F0TCIWJ2t1Cew==",
+        "dependencies": {
+          "LiveChartsCore": "2.0.5",
+          "SkiaSharp": "2.88.9",
+          "SkiaSharp.HarfBuzz": "2.88.9"
+        }
+      },
+      "OpenTK": {
+        "type": "Transitive",
+        "resolved": "3.3.1",
+        "contentHash": "vJ00JIs0EOEhqU3+1w6ocurNUFaewd7YXV8sixI029AQeQaht0QjDGgXm2Fk/y8A5Wtx6UsmrjJDKi4USoVeSg=="
+      },
+      "OpenTK.GLWpfControl": {
+        "type": "Transitive",
+        "resolved": "3.3.0",
+        "contentHash": "viHlwA0RIYLA1EyoA+gOkfqpA9xMZV6HigVYhaHaEsYb3jk518RdCKEdFggu/P4oYUNYZmmHaUYDC9pwarkXjA==",
+        "dependencies": {
+          "OpenTK": "[3.3.0, 3.4.0)"
+        }
+      },
+      "SkiaSharp": {
+        "type": "Transitive",
+        "resolved": "3.119.0",
+        "contentHash": "gR9yVoOta2Mc1Rxt15LD65AckfHMfwjIs/3kkD59C9bT2nYYISsE6uz3t4aMPNHA6CgsIL0Ssn+jE5OVilZ1yw==",
+        "dependencies": {
+          "SkiaSharp.NativeAssets.Win32": "3.119.0",
+          "SkiaSharp.NativeAssets.macOS": "3.119.0"
+        }
+      },
+      "SkiaSharp.HarfBuzz": {
+        "type": "Transitive",
+        "resolved": "3.119.0",
+        "contentHash": "5ocGzl+RYEZFnUPUbModshnEFvKTku4hTtOBsLvy5MCK2KAHjq5Nw2+uAVUx79Rjh0z8fTojT6ZVav8MJgW0ug==",
+        "dependencies": {
+          "HarfBuzzSharp": "8.3.1.1",
+          "SkiaSharp": "3.119.0"
+        }
+      },
+      "SkiaSharp.NativeAssets.macOS": {
+        "type": "Transitive",
+        "resolved": "3.119.0",
+        "contentHash": "YE1vNn0Nyw2PWtv7hw1PYkKJO0itFiQp9vSqGppZUKzQJqwp28a2jgdCMPfYtOiR8KCnDgZqQoynqJRRaE2ZVg=="
+      },
+      "SkiaSharp.NativeAssets.Win32": {
+        "type": "Transitive",
+        "resolved": "3.119.0",
+        "contentHash": "IwC9yx36lOdXVT2DjgmWHl1qkVspfj8ctd4+li8CNnvqdfaTolXCOh6TLznURcPAvzatx9K/tLOB7zT6T8EA9w=="
+      },
+      "SkiaSharp.Views.Desktop.Common": {
+        "type": "Transitive",
+        "resolved": "3.119.0",
+        "contentHash": "KST7Q3n+X5BhDj1aKTJXk9tITWWznveka9n+pBjOtE53Omc+wlZR0s4fQStybWCVVaWG9eaeOMaw93J3zEMklA==",
+        "dependencies": {
+          "SkiaSharp": "3.119.0"
+        }
+      },
+      "SkiaSharp.Views.WPF": {
+        "type": "Transitive",
+        "resolved": "3.119.0",
+        "contentHash": "1Dmj9RlBW/gvmJwSUER+N9plA/kcWOgiL5g3q2DB+USVQav8rQtfOZIQZ1Wt/AqhwepOacv1M6pZKDWtXmwDAg==",
+        "dependencies": {
+          "OpenTK": "3.3.1",
+          "OpenTK.GLWpfControl": "3.3.0",
+          "SkiaSharp": "3.119.0",
+          "SkiaSharp.Views.Desktop.Common": "3.119.0"
+        }
+      },
+      "WPF-UI.Abstractions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "7Kj9DmCCo4SOCd1jAiw4+EcMFP2nR8rLLvitAYzVtzbWToTsodkbie24+8x9C4LDLxkopWEUGX62szqqNy7oeg=="
+      }
+    },
+    "net10.0-windows7.0/win-x64": {
+      "System.Management": {
+        "type": "Direct",
+        "requested": "[10.0.11, )",
+        "resolved": "10.0.11",
+        "contentHash": "xyNn8KGbWI88LoUwg3rB8qcpFFST6dr8Ro/qS8GBu2GOwR0v7J82kVFHTiiPtvEKS79VbMTxs/sIKQ+Cq1Zs1g=="
+      },
+      "System.ServiceProcess.ServiceController": {
+        "type": "Direct",
+        "requested": "[10.0.11, )",
+        "resolved": "10.0.11",
+        "contentHash": "khROyIQ3GAZy5MbCabfmlbvxf9nuvdveFP2XbRCteZ9Lq8OFEvImmrjV6acl1LegRu/9T6VMxi9Lr+KZu29VHg=="
+      },
+      "HarfBuzzSharp.NativeAssets.macOS": {
+        "type": "Transitive",
+        "resolved": "8.3.1.1",
+        "contentHash": "jbtCsgftcaFLCA13tVKo5iWdElJScrulLTKJre36O4YQTIlwDtPPqhRZNk+Y0vv4D1gxbscasGRucUDfS44ofQ=="
+      },
+      "HarfBuzzSharp.NativeAssets.Win32": {
+        "type": "Transitive",
+        "resolved": "8.3.1.1",
+        "contentHash": "UsJtQsfAJoFDZrXc4hCUfRPMqccfKZ0iumJ/upcUjz/cmsTgVFGNEL5yaJWmkqsuFYdMWbj/En5/kS4PFl9hBA=="
+      },
+      "SkiaSharp.NativeAssets.macOS": {
+        "type": "Transitive",
+        "resolved": "3.119.0",
+        "contentHash": "YE1vNn0Nyw2PWtv7hw1PYkKJO0itFiQp9vSqGppZUKzQJqwp28a2jgdCMPfYtOiR8KCnDgZqQoynqJRRaE2ZVg=="
+      },
+      "SkiaSharp.NativeAssets.Win32": {
+        "type": "Transitive",
+        "resolved": "3.119.0",
+        "contentHash": "IwC9yx36lOdXVT2DjgmWHl1qkVspfj8ctd4+li8CNnvqdfaTolXCOh6TLznURcPAvzatx9K/tLOB7zT6T8EA9w=="
+      }
+    }
+  }
+}

--- a/hmailserver/source/Tools/DBSetup/DBSetup.csproj
+++ b/hmailserver/source/Tools/DBSetup/DBSetup.csproj
@@ -18,7 +18,7 @@
     <RootNamespace>DBSetup</RootNamespace>
     <AssemblyName>DBSetup</AssemblyName>
     <ApplicationIcon>database_add.ico</ApplicationIcon>
-    <Version>6.2.23-alpha2</Version>
+    <Version>6.2.24</Version>
     <Product>hMailServer Database Setup</Product>
     <Company>Progressive Robot Ltd</Company>
     <Copyright>Copyright (c) 2026 Christopher Holloway / Progressive Robot Ltd</Copyright>

--- a/hmailserver/source/Tools/DBSetup/packages.lock.json
+++ b/hmailserver/source/Tools/DBSetup/packages.lock.json
@@ -1,0 +1,24 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net10.0-windows7.0": {
+      "System.ServiceProcess.ServiceController": {
+        "type": "Direct",
+        "requested": "[10.0.11, )",
+        "resolved": "10.0.11",
+        "contentHash": "khROyIQ3GAZy5MbCabfmlbvxf9nuvdveFP2XbRCteZ9Lq8OFEvImmrjV6acl1LegRu/9T6VMxi9Lr+KZu29VHg=="
+      },
+      "shared": {
+        "type": "Project"
+      }
+    },
+    "net10.0-windows7.0/win-x64": {
+      "System.ServiceProcess.ServiceController": {
+        "type": "Direct",
+        "requested": "[10.0.11, )",
+        "resolved": "10.0.11",
+        "contentHash": "khROyIQ3GAZy5MbCabfmlbvxf9nuvdveFP2XbRCteZ9Lq8OFEvImmrjV6acl1LegRu/9T6VMxi9Lr+KZu29VHg=="
+      }
+    }
+  }
+}

--- a/hmailserver/source/Tools/DBSetupQuick/DBSetupQuick.csproj
+++ b/hmailserver/source/Tools/DBSetupQuick/DBSetupQuick.csproj
@@ -15,7 +15,7 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <RootNamespace>DBSetupQuick</RootNamespace>
     <AssemblyName>DBSetupQuick</AssemblyName>
-    <Version>6.2.23-alpha2</Version>
+    <Version>6.2.24</Version>
     <Product>hMailServer Database Setup (quick)</Product>
     <Company>Progressive Robot Ltd</Company>
     <Copyright>Copyright (c) 2026 Christopher Holloway / Progressive Robot Ltd</Copyright>

--- a/hmailserver/source/Tools/DBSetupQuick/packages.lock.json
+++ b/hmailserver/source/Tools/DBSetupQuick/packages.lock.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net10.0-windows7.0": {
+      "shared": {
+        "type": "Project"
+      }
+    },
+    "net10.0-windows7.0/win-x64": {}
+  }
+}

--- a/hmailserver/source/Tools/DBUpdater/DBUpdater.csproj
+++ b/hmailserver/source/Tools/DBUpdater/DBUpdater.csproj
@@ -16,7 +16,7 @@
     <RootNamespace>DBUpdater</RootNamespace>
     <AssemblyName>DBUpdater</AssemblyName>
     <ApplicationIcon>database_refresh.ico</ApplicationIcon>
-    <Version>6.2.23-alpha2</Version>
+    <Version>6.2.24</Version>
     <Product>hMailServer Database Updater</Product>
     <Company>Progressive Robot Ltd</Company>
     <Copyright>Copyright (c) 2026 Christopher Holloway / Progressive Robot Ltd</Copyright>

--- a/hmailserver/source/Tools/DBUpdater/packages.lock.json
+++ b/hmailserver/source/Tools/DBUpdater/packages.lock.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net10.0-windows7.0": {
+      "shared": {
+        "type": "Project"
+      }
+    },
+    "net10.0-windows7.0/win-x64": {}
+  }
+}

--- a/hmailserver/source/Tools/DataDirectorySynchronizer/DataDirectorySynchronizer.csproj
+++ b/hmailserver/source/Tools/DataDirectorySynchronizer/DataDirectorySynchronizer.csproj
@@ -16,7 +16,7 @@
     <RootNamespace>DataDirectorySynchronizer</RootNamespace>
     <AssemblyName>DataDirectorySynchronizer</AssemblyName>
     <ApplicationIcon>georectify.ico</ApplicationIcon>
-    <Version>6.2.23-alpha2</Version>
+    <Version>6.2.24</Version>
     <Product>hMailServer Data Directory Synchronizer</Product>
     <Company>Progressive Robot Ltd</Company>
     <Copyright>Copyright (c) 2026 Christopher Holloway / Progressive Robot Ltd</Copyright>

--- a/hmailserver/source/Tools/DataDirectorySynchronizer/packages.lock.json
+++ b/hmailserver/source/Tools/DataDirectorySynchronizer/packages.lock.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net10.0-windows7.0": {
+      "shared": {
+        "type": "Project"
+      }
+    },
+    "net10.0-windows7.0/win-x64": {}
+  }
+}

--- a/hmailserver/source/Tools/Directory.Build.props
+++ b/hmailserver/source/Tools/Directory.Build.props
@@ -15,5 +15,19 @@
   -->
   <PropertyGroup>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
+
+    <!--
+      NuGet lock files (packages.lock.json beside each project). A restore
+      records the exact package graph - every transitive version and its
+      content hash - and CI restores with "dotnet restore ... -locked-mode",
+      which fails rather than silently resolving something different from
+      what was committed. That is the OpenSSF Scorecard Pinned-Dependencies
+      finding for NuGet, and it is real: without a lock file, a floating
+      transitive dependency or a re-published package version changes what
+      ships without a commit saying so. On a developer machine a plain
+      restore updates the lock file when a package reference changes; commit
+      it with the change. Dependabot updates lock files with its bumps.
+    -->
+    <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
   </PropertyGroup>
 </Project>

--- a/hmailserver/source/Tools/ImportTool/ImportTool.csproj
+++ b/hmailserver/source/Tools/ImportTool/ImportTool.csproj
@@ -15,7 +15,7 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <RootNamespace>ImportTool</RootNamespace>
     <AssemblyName>ImportTool</AssemblyName>
-    <Version>6.2.23-alpha2</Version>
+    <Version>6.2.24</Version>
     <Product>hMailServer Import Tool</Product>
     <Company>Progressive Robot Ltd</Company>
     <Copyright>Copyright (c) 2026 Christopher Holloway / Progressive Robot Ltd</Copyright>

--- a/hmailserver/source/Tools/ImportTool/packages.lock.json
+++ b/hmailserver/source/Tools/ImportTool/packages.lock.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net10.0-windows7.0": {
+      "shared": {
+        "type": "Project"
+      }
+    },
+    "net10.0-windows7.0/win-x64": {}
+  }
+}

--- a/hmailserver/source/Tools/Shared/Shared.csproj
+++ b/hmailserver/source/Tools/Shared/Shared.csproj
@@ -13,7 +13,7 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <RootNamespace>Shared</RootNamespace>
     <AssemblyName>Shared</AssemblyName>
-    <Version>6.2.23-alpha2</Version>
+    <Version>6.2.24</Version>
     <Product>hMailServer Shared Tools Library</Product>
     <Company>Progressive Robot Ltd</Company>
     <Copyright>Copyright (c) 2026 Christopher Holloway / Progressive Robot Ltd</Copyright>

--- a/hmailserver/source/Tools/Shared/packages.lock.json
+++ b/hmailserver/source/Tools/Shared/packages.lock.json
@@ -1,0 +1,6 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net10.0-windows7.0": {}
+  }
+}


### PR DESCRIPTION
6.2.24 is the code of 6.2.23 Alpha 2 plus NuGet lock files beside the nine .NET tool projects, CI restores in locked mode, and the version stamp. Nothing compiled into the server, the tools or the installer changed otherwise. Full gate on the stamped binary: 1838/1838 in 31 minutes; two clean builds gave an identical hMailServer.exe; Control Panel suite 645/645. The other four Scorecard findings are dismissed on the security page with the reason on each, and the master ruleset now requires eight status checks (this is the first pull request merged under them).