### PR TITLE
The Code Quality page is back to zero after today's ports

### DIFF
--- a/hmailserver/source/Tools/DataDirectorySynchronizer/Pages/ucProgress.cs
+++ b/hmailserver/source/Tools/DataDirectorySynchronizer/Pages/ucProgress.cs
@@ -121,7 +121,7 @@ namespace DataDirectorySynchronizer.Pages
 
       private void IteratePublicFolder(DirectoryInfo dirRoot, string publicFolderDiskName)
       {
-         DirectoryInfo publicFolder = new DirectoryInfo(Path.Combine(dirRoot.FullName, publicFolderDiskName));
+         DirectoryInfo publicFolder = new DirectoryInfo(Path.Join(dirRoot.FullName, publicFolderDiskName));
 
          if (!publicFolder.Exists)
             return;

--- a/hmailserver/test/RegressionTests/Stress/IMAP/ConcurrentConnectionsStressTests.cs
+++ b/hmailserver/test/RegressionTests/Stress/IMAP/ConcurrentConnectionsStressTests.cs
@@ -5,6 +5,7 @@
 
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
 using NUnit.Framework;
@@ -188,7 +189,7 @@ namespace RegressionTests.Stress.IMAP
 
             simulator.Disconnect();
          }
-         catch (Exception ex)
+         catch (Exception ex) when (!ExceptionPolicy.IsFatal(ex))
          {
             Record(failures, "Reader aborted: " + ex.Message);
          }
@@ -215,7 +216,7 @@ namespace RegressionTests.Stress.IMAP
 
             simulator.Disconnect();
          }
-         catch (Exception ex)
+         catch (Exception ex) when (!ExceptionPolicy.IsFatal(ex))
          {
             Record(failures, "Writer aborted: " + ex.Message);
          }
@@ -247,7 +248,7 @@ namespace RegressionTests.Stress.IMAP
 
             simulator.Disconnect();
          }
-         catch (Exception ex)
+         catch (Exception ex) when (!ExceptionPolicy.IsFatal(ex))
          {
             Record(failures, "Lock holder aborted: " + ex.Message);
          }
@@ -298,7 +299,7 @@ namespace RegressionTests.Stress.IMAP
 
             simulator.Disconnect();
          }
-         catch (Exception ex)
+         catch (Exception ex) when (!ExceptionPolicy.IsFatal(ex))
          {
             Record(failures, "Mutator aborted: " + ex.Message);
          }
@@ -346,7 +347,7 @@ namespace RegressionTests.Stress.IMAP
 
             simulator.Disconnect();
          }
-         catch (Exception ex)
+         catch (Exception ex) when (!ExceptionPolicy.IsFatal(ex))
          {
             // A crashing worker drops the connection mid-command.
             Record(failures, "Reader aborted: " + ex.Message);
@@ -370,7 +371,7 @@ namespace RegressionTests.Stress.IMAP
 
             simulator.Disconnect();
          }
-         catch (Exception ex)
+         catch (Exception ex) when (!ExceptionPolicy.IsFatal(ex))
          {
             Record(failures, "Writer aborted: " + ex.Message);
          }
@@ -481,19 +482,18 @@ namespace RegressionTests.Stress.IMAP
 
                Interlocked.Increment(ref state.Lists);
 
-               foreach (var folder in stableFolders)
+               var omitted = stableFolders.FirstOrDefault(folder => !ListingContainsFolder(listing, folder));
+
+               if (omitted != null)
                {
-                  if (!ListingContainsFolder(listing, folder))
-                  {
-                     Record(failures, string.Format("LIST omitted {0}, which exists and is never modified.", folder));
-                     return;
-                  }
+                  Record(failures, string.Format("LIST omitted {0}, which exists and is never modified.", omitted));
+                  return;
                }
             }
 
             simulator.Disconnect();
          }
-         catch (Exception ex)
+         catch (Exception ex) when (!ExceptionPolicy.IsFatal(ex))
          {
             // A crashing worker drops the connection mid-command.
             Record(failures, "Reader aborted: " + ex.Message);
@@ -538,7 +538,7 @@ namespace RegressionTests.Stress.IMAP
 
             simulator.Disconnect();
          }
-         catch (Exception ex)
+         catch (Exception ex) when (!ExceptionPolicy.IsFatal(ex))
          {
             Record(failures, "Writer aborted: " + ex.Message);
          }

--- a/hmailserver/test/RegressionTests/Stress/IMAP/NotificationThreadingStressTests.cs
+++ b/hmailserver/test/RegressionTests/Stress/IMAP/NotificationThreadingStressTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text;
 using System.Threading;
 using NUnit.Framework;
 using RegressionTests.Infrastructure;
@@ -213,7 +214,7 @@ namespace RegressionTests.Stress.IMAP
 
             simulator.Disconnect();
          }
-         catch (Exception ex)
+         catch (Exception ex) when (!ExceptionPolicy.IsFatal(ex))
          {
             Record(failures, "Idler aborted: " + ex.Message);
          }
@@ -247,7 +248,7 @@ namespace RegressionTests.Stress.IMAP
 
             simulator.Disconnect();
          }
-         catch (Exception ex)
+         catch (Exception ex) when (!ExceptionPolicy.IsFatal(ex))
          {
             Record(failures, "Churner aborted: " + ex.Message);
          }
@@ -285,7 +286,7 @@ namespace RegressionTests.Stress.IMAP
 
             simulator.Disconnect();
          }
-         catch (Exception ex)
+         catch (Exception ex) when (!ExceptionPolicy.IsFatal(ex))
          {
             Record(failures, "Notifier aborted: " + ex.Message);
          }
@@ -305,7 +306,7 @@ namespace RegressionTests.Stress.IMAP
                Interlocked.Increment(ref state.Deliveries);
             }
          }
-         catch (Exception ex)
+         catch (Exception ex) when (!ExceptionPolicy.IsFatal(ex))
          {
             Record(failures, "Delivery aborted: " + ex.Message);
          }
@@ -330,14 +331,14 @@ namespace RegressionTests.Stress.IMAP
       private static string ReceiveUntil(ImapClientSimulator simulator, string text, TimeSpan timeout)
       {
          var deadline = DateTime.UtcNow + timeout;
-         var result = string.Empty;
+         var result = new StringBuilder();
 
          while (DateTime.UtcNow < deadline)
          {
-            result += simulator.Receive();
+            result.Append(simulator.Receive());
 
-            if (result.Contains(text))
-               return result;
+            if (result.ToString().Contains(text))
+               return result.ToString();
          }
 
          throw new TimeoutException("Timeout while waiting for: " + text);


### PR DESCRIPTION
Today's merges brought fifteen note-level findings onto the Code Quality page: twelve catch-alls in the two stress fixtures ported from upstream, a foreach-with-if the analyser wants as a Where, a string concatenated in a receive loop, and one Path.Combine in the synchronizer's new public-folder walk. All fifteen are fixed the way the rest of the tree already does it, with no suppressions. The local CodeQL quality suite over the whole tree reports zero results, and the concurrency stress fixture passes 4/4 after the LIST-check rewrite.