### PR TITLE
Event scripts can create only the COM classes ScriptAllowedObjects names: the script site answers the engines' object-safety questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Mail filtering and routing
 
 * **Sieve** (RFC 5228) — a standards-based interpreter runs each account's active script during delivery (`keep`, `fileinto`, `discard`, `redirect`, implicit keep, plus the `copy`, `relational`, `subaddress`, `imap4flags` and `vacation` extensions), with an optional **ManageSieve** (RFC 5804) listener so clients can manage scripts over TCP.
 * The original rules engine, with global and per-account rules, regular-expression criteria and scripted actions.
-* Server-side **event scripts** (VBScript/JScript) on connection, HELO, DATA, accept and delivery events.
+* Server-side **event scripts** (VBScript/JScript) on connection, HELO, DATA, accept and delivery events, with `ScriptAllowedObjects` bounding which COM classes a script may create.
 * Routes, aliases, distribution lists, catch-all addresses and plus-addressing.
 * Multiple smart hosts with automatic failover: separate several hosts with `|` in the relayer field and delivery moves to the next when one cannot be reached.
 
@@ -447,6 +447,13 @@ Administration and monitoring:
                                  ; searchable over COM (Utilities.SearchArchive) and REST, a copy can be put
                                  ; on legal hold (Utilities.SetArchiveHold), and a held copy is never removed
                                  ; by ArchiveRetentionDays or by an address erasure
+   ScriptAllowedObjects=*        ; the COM classes an event script may create with CreateObject (VBScript) or
+                                 ; new ActiveXObject (JScript): * (the default when absent) = any class, as before;
+                                 ; empty = none; otherwise a comma-separated list of ProgIDs or {CLSID}s, e.g.
+                                 ; WScript.Shell,MSXML2.ServerXMLHTTP (what the Control Panel's script templates
+                                 ; use). A denied class fails in the script with error 429 and is named in the
+                                 ; application log. Scripts still run in-process as the service account: this
+                                 ; bounds what a script can reach, not what the service can
    OutboundPipelining=1          ; RFC 2920 on the delivery client: when the remote advertises PIPELINING, send
                                  ; MAIL FROM, every RCPT TO and the data command in one flight and read the
                                  ; replies back in order. 0 = one command per reply, as before

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -70,7 +70,7 @@ strong and where it is thin far more honestly than any prose summary.
 | [Routing, queue and delivery](#routing-queue-and-delivery) | 24 | – | 0 | 1 |
 | [Administration, API and Control Panel](#administration-api-and-control-panel) | 69 | – | 1 | – |
 | [Observability and diagnostics](#observability-and-diagnostics) | 38 | – | – | 1 |
-| [Extensibility and scripting](#extensibility-and-scripting) | 39 | – | 1 | – |
+| [Extensibility and scripting](#extensibility-and-scripting) | 40 | – | – | – |
 | [Build, testing and supply chain](#build-testing-and-supply-chain) | 11 | – | 0 | – |
 | [Cross-cutting and platform](#cross-cutting-and-platform) | 10 | 1 | 1 | – |
 | **Forward-looking** | | | | |
@@ -78,7 +78,7 @@ strong and where it is thin far more honestly than any prose summary.
 | [Future-proofing: standards and protocols](#future-proofing-standards-and-protocols) | 8 | – | – | 2 |
 | [Future-proofing: platform and supply chain](#future-proofing-platform-and-supply-chain) | 7 | 1 | – | 2 |
 | [Future-proofing: deployment and operations](#future-proofing-deployment-and-operations) | 7 | 1 | 1 | – |
-| **Total** | **779** | **9** | **26** | **31** |
+| **Total** | **780** | **9** | **25** | **31** |
 
 Three things stand out and are worth naming rather than leaving to be inferred.
 **Storage, the administration surface and the core protocol layer are the
@@ -1035,7 +1035,7 @@ the source, not from documentation.
 
 ### Extensibility and scripting
 
-39 shipped · 0 underway · 1 not started · 0 deferred
+40 shipped · 0 underway · 0 not started · 0 deferred
 
 | | Capability | Detail |
 |:-:|---|---|
@@ -1077,7 +1077,7 @@ the source, not from documentation.
 | ✅ | VBScript and JScript event scripting | Windows Active Scripting (IActiveScript) engine created by CoCreateInstance on the language name; only the literal settings "VBScript" and "JScript" are recognised… |
 | ✅ | Watchdog limitation: blocked COM calls | An interrupt aborts script execution but cannot release a handler blocked inside a COM call (e.g. a synchronous ServerXMLHTTP to a dead host) - the limit is documented in the error text the admin receives |
 | ✅ | External filter hook (rspamd / MTA-hook style) | Shipped 20 August 2026 and inert until `FilterHookUrl` names an engine: the accepted message is POSTed to it with the envelope, connecting address and HELO as request headers — the shape rspamd's own check endpoint expects — and the verdict comes back as a score, so it lands alongside SPF, DKIM and DMARC and the administrator's existing thresholds decide what happens. Milter itself stays declined; the row above says why the HTTP shape was chosen over it. |
-| ⬜ | Script sandboxing / capability restriction | None: scripts run in-process under the service account with unrestricted CreateObject (the shipped Control Panel templates use WScript.Shell and MSXML2.ServerXMLHTTP); the only bound is the wall-clock watchdog. No allow-list… |
+| ✅ | Script sandboxing / capability restriction | None: scripts run in-process under the service account with unrestricted CreateObject (the shipped Control Panel templates use WScript.Shell and MSXML2.ServerXMLHTTP); the only bound is the wall-clock watchdog. No allow-list… **An allow-list shipped 5 September 2026: `ScriptAllowedObjects`.** The script site implements `IInternetHostSecurityManager`, which VBScript's `CreateObject` and JScript's `new ActiveXObject` consult before instantiating a class: `*` (the default when the key is absent) allows every class as before, empty allows none, otherwise exactly the listed ProgIDs and `{CLSID}`s. A denied class fails inside the script with the engine's own error 429 and one application-log line names the class and the setting. Still true, and written beside the key: scripts run in-process under the service account, so the list bounds what a script can reach, not what the service can - a process-level sandbox would be a different design. `API/ScriptObjectPolicy` (5 tests) proves the denial, the allow, the CLSID form, JScript and the unrestricted default. |
 | ✅ | XCLIENT / PROXY protocol — shipped 21 Aug 2026, both off by default | Put a load balancer, a TLS terminator or a Postfix relay in front of the SMTP listener and every connection appeared to come from **it**. That is not one missing feature, it is **DNSBL, SPF, greylisting, auto-ban and the IP-range rules all quietly evaluating the wrong address while still reporting success** — and the `Received:` header recording the lie. Both mechanisms now exist: PROXY protocol **v1 and v2** (consumed before the TLS handshake and before the greeting) and Postfix **XCLIENT** (`ADDR NAME PORT PROTO HELO LOGIN`, answered with a fresh 220 so the upstream re-EHLOs). **The security rule is the whole feature**: a peer that can rewrite its own source address has defeated every IP-based control here, so both are off by default, the trusted list is **empty by default**, and every trust decision is made against the **real TCP peer** — never an address a header just supplied, so chained proxies cannot bootstrap trust. A malformed entry in the list matches **nothing** rather than everything. XCLIENT is not even *advertised* to an untrusted peer, because advertising it invites the attempt and leaks the deployment shape; a PROXY header from an untrusted peer **drops the connection** rather than being ignored, since ignoring it would leave the real client's commands being read as the proxy's. The rewrite lands before everything that consumes the address, and the security range is **re-read for the asserted client**, so an auto-ban range still bites through the proxy. Two operational consequences are stated rather than hidden: trust is per-source, not per-port, so a listed proxy **must** send the header on every connection; and the upstream has to be configured to send one at all (HAProxy `send-proxy`), which this server cannot check. |
 
 ### Build, testing and supply chain

--- a/hmailserver/source/Server/Common/Application/IniFileSettings.cpp
+++ b/hmailserver/source/Server/Common/Application/IniFileSettings.cpp
@@ -381,6 +381,9 @@ namespace HM
       // and the sender would have bounced the mail instead of retrying.
       db_connection_acquire_timeout_ =  ReadIniSettingInteger_("Settings", "DBConnectionAcquireTimeout", 60);
       script_timeout_ =  ReadIniSettingInteger_("Settings", "ScriptTimeout", 60);
+      // Absent means "*": a key that appears in an upgrade must not break the
+      // scripts an installation already runs. Present and empty means none.
+      script_allowed_objects_ = ReadIniSettingString_("Settings", "ScriptAllowedObjects", "*");
       external_process_timeout_ =  ReadIniSettingInteger_("Settings", "ExternalProcessTimeout", 300);
 
       // Async work-queue health. The stall threshold is how long every worker may

--- a/hmailserver/source/Server/Common/Application/IniFileSettings.h
+++ b/hmailserver/source/Server/Common/Application/IniFileSettings.h
@@ -273,6 +273,13 @@ namespace HM
       int GetClientSessionCeiling () {return client_session_ceiling_; }
       int GetDBConnectionAcquireTimeout () {return db_connection_acquire_timeout_; }
       int GetScriptTimeout () {return script_timeout_; }
+
+      // ScriptAllowedObjects: the COM classes an event script may create with
+      // CreateObject / new ActiveXObject, by ProgID or CLSID, comma-separated.
+      // "*" - the default when the key is absent - means any class, as before the
+      // setting existed; empty means none. Enforced by ScriptObjectPolicy through
+      // the script site's IInternetHostSecurityManager.
+      String GetScriptAllowedObjects() const { return script_allowed_objects_; }
       int GetExternalProcessTimeout () {return external_process_timeout_; }
       int GetAsyncQueueStallThreshold () {return async_queue_stall_threshold_; }
       int GetAsyncQueueReservedThreads () {return async_queue_reserved_threads_; }
@@ -1007,6 +1014,7 @@ namespace HM
       int client_session_ceiling_;
       int db_connection_acquire_timeout_;
       int script_timeout_;
+      String script_allowed_objects_;
       int external_process_timeout_;
       int async_queue_stall_threshold_;
       int async_queue_reserved_threads_;

--- a/hmailserver/source/Server/Common/Scripting/ScriptObjectPolicy.cpp
+++ b/hmailserver/source/Server/Common/Scripting/ScriptObjectPolicy.cpp
@@ -1,0 +1,104 @@
+// Copyright (c) 2026 Christopher Holloway / Progressive Robot Ltd
+// https://www.progressiverobot.com
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+#include "stdafx.h"
+#include "ScriptObjectPolicy.h"
+
+#include "../Application/IniFileSettings.h"
+#include "../Util/Parsing/StringParser.h"
+
+#ifdef _DEBUG
+#define DEBUG_NEW new(_NORMAL_BLOCK, __FILE__, __LINE__)
+#define new DEBUG_NEW
+#endif
+
+namespace HM
+{
+   bool
+   ScriptObjectPolicy::IsUnrestricted()
+   {
+      String setting = IniFileSettings::Instance()->GetScriptAllowedObjects();
+      setting.Trim();
+      return setting == _T("*");
+   }
+
+   bool
+   ScriptObjectPolicy::IsAllowed(REFCLSID clsid, String &objectName)
+   {
+      objectName = DescribeClass_(clsid);
+
+      if (IsUnrestricted())
+         return true;
+
+      // The ProgID the class registers, lower-cased, so an entry written the way
+      // a script writes it ("Scripting.FileSystemObject") matches whatever CLSID
+      // the engine resolved it to - including a versioned ProgID's CLSID when the
+      // administrator listed the version-independent name, because both names
+      // register the same class.
+      String progId;
+      LPOLESTR registeredProgId = NULL;
+      if (SUCCEEDED(ProgIDFromCLSID(clsid, &registeredProgId)) && registeredProgId)
+      {
+         progId = registeredProgId;
+         CoTaskMemFree(registeredProgId);
+         progId.ToLower();
+      }
+
+      std::vector<String> entries = StringParser::SplitString(IniFileSettings::Instance()->GetScriptAllowedObjects(), ",");
+      for (size_t i = 0; i < entries.size(); i++)
+      {
+         String entry = entries[i];
+         entry.Trim();
+         if (entry.IsEmpty())
+            continue;
+
+         if (EntryMatches_(entry, clsid, progId))
+            return true;
+      }
+
+      return false;
+   }
+
+   bool
+   ScriptObjectPolicy::EntryMatches_(const String &entry, REFCLSID clsid, const String &progId)
+   {
+      // A CLSID in braces compares as a CLSID; anything else is a ProgID, compared
+      // both by name and by the class it resolves to.
+      CLSID entryClass = {0};
+      if (entry.StartsWith(_T("{")))
+      {
+         if (SUCCEEDED(CLSIDFromString(const_cast<LPOLESTR>(entry.c_str()), &entryClass)))
+            return IsEqualCLSID(entryClass, clsid) != FALSE;
+         return false;
+      }
+
+      String lowered = entry;
+      lowered.ToLower();
+      if (!progId.IsEmpty() && lowered == progId)
+         return true;
+
+      if (SUCCEEDED(CLSIDFromProgID(entry.c_str(), &entryClass)))
+         return IsEqualCLSID(entryClass, clsid) != FALSE;
+
+      return false;
+   }
+
+   String
+   ScriptObjectPolicy::DescribeClass_(REFCLSID clsid)
+   {
+      LPOLESTR registeredProgId = NULL;
+      if (SUCCEEDED(ProgIDFromCLSID(clsid, &registeredProgId)) && registeredProgId)
+      {
+         String name = registeredProgId;
+         CoTaskMemFree(registeredProgId);
+         return name;
+      }
+
+      OLECHAR text[64] = {0};
+      if (StringFromGUID2(clsid, text, sizeof(text) / sizeof(text[0])) > 0)
+         return String(text);
+
+      return _T("(unknown class)");
+   }
+}

--- a/hmailserver/source/Server/Common/Scripting/ScriptObjectPolicy.h
+++ b/hmailserver/source/Server/Common/Scripting/ScriptObjectPolicy.h
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 Christopher Holloway / Progressive Robot Ltd
+// https://www.progressiverobot.com
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+#pragma once
+
+namespace HM
+{
+   // The allow-list behind ScriptAllowedObjects (hMailServer.ini, [Settings]).
+   //
+   // An event script runs in-process, under the service account, and until now
+   // CreateObject (VBScript) and new ActiveXObject (JScript) could instantiate any
+   // COM class on the machine - WScript.Shell runs programs, Scripting.FileSystemObject
+   // reads and writes the disk, ADODB.Connection opens databases - which made a
+   // writable script file the same thing as a shell as LocalSystem. The script
+   // engines ask their host before creating an object (IInternetHostSecurityManager,
+   // the mechanism Internet Explorer used to sandbox pages), and this is the answer.
+   //
+   // ScriptAllowedObjects=*                    every class, the behaviour before the setting existed
+   // ScriptAllowedObjects=                     no class at all
+   // ScriptAllowedObjects=WScript.Shell,MSXML2.ServerXMLHTTP,{0D43FE01-F093-11CF-8940-00A0C9054228}
+   //                                           exactly these, named by ProgID or by CLSID
+   //
+   // The default when the key is absent is "*": a setting that appears in an
+   // upgrade must not break the scripts an installation already runs. The row in
+   // the roadmap that asked for this is the one that also says the shipped Control
+   // Panel templates use WScript.Shell and MSXML2.ServerXMLHTTP.
+   class ScriptObjectPolicy
+   {
+   public:
+      // Whether a script may create the class. objectName receives what the
+      // decision was about - the class's registered ProgID when it has one, else
+      // the CLSID in braces - for the log line and the error text.
+      static bool IsAllowed(REFCLSID clsid, String &objectName);
+
+      // The names in the setting, trimmed, in the order written; "*" alone means
+      // unrestricted. Exposed for the log line that says what the policy is.
+      static bool IsUnrestricted();
+
+   private:
+      static String DescribeClass_(REFCLSID clsid);
+      static bool EntryMatches_(const String &entry, REFCLSID clsid, const String &progId);
+   };
+}

--- a/hmailserver/source/Server/Common/Scripting/ScriptSite.h
+++ b/hmailserver/source/Server/Common/Scripting/ScriptSite.h
@@ -34,7 +34,11 @@
 #pragma once
 
 #include <activscp.h>
+#include <urlmon.h>
+#include <objsafe.h>
+#include <servprov.h>
 #include "ScriptObjectContainer.h"
+#include "ScriptObjectPolicy.h"
 
 
 
@@ -275,6 +279,30 @@ public:
       USES_CONVERSION;
       HR(engine_.CoCreateInstance(T2COLE(pszLanguage)));
 
+      // An engine consults its host's security manager (IInternetHostSecurityManager
+      // below, answered from ScriptAllowedObjects) only when told to, through its
+      // own IObjectSafety with INTERFACE_USES_SECURITY_MANAGER. Told only when the
+      // list restricts something, so an unrestricted server runs its scripts by the
+      // exact path it always did. An engine that cannot be told cannot be bounded,
+      // and a bound the administrator asked for is not silently dropped: the
+      // script does not run, and the error log says why.
+      if (!HM::ScriptObjectPolicy::IsUnrestricted())
+      {
+         CComQIPtr<IObjectSafety> safety = engine_;
+         HRESULT safetyResult = safety ? safety->SetInterfaceSafetyOptions(IID_IActiveScript,
+            INTERFACE_USES_SECURITY_MANAGER, INTERFACE_USES_SECURITY_MANAGER) : E_NOINTERFACE;
+         if (FAILED(safetyResult))
+         {
+            HM::String message;
+            message.Format(_T("ScriptAllowedObjects cannot be enforced: the %s engine does not accept a host security manager (0x%08X). No script runs until the setting is * or the engine is replaced."),
+                           pszLanguage, safetyResult);
+            HM::Logger::Instance()->LogError(message);
+            last_error_message_ = message;
+            engine_.Release();
+            return safetyResult;
+         }
+      }
+
       //if (lstrcmp(pszLanguage, _T("JScript")) == 0)
       //{
       //   // Set the JScript version to use - see https://docs.microsoft.com/en-us/scripting/winscript/reference/iactivescriptproperty-setproperty
@@ -450,6 +478,121 @@ protected:
 };
 
 /////////////////////////////////////////////////////////////////////////////
+// IInternetHostSecurityManager
+//
+// The script engines ask their host before CreateObject (VBScript) or new
+// ActiveXObject (JScript) instantiates a class: ProcessUrlAction with
+// URLACTION_ACTIVEX_RUN and the CLSID, and then QueryCustomPolicy with
+// GUID_CUSTOM_CONFIRMOBJECTSAFETY for the object they made. A site without this
+// interface lets them create anything, which is what every hMailServer did until
+// now; with it, the answer comes from ScriptAllowedObjects. A denied class fails
+// inside the script with the engine's own "can't create object" error (429),
+// which the script can trap like any other failure, and one application-log line
+// names the class and the setting.
+
+class ATL_NO_VTABLE IInternetHostSecurityManagerImpl : public IInternetHostSecurityManager
+{
+public:
+   STDMETHOD(GetSecurityId)(BYTE * /*pbSecurityId*/, DWORD * /*pcbSecurityId*/, DWORD_PTR /*dwReserved*/)
+   {
+      return E_NOTIMPL;
+   }
+
+   STDMETHOD(ProcessUrlAction)(DWORD dwAction, BYTE *pPolicy, DWORD cbPolicy, BYTE *pContext, DWORD cbContext, DWORD /*dwFlags*/, DWORD /*dwReserved*/)
+   {
+      if (pPolicy == NULL || cbPolicy < sizeof(DWORD))
+         return E_INVALIDARG;
+
+      DWORD policy = URLPOLICY_ALLOW;
+      if (dwAction == URLACTION_ACTIVEX_RUN)
+      {
+         CLSID clsid = {0};
+         if (pContext != NULL && cbContext >= sizeof(CLSID))
+            memcpy(&clsid, pContext, sizeof(CLSID));
+
+         if (!ClassAllowed_(clsid))
+            policy = URLPOLICY_DISALLOW;
+      }
+
+      *reinterpret_cast<DWORD*>(pPolicy) = policy;
+      HM::String what;
+      what.Format(_T("url action 0x%04X: %s"), (unsigned) dwAction, policy == URLPOLICY_ALLOW ? _T("allowed") : _T("refused"));
+      Trace_(what, cbContext);
+      return policy == URLPOLICY_ALLOW ? S_OK : S_FALSE;
+   }
+
+   STDMETHOD(QueryCustomPolicy)(REFGUID guidKey, BYTE **ppPolicy, DWORD *pcbPolicy, BYTE *pContext, DWORD cbContext, DWORD /*dwReserved*/)
+   {
+      if (ppPolicy == NULL || pcbPolicy == NULL)
+         return E_POINTER;
+      *ppPolicy = NULL;
+      *pcbPolicy = 0;
+
+      // GUID_CUSTOM_CONFIRMOBJECTSAFETY, objsafe.h: "may the script use the object it
+      // has just created". Answered here for the same reason ProcessUrlAction is:
+      // left to the engine's default, it would refuse every class not marked safe
+      // for scripting - Scripting.FileSystemObject among them - whatever the list
+      // says. Any other question is the engine's.
+      // {10200490-fa38-11d0-ac0e-00a0c90fffc0}: urlmon.h declares the constant and no
+      // import library the SDK ships defines it, so the value is written here - read
+      // back from what the engine asks, since the value in circulation was wrong.
+      static const GUID ConfirmObjectSafety = { 0x10200490, 0xfa38, 0x11d0, { 0xac, 0x0e, 0x00, 0xa0, 0xc9, 0x0f, 0xff, 0xc0 } };
+      OLECHAR asked[64] = {0};
+      StringFromGUID2(guidKey, asked, sizeof(asked) / sizeof(asked[0]));
+      if (!IsEqualGUID(guidKey, ConfirmObjectSafety))
+      {
+         Trace_(HM::String(_T("custom policy ")) + asked + _T(" left to the engine"), cbContext);
+         return INET_E_DEFAULT_ACTION;
+      }
+
+      // The context is objsafe.h's CONFIRMSAFETY - the class, the object and flags -
+      // and the class is its first field. Only the class is read and only the
+      // class's size is required: the engine passes the structure with a size
+      // short of the padded sizeof, and a strict check denied every listed class.
+      DWORD policy = URLPOLICY_DISALLOW;
+      if (pContext != NULL && cbContext >= sizeof(CLSID))
+      {
+         CLSID clsid = {0};
+         memcpy(&clsid, pContext, sizeof(CLSID));
+         if (ClassAllowed_(clsid))
+            policy = URLPOLICY_ALLOW;
+      }
+
+      *ppPolicy = static_cast<BYTE*>(CoTaskMemAlloc(sizeof(DWORD)));
+      if (*ppPolicy == NULL)
+         return E_OUTOFMEMORY;
+      *reinterpret_cast<DWORD*>(*ppPolicy) = policy;
+      *pcbPolicy = sizeof(DWORD);
+      Trace_(policy == URLPOLICY_ALLOW ? _T("confirm object safety: allowed") : _T("confirm object safety: refused"), cbContext);
+      return S_OK;
+   }
+
+private:
+   // What the engine asked and what it was told, in the debug log.
+   static void Trace_(const HM::String &what, DWORD contextBytes)
+   {
+      if (!(HM::Logger::Instance()->GetLogMask() & HM::Logger::LSDebug))
+         return;
+      HM::String message;
+      message.Format(_T("Script host: %s (%u context bytes)."), what.c_str(), (unsigned) contextBytes);
+      HM::Logger::Instance()->LogDebug(message);
+   }
+
+   static bool ClassAllowed_(REFCLSID clsid)
+   {
+      HM::String objectName;
+      if (HM::ScriptObjectPolicy::IsAllowed(clsid, objectName))
+         return true;
+
+      HM::String message;
+      message.Format(_T("Script denied: CreateObject of %s is not in ScriptAllowedObjects."), objectName.c_str());
+      if (HM::Logger::Instance()->GetLogMask() & HM::Logger::LSApplication)
+         HM::Logger::Instance()->LogApplication(message);
+      return false;
+   }
+};
+
+/////////////////////////////////////////////////////////////////////////////
 // CScriptSiteBasic
 //
 // This is the minimum code needed to run a script engine. It has no support
@@ -472,14 +615,33 @@ protected:
 
 class ATL_NO_VTABLE CScriptSiteBasic :
    public CComObjectRootEx<CComSingleThreadModel>,
-   public CScriptSiteImpl
+   public CScriptSiteImpl,
+   public IInternetHostSecurityManagerImpl,
+   public IServiceProvider
 {
 public:
    DECLARE_PROTECT_FINAL_CONSTRUCT()
    BEGIN_COM_MAP(CScriptSiteBasic)
       COM_INTERFACE_ENTRY(IActiveScriptSite)
       COM_INTERFACE_ENTRY(IActiveScriptSiteWindow)
+      COM_INTERFACE_ENTRY(IInternetHostSecurityManager)
+      COM_INTERFACE_ENTRY(IServiceProvider)
    END_COM_MAP()
+
+   // An engine may ask for the security manager as a service
+   // (SID_SInternetHostSecurityManager, whose value is the interface's IID) rather
+   // than as an interface on the site; both roads lead to the same object.
+   STDMETHOD(QueryService)(REFGUID guidService, REFIID riid, void **ppv)
+   {
+      if (ppv == NULL)
+         return E_POINTER;
+      *ppv = NULL;
+
+      if (IsEqualGUID(guidService, __uuidof(IInternetHostSecurityManager)))
+         return GetUnknown()->QueryInterface(riid, ppv);
+
+      return E_NOINTERFACE;
+   }
 };
 
 

--- a/hmailserver/source/Server/hMailServer/hMailServer.vcxproj
+++ b/hmailserver/source/Server/hMailServer/hMailServer.vcxproj
@@ -424,6 +424,7 @@ EXIT 0
     <ClCompile Include="..\Common\Scripting\Events.cpp" />
     <ClCompile Include="..\Common\Scripting\Result.cpp" />
     <ClCompile Include="..\Common\Scripting\ScriptObjectContainer.cpp" />
+    <ClCompile Include="..\Common\Scripting\ScriptObjectPolicy.cpp" />
     <ClCompile Include="..\Common\Scripting\ScriptServer.cpp" />
     <ClCompile Include="..\Common\Sql\ADOConnection.cpp" />
     <ClCompile Include="..\Common\SQL\ADOInt64Helper.cpp" />
@@ -1032,6 +1033,7 @@ EXIT 0
     <ClInclude Include="..\Common\Scripting\Events.h" />
     <ClInclude Include="..\Common\Scripting\Result.h" />
     <ClInclude Include="..\Common\Scripting\ScriptObjectContainer.h" />
+    <ClInclude Include="..\Common\Scripting\ScriptObjectPolicy.h" />
     <ClInclude Include="..\Common\Scripting\ScriptServer.h" />
     <ClInclude Include="..\Common\Scripting\ScriptSite.h" />
     <ClInclude Include="..\Common\Sql\ADOConnection.h" />

--- a/hmailserver/test/RegressionTests/API/ScriptObjectPolicy.cs
+++ b/hmailserver/test/RegressionTests/API/ScriptObjectPolicy.cs
@@ -1,0 +1,194 @@
+// Copyright (c) 2026 Christopher Holloway / Progressive Robot Ltd
+// https://www.progressiverobot.com
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using System;
+using System.IO;
+using System.Threading;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using RegressionTests.Infrastructure;
+using RegressionTests.Shared;
+using hMailServer;
+
+namespace RegressionTests.API
+{
+   /// <summary>
+   ///    ScriptAllowedObjects (hMailServer.ini, [Settings]) is the allow-list behind
+   ///    CreateObject in VBScript and new ActiveXObject in JScript. Absent or "*", a
+   ///    script may create any COM class on the machine, as it always could; empty,
+   ///    none; otherwise exactly the ProgIDs and CLSIDs listed. A denied class fails
+   ///    inside the script with the engine's own "can't create object" error (429),
+   ///    which the script can trap, and the server writes one application-log line
+   ///    naming the class and the setting. Every assertion here is on what the
+   ///    script itself reports through EventLog.Write after trying.
+   /// </summary>
+   [TestFixture]
+   public class ScriptObjectPolicy : TestFixtureBase
+   {
+      private const string Password = "test";
+
+      // Scripting.FileSystemObject's CLSID, registered on every Windows since 98.
+      private const string FileSystemObjectClsid = "{0D43FE01-F093-11CF-8940-00A0C9054228}";
+
+      private const string VbScript =
+         @"Sub OnAcceptMessage(oClient, oMessage)
+              On Error Resume Next
+              Set fso = CreateObject(""Scripting.FileSystemObject"")
+              If Err.Number = 0 Then
+                 EventLog.Write(""fso created"")
+              Else
+                 EventLog.Write(""fso denied "" & Err.Number)
+              End If
+              Err.Clear
+              Set shell = CreateObject(""WScript.Shell"")
+              If Err.Number = 0 Then
+                 EventLog.Write(""shell created"")
+              Else
+                 EventLog.Write(""shell denied "" & Err.Number)
+              End If
+           End Sub";
+
+      private const string JScript =
+         @"function OnAcceptMessage(oClient, oMessage)
+           {
+              try
+              {
+                 var fso = new ActiveXObject('Scripting.FileSystemObject');
+                 EventLog.Write('fso created');
+              }
+              catch (e)
+              {
+                 EventLog.Write('fso denied ' + (e.number & 0xFFFF));
+              }
+           }";
+
+      [TearDown]
+      public void RestoreTheUnrestrictedDefault()
+      {
+         IniFileSetting.Delete("ScriptAllowedObjects");
+         _application.Reinitialize();
+
+         var scripting = _settings.Scripting;
+         File.WriteAllText(scripting.CurrentScriptFile, "");
+         scripting.Enabled = false;
+         scripting.Reload();
+      }
+
+      private void SetPolicy(string value)
+      {
+         if (value == null)
+            IniFileSetting.Delete("ScriptAllowedObjects");
+         else
+            IniFileSetting.Write("ScriptAllowedObjects", value);
+         _application.Reinitialize();
+      }
+
+      private void InstallScript(string language, string script)
+      {
+         LogHandler.DeleteEventLog();
+         LogHandler.DeleteCurrentDefaultLog();
+
+         var scripting = _settings.Scripting;
+         scripting.Language = language;
+         File.WriteAllText(scripting.CurrentScriptFile, script);
+         scripting.Enabled = true;
+         scripting.Reload();
+      }
+
+      // Delivers one message, which fires OnAcceptMessage, and waits until the
+      // script has written its last line - "shell ..." for VBScript, "fso ..." for
+      // JScript - so the event log is complete before it is read.
+      private string FireTheScript(string lastLinePrefix)
+      {
+         // A fresh account each time: a test may fire the script more than once.
+         string address = "policy" + Guid.NewGuid().ToString("N").Substring(0, 8) + "@example.test";
+         Account account = SingletonProvider<TestSetup>.Instance.AddAccount(_domain, address, Password);
+         SmtpClientSimulator.StaticSend(account.Address, account.Address, "Policy", "Body text.");
+         Pop3ClientSimulator.AssertMessageCount(account.Address, Password, 1);
+
+         string eventLog = "";
+         for (int attempt = 0; attempt < 100; attempt++)
+         {
+            string file = LogHandler.GetEventLogFileName();
+            if (File.Exists(file))
+            {
+               eventLog = File.ReadAllText(file);
+               if (eventLog.Contains(lastLinePrefix))
+                  return eventLog;
+            }
+            Thread.Sleep(100);
+         }
+         Assert.Fail("The script never wrote its '" + lastLinePrefix + "' line. Event log: " + eventLog);
+         return eventLog;
+      }
+
+      [Test]
+      [Description("With ScriptAllowedObjects present and empty, CreateObject fails inside the script with error 429 for every class, the message is still delivered, and the application log names the class and the setting.")]
+      public void AnEmptyListDeniesEveryClass()
+      {
+         SetPolicy("");
+         InstallScript("VBScript", VbScript);
+
+         string eventLog = FireTheScript("shell ");
+         StringAssert.Contains("fso denied 429", eventLog);
+         StringAssert.Contains("shell denied 429", eventLog);
+         StringAssert.DoesNotContain("created", eventLog);
+
+         Assert.IsTrue(LogHandler.DefaultLogContains("Script denied: CreateObject of Scripting.FileSystemObject is not in ScriptAllowedObjects"),
+            "The denial is logged with the class and the setting that denied it: " + LogHandler.ReadCurrentDefaultLog());
+      }
+
+      [Test]
+      [Description("A listed ProgID is created; an unlisted one is denied in the same script.")]
+      public void TheListNamesWhatMayBeCreated()
+      {
+         SetPolicy("Scripting.FileSystemObject");
+         InstallScript("VBScript", VbScript);
+
+         string eventLog = FireTheScript("shell ");
+         StringAssert.Contains("fso created", eventLog);
+         StringAssert.Contains("shell denied 429", eventLog);
+      }
+
+      [Test]
+      [Description("A class may be listed by its CLSID in braces instead of its ProgID; whitespace and case are tolerated.")]
+      public void AClsidNamesAClassToo()
+      {
+         SetPolicy(" " + FileSystemObjectClsid.ToLowerInvariant() + " , wscript.SHELL ");
+         InstallScript("VBScript", VbScript);
+
+         string eventLog = FireTheScript("shell ");
+         StringAssert.Contains("fso created", eventLog);
+         StringAssert.Contains("shell created", eventLog);
+      }
+
+      [Test]
+      [Description("JScript's new ActiveXObject is held to the same list, and reports the same 429 inside the script.")]
+      public void JScriptIsHeldToTheSameList()
+      {
+         SetPolicy("");
+         InstallScript("JScript", JScript);
+
+         string eventLog = FireTheScript("fso ");
+         StringAssert.Contains("fso denied 429", eventLog);
+      }
+
+      [Test]
+      [Description("With the key absent, or set to *, every class may be created - the behaviour every installation had before the setting existed.")]
+      public void AbsentOrStarMeansUnrestricted()
+      {
+         SetPolicy(null);
+         InstallScript("VBScript", VbScript);
+         string eventLog = FireTheScript("shell ");
+         StringAssert.Contains("fso created", eventLog);
+         StringAssert.Contains("shell created", eventLog);
+
+         SetPolicy("*");
+         InstallScript("VBScript", VbScript);
+         eventLog = FireTheScript("shell ");
+         StringAssert.Contains("fso created", eventLog);
+         StringAssert.Contains("shell created", eventLog);
+      }
+   }
+}

--- a/hmailserver/test/RegressionTests/RegressionTests.csproj
+++ b/hmailserver/test/RegressionTests/RegressionTests.csproj
@@ -626,6 +626,7 @@
     <Compile Include="API\RestApiQuarantineAndAliases.cs" />
     <Compile Include="API\RestApiSrvRecords.cs" />
     <Compile Include="API\ScriptReload.cs" />
+    <Compile Include="API\ScriptObjectPolicy.cs" />
     <Compile Include="AntiSpam\DKIM\ArcSealing.cs" />
     <Compile Include="POP3\ProtocolConformance.cs" />
     <Compile Include="SSL\PostQuantumKeyExchange.cs" />


### PR DESCRIPTION
Roadmap row 1080 → ✅. An event script could `CreateObject` any COM class on the machine, in-process, as the service account; the only bound was the wall-clock watchdog.

### What changed

- **`ScriptAllowedObjects`** (`hMailServer.ini`, `[Settings]`): `*` (the default when absent) allows every class as before; empty allows none; otherwise exactly the listed ProgIDs and `{CLSID}`s, case-insensitive, a ProgID matched by name and by the class it resolves to.
- **The script site implements `IInternetHostSecurityManager`** (and `IServiceProvider`, which is how the engines ask), and tells the engine to consult it - `INTERFACE_USES_SECURITY_MANAGER` through the engine's `IObjectSafety`, set only when the list restricts something, failing closed if an engine cannot be told: `ProcessUrlAction(URLACTION_ACTIVEX_RUN)` and `QueryCustomPolicy(GUID_CUSTOM_CONFIRMOBJECTSAFETY)` are answered from the list - the second one deliberately, because the engine's default refuses every class not marked safe for scripting, `Scripting.FileSystemObject` included, whatever the list says. The policy GUID is defined locally (no shipped import library defines it) with the value the engine actually asks for, `{10200490-…-00a0c90fffc0}`, not the one in circulation; every question and answer goes to the debug log.
- **A denied class** fails inside the script with the engine's own 429, trappable with `On Error Resume Next` / `try`, and one application-log line names the class and the setting.
- Written down beside the key: the shipped Control Panel templates use `WScript.Shell` and `MSXML2.ServerXMLHTTP`; and the list bounds what a script can reach, not what the service can.

### Proof

`API/ScriptObjectPolicy` (5 tests): empty list denies both classes with 429 and still delivers; a listed ProgID is created while an unlisted one is denied in the same script; a `{CLSID}` names a class; JScript's `new ActiveXObject` gets the same 429; absent and `*` create both. Verification: API/ScriptObjectPolicy, Events and ScriptReload 33/33 (the first runs found, in turn, that the engines need INTERFACE_USES_SECURITY_MANAGER before they ask at all, and that the policy GUID in circulation is not the one they ask with), then the full regression gate on the Release build: 1982 tests, 1975 passed, 0 failed, the 7 explicit skips.
