### PR TITLE
Every error- and warning-level Code Quality finding, cleared

### DIFF
--- a/hmailserver/source/Tools/ControlPanel/Services/PathPicker.cs
+++ b/hmailserver/source/Tools/ControlPanel/Services/PathPicker.cs
@@ -31,7 +31,9 @@ namespace hMailServer.ControlPanel.Services
       /// </summary>
       public static string PickFile(string current, string filter)
       {
-         var dialog = new OpenFileDialog
+         // Fully qualified: the WPF dialog, which is not disposable, not the
+         // WinForms one of the same name.
+         var dialog = new Microsoft.Win32.OpenFileDialog
          {
             Filter = string.IsNullOrEmpty(filter) ? "All files (*.*)|*.*" : filter
          };

--- a/hmailserver/source/Tools/ControlPanel/Services/ThemeTokens.cs
+++ b/hmailserver/source/Tools/ControlPanel/Services/ThemeTokens.cs
@@ -134,10 +134,10 @@ namespace hMailServer.ControlPanel.Services
 
          try
          {
-            Application current = Application.Current;
+            System.Windows.Threading.Dispatcher dispatcher = Application.Current?.Dispatcher;
 
-            if (current?.Dispatcher != null && !current.Dispatcher.CheckAccess())
-               current.Dispatcher.BeginInvoke(new Action(Refresh));
+            if (dispatcher != null && !dispatcher.CheckAccess())
+               dispatcher.BeginInvoke(new Action(Refresh));
             else
                Refresh();
          }

--- a/hmailserver/source/Tools/ControlPanel/Views/NavigationPalette.cs
+++ b/hmailserver/source/Tools/ControlPanel/Views/NavigationPalette.cs
@@ -68,7 +68,7 @@ namespace hMailServer.ControlPanel.Views
          // The application face. The palette is a plain chromeless Window, not
          // a FluentDialogWindow, so it never inherited the face the rest of
          // the app gets from its window base classes.
-         FontFamily = new FontFamily(Typography.UiFontFamily);
+         FontFamily = new System.Windows.Media.FontFamily(Typography.UiFontFamily);
          WindowStyle = WindowStyle.None;
          AllowsTransparency = true;
          Background = Brushes.Transparent;

--- a/hmailserver/source/Tools/ControlPanel/Views/ServerSettingsView.xaml.cs
+++ b/hmailserver/source/Tools/ControlPanel/Views/ServerSettingsView.xaml.cs
@@ -3272,7 +3272,7 @@ namespace hMailServer.ControlPanel.Views
       /// </summary>
       private static void WireLogFormatDependency(ComCombo format, IniBool json)
       {
-         if (format?.Combo == null || json?.Box == null)
+         if (format == null || json == null || format.Combo == null || json.Box == null)
             return;
 
          void Update()
@@ -3295,7 +3295,9 @@ namespace hMailServer.ControlPanel.Views
 
       private static void WireChaChaDependency(ComBool preferServer, ComBool chacha, ComBool tls12, ComBool tls13)
       {
-         if (preferServer?.Box == null || chacha?.Box == null || tls12?.Box == null || tls13?.Box == null)
+         if (preferServer == null || chacha == null || tls12 == null || tls13 == null)
+            return;
+         if (preferServer.Box == null || chacha.Box == null || tls12.Box == null || tls13.Box == null)
             return;
 
          void Update()

--- a/hmailserver/source/Tools/ControlPanel/Views/SslCertificatesView.xaml.cs
+++ b/hmailserver/source/Tools/ControlPanel/Views/SslCertificatesView.xaml.cs
@@ -484,7 +484,7 @@ namespace hMailServer.ControlPanel.Views
 
       private static string BrowsePem()
       {
-         var dialog = new OpenFileDialog
+         var dialog = new Microsoft.Win32.OpenFileDialog
          {
             Filter = "PEM files (*.pem;*.crt;*.key)|*.pem;*.crt;*.key|All files (*.*)|*.*"
          };

--- a/hmailserver/source/Tools/ControlPanel/Views/UtilityViews.cs
+++ b/hmailserver/source/Tools/ControlPanel/Views/UtilityViews.cs
@@ -795,8 +795,9 @@ namespace hMailServer.ControlPanel.Views
 
          Services.MessageStoreConsistencyReport report = Services.MessageStoreConsistencyReport.Parse(text);
          string when = string.IsNullOrEmpty(report.Generated) ? "" : " Last scan: " + report.Generated + ".";
-         string truncated = report.IsTruncated
-            ? " The report header says " + report.ReportedMissingCount.Value + " but lists " + report.Entries.Count +
+         int? reportedMissing = report.ReportedMissingCount;
+         string truncated = report.IsTruncated && reportedMissing.HasValue
+            ? " The report header says " + reportedMissing.Value + " but lists " + report.Entries.Count +
               " - it was probably read while the server was rewriting it, so refresh."
             : "";
 

--- a/hmailserver/source/Tools/Shared/Miscellaneous/ToolApplication.cs
+++ b/hmailserver/source/Tools/Shared/Miscellaneous/ToolApplication.cs
@@ -8,6 +8,10 @@ namespace hMailServer.Shared
 {
    public static class ToolApplication
    {
+      // The default font lives as long as the process; Application.SetDefaultFont
+      // keeps a reference and every form draws with it.
+      private static readonly Font DefaultFont = new Font("Microsoft Sans Serif", 8.25f);
+
       /// <summary>
       /// Standard WinForms bootstrap for the setup tools. The forms were designed
       /// against the .NET Framework defaults (Microsoft Sans Serif 8.25pt,
@@ -18,7 +22,7 @@ namespace hMailServer.Shared
       {
          System.Windows.Forms.Application.EnableVisualStyles();
          System.Windows.Forms.Application.SetCompatibleTextRenderingDefault(false);
-         System.Windows.Forms.Application.SetDefaultFont(new Font("Microsoft Sans Serif", 8.25f));
+         System.Windows.Forms.Application.SetDefaultFont(DefaultFont);
          System.Windows.Forms.Application.SetHighDpiMode(HighDpiMode.SystemAware);
       }
    }

--- a/hmailserver/test/RegressionTests/Infrastructure/AccountProperties.cs
+++ b/hmailserver/test/RegressionTests/Infrastructure/AccountProperties.cs
@@ -29,7 +29,7 @@ namespace RegressionTests.Infrastructure
          ImapClientSimulator.AssertMessageCount("test@example.test", "test", "Inbox", 30);
 
          var size = account.Size;
-         if (size == 0)
+         if (!(size > 0))
             throw new Exception("Account is empty");
       }
 

--- a/hmailserver/test/RegressionTests/Infrastructure/LogDeviceAndFormat.cs
+++ b/hmailserver/test/RegressionTests/Infrastructure/LogDeviceAndFormat.cs
@@ -110,7 +110,7 @@ namespace RegressionTests.Infrastructure
                @"^(?<host>\S+) - (?<user>session-\d+) " + ClfDate + @" ""SMTPD SENT: 220 [^""\r\n]*"" 220 -\r?$",
                RegexOptions.Multiline);
 
-            Match match = null;
+            Match match = Match.Empty;
             var log = string.Empty;
 
             for (var attempt = 0; attempt < 20; attempt++)
@@ -356,7 +356,7 @@ namespace RegressionTests.Infrastructure
             var summaryPattern = new Regex(
                @"SQL log device: stopped\. (?<written>\d+) entries written to table hm_log, (?<tofile>\d+) written to file instead\.");
 
-            Match summary = null;
+            Match summary = Match.Empty;
 
             for (var attempt = 0; attempt < 40; attempt++)
             {

--- a/hmailserver/test/RegressionTests/Infrastructure/PrometheusConventions.cs
+++ b/hmailserver/test/RegressionTests/Infrastructure/PrometheusConventions.cs
@@ -304,10 +304,14 @@ namespace RegressionTests.Infrastructure
                Assert.IsFalse(double.IsNaN(value),
                   "hmailserver_state{state=\"" + state + "\"} is missing. A StateSet emits every state, not only the active one, " +
                   "so a PromQL alert can compare against a state that is currently 0. Body: " + body);
-               Assert.IsTrue(value == 0 || value == 1,
+               // A StateSet member is exactly 0 or 1; compared with a tolerance because the
+               // value has been through a text exposition and a double parse.
+               bool isZero = Math.Abs(value) < 1e-9;
+               bool isOne = Math.Abs(value - 1) < 1e-9;
+               Assert.IsTrue(isZero || isOne,
                   "hmailserver_state series must be boolean, got " + value + " for " + state + ". Body: " + body);
 
-               if (value == 1)
+               if (isOne)
                   statesSetToOne++;
             }
 

--- a/hmailserver/test/RegressionTests/SMTP/TlsRptReporting.cs
+++ b/hmailserver/test/RegressionTests/SMTP/TlsRptReporting.cs
@@ -100,7 +100,8 @@ namespace RegressionTests.SMTP
                   }
                }
 
-               ClassicAssert.IsNotNull(port25, "No SMTP port 25 exists in the test environment.");
+               if (port25 == null)
+                  throw new InvalidOperationException("No SMTP port 25 exists in the test environment.");
 
                originalPort25Security = port25.ConnectionSecurity;
                originalPort25Certificate = port25.SSLCertificateID;

--- a/hmailserver/test/RegressionTests/Stress/ContentStressTest.cs
+++ b/hmailserver/test/RegressionTests/Stress/ContentStressTest.cs
@@ -262,8 +262,8 @@ namespace RegressionTests.Stress
       private void AssertIsConnectionTerminatedException(IOException exception)
       {
          var inner = exception.InnerException as SocketException;
-         Assert.IsNotNull(inner);
-
+         if (inner == null)
+            throw new AssertionException("The inner exception is not a SocketException: " + exception.InnerException);
 
          Assert.AreEqual(10054, inner.ErrorCode);
       }

--- a/hmailserver/test/StressTest/LargeMessagesTest.cs
+++ b/hmailserver/test/StressTest/LargeMessagesTest.cs
@@ -52,7 +52,7 @@ namespace StressTest
                mail.SubjectEncoding = Encoding.GetEncoding(1252);
                mail.Attachments.Add(new Attachment(largeFile));
 
-               var oClient = new SmtpClient("localhost", 25);
+               using (var oClient = new SmtpClient("localhost", 25))
                {
                   oClient.Send(mail);
                }

--- a/hmailserver/test/StressTest/SMTP.cs
+++ b/hmailserver/test/StressTest/SMTP.cs
@@ -232,7 +232,7 @@ namespace StressTest
 
          string executableName = Shared.GetExecutableName();
 
-         var mail = new MailMessage {From = new MailAddress("test@example.test")};
+         using var mail = new MailMessage {From = new MailAddress("test@example.test")};
          mail.To.Add("test@example.test");
          mail.Subject = "Automatic test";
          mail.Body = "Automatic test";
@@ -242,7 +242,7 @@ namespace StressTest
 
          for (int i = 1; i <= numberOfMessages; i++)
          {
-            var oClient = new SmtpClient("127.0.0.1", 25);
+            using var oClient = new SmtpClient("127.0.0.1", 25);
             oClient.Send(mail);
 
             if (i%10 == 0)
@@ -446,7 +446,7 @@ namespace StressTest
 
          const int numberOfMessages = 100;
 
-         var mail = new MailMessage();
+         using var mail = new MailMessage();
          mail.From = new MailAddress("test@example.test");
          mail.To.Add("test@example.test");
          mail.Subject = "Automatic server test";
@@ -457,7 +457,7 @@ namespace StressTest
          for (int i = 1; i <= numberOfMessages; i++)
          {
 
-            var oClient = new SmtpClient("localhost", 25);
+            using var oClient = new SmtpClient("localhost", 25);
             oClient.Send(mail);
 
             if (i % 5 == 0)

--- a/hmailserver/test/TestBedUI/TestBedUI.csproj
+++ b/hmailserver/test/TestBedUI/TestBedUI.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TestBedUI</RootNamespace>
     <AssemblyName>TestBedUI</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/hmailserver/test/TestBedUI/formMain.cs
+++ b/hmailserver/test/TestBedUI/formMain.cs
@@ -24,14 +24,16 @@ namespace TestBedUI
         {
             try
             {
-                var message = new MailMessage();
-                message.From = new MailAddress(textFrom.Text);
-                message.To.Add(textTo.Text);
-                message.Subject = textSubject.Text;
+                using (var message = new MailMessage())
+                using (var client = new SmtpClient())
+                {
+                    message.From = new MailAddress(textFrom.Text);
+                    message.To.Add(textTo.Text);
+                    message.Subject = textSubject.Text;
 
-                SmtpClient client = new SmtpClient();
-                client.Host = "localhost";
-                client.Send(message);
+                    client.Host = "localhost";
+                    client.Send(message);
+                }
             }
             catch(Exception ex)
             {
@@ -43,14 +45,16 @@ namespace TestBedUI
         {
             try
             {
-                var message = new MailMessage();
-                message.From = new MailAddress(textFrom.Text);
-                message.To.Add(textTo.Text);
-                message.Subject = textSubject.Text;
-                message.Body = @"X5O!P%@AP[4\PZX54(P^)7CC)7}" + @"$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*";
-                SmtpClient client = new SmtpClient();
-                client.Host = "localhost";
-                client.Send(message);
+                using (var message = new MailMessage())
+                using (var client = new SmtpClient())
+                {
+                    message.From = new MailAddress(textFrom.Text);
+                    message.To.Add(textTo.Text);
+                    message.Subject = textSubject.Text;
+                    message.Body = @"X5O!P%@AP[4\PZX54(P^)7CC)7}" + @"$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*";
+                    client.Host = "localhost";
+                    client.Send(message);
+                }
             }
             catch (Exception ex)
             {

--- a/hmailserver/test/VMTestRunner.Console/Infrastructure/HyperV.cs
+++ b/hmailserver/test/VMTestRunner.Console/Infrastructure/HyperV.cs
@@ -15,6 +15,7 @@ namespace VMTestRunner.Console
    {
       private string _vmName;
       private PSCredential _credential;
+      private SecureString _securePassword;
       private readonly int _testIndex;
 
       private static readonly NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
@@ -130,12 +131,15 @@ namespace VMTestRunner.Console
 
       public void SetCredentials(string username, string password)
       {
-         var securePassword = new SecureString();
+         // Owned for the lifetime of the credential, which is held for the life
+         // of this object; a previous password is released when replaced.
+         _securePassword?.Dispose();
+         _securePassword = new SecureString();
 
          foreach (char c in password)
-            securePassword.AppendChar(c);
+            _securePassword.AppendChar(c);
 
-         _credential = new PSCredential(username, securePassword);
+         _credential = new PSCredential(username, _securePassword);
       }
 
       public void CopyFileToGuest(string hostPath, string guestPath)

--- a/hmailserver/tools/DatabaseUnicodeConversion/Parser.cs
+++ b/hmailserver/tools/DatabaseUnicodeConversion/Parser.cs
@@ -14,12 +14,10 @@ namespace DatabaseUnicodeConversion
     class Parser
     {
         private List<string> outCommands;
-        private List<string> outCommandsMySQL;
 
         public void Run(string sInputFile, string sOutputFile)
         {
             outCommands = new List<string>();
-            outCommandsMySQL = new List<string>();
 
             TextReader reader = File.OpenText(sInputFile);
             string sFileContents = reader.ReadToEnd();
@@ -97,8 +95,6 @@ namespace DatabaseUnicodeConversion
 
                     // MSSQL:
                     outCommands.Add("hm_drop_table_objects '" + tableName + "'");
-
-                    outCommandsMySQL.Add("ALTER TABLE " + tableName + " CONVERT TO CHARACTER SET utf8");
 
                     continue;
                 }

--- a/hmailserver/tools/SQLScriptCreator/Generators/SQLCEGenerator.cs
+++ b/hmailserver/tools/SQLScriptCreator/Generators/SQLCEGenerator.cs
@@ -60,8 +60,6 @@ namespace SQLScriptCreator.Generators
 
       public List<string> GenerateAddColumnStatement(AddColumn addColumnStatement)
       {
-
-         List<string> result = new List<string>();
          StringBuilder sb = new StringBuilder();
          sb.AppendFormat("ALTER TABLE {0} ADD {1} {2} {3}", addColumnStatement.Table, addColumnStatement.Name, addColumnStatement.DataType, addColumnStatement.Nullable ? "NULL" : "NOT NULL");
 

--- a/hmailserver/tools/SQLScriptCreator/ScriptGenerator.cs
+++ b/hmailserver/tools/SQLScriptCreator/ScriptGenerator.cs
@@ -102,7 +102,7 @@ namespace SQLScriptCreator.Statements
                   }
                }
                else
-                  throw new Exception("Unknown statement type:" + statement.ToString());
+                  throw new Exception("Unknown statement type:" + statement.GetType().Name);
                               
 
                if (scripts.ContainsKey(generator.Name))
@@ -116,7 +116,7 @@ namespace SQLScriptCreator.Statements
 
             if (found == false)
             {
-               throw new Exception("SQL not generated for statement: " + statement.ToString());
+               throw new Exception("SQL not generated for statement: " + statement.GetType().Name);
             }
             
          }

--- a/hmailserver/tools/TranslationExtractor/Program.cs
+++ b/hmailserver/tools/TranslationExtractor/Program.cs
@@ -4,8 +4,9 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 using System;
-using System.Net;
 using System.IO;
+using System.Net;
+using System.Net.Http;
 using System.Text;
 
 namespace TranslationExtractor
@@ -39,13 +40,9 @@ namespace TranslationExtractor
       {
          var url = string.Format(TranslationScript, language);
 
-         var request = (HttpWebRequest) WebRequest.Create(url);
-
-         using (var response = request.GetResponse())
-         using (var responseStream = response.GetResponseStream())
-         using (var streamReader = new StreamReader(responseStream))
+         using (var client = new HttpClient())
          {
-            var content = streamReader.ReadToEnd();
+            var content = client.GetStringAsync(url).GetAwaiter().GetResult();
 
             var targetFile = Path.Combine(targetDir, string.Format("{0}.ini", language));
 

--- a/hmailserver/tools/TranslationExtractor/TranslationExtractor.csproj
+++ b/hmailserver/tools/TranslationExtractor/TranslationExtractor.csproj
@@ -40,6 +40,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>


### PR DESCRIPTION
Thirty-three findings in twenty files: the two errors and one warning that held Maintainability at Poor, and the thirty warnings that held Reliability at Fair. GitHub grades each metric by the highest severity still present, so both should read Good once the push-triggered quality scan on master completes. Notes are untouched (1,400 of them, mostly the catch-of-all / path-combine / unmanaged-code policy rules the curated CodeQL config already excludes with reasons). Everything builds; the eighteen tests in the touched fixtures pass against the running 6.2.24 server; format clean.