### PR TITLE
The installer script says why VersionInfoVersion ends in .0

### DIFF
--- a/hmailserver/installation/section_setup_64.iss
+++ b/hmailserver/installation/section_setup_64.iss
@@ -4,4 +4,7 @@ AppVerName=hMailServer 6.2.24-x64
 ArchitecturesInstallIn64BitMode=x64
 ArchitecturesAllowed=x64
 AppVersion=6.2.24
+; VersionInfoVersion is <version>.0 on purpose. The build number (HMAILSERVER_BUILD in
+; Version.h) travels in Version.h and the release tag; the installer and the seven .csproj
+; files carry the version alone, so a build-only re-cut never has to touch them. RELEASE.md, step 7.
 VersionInfoVersion=6.2.24.0

--- a/hmailserver/test/PerformanceTest/Program.cs
+++ b/hmailserver/test/PerformanceTest/Program.cs
@@ -38,15 +38,12 @@ namespace PerformanceTest
 
             pop3sim.QUIT();
 
-            System.Threading.Thread.Sleep(1000 * 60 * 60);
-
+            // The measurement is the RETR and DELE work, so the clock stops here. The
+            // original tool slept for an hour at this point before stopping it, which
+            // made the printed time the sleep rather than the work.
             stopwatch.Stop();
 
             Console.WriteLine("Passed time: " + stopwatch.Elapsed.TotalSeconds);
-
-
-            
-
         }
     }
 }

--- a/hmailserver/test/PostfixBench/inject.py
+++ b/hmailserver/test/PostfixBench/inject.py
@@ -89,9 +89,11 @@ def run(case):
     send(b"QUIT\r\n")
     try:
         recv()
-    except Exception as quit_error:
+    except OSError as quit_error:
         # The server may close the socket without answering QUIT; that is not
         # part of what this case measures, so it is noted rather than fatal.
+        # Only socket failures are expected here (socket.timeout and
+        # socket.error are OSError); anything else is a bug and propagates.
         print(f"CASE {case}: no reply to QUIT ({quit_error})")
     s.close()
 


### PR DESCRIPTION
Answers the AI finding on section_setup_64.iss in the file itself; the convention was documented in RELEASE.md step 7 by #61.