### PR TITLE
The ACME client no longer hands OpenSSL a FILE* of its own, which on Windows ended the process the instant a certificate had been issued and at the start of every renewal (issue #93)

### DIFF
--- a/hmailserver/source/Server/Common/Application/Reinitializator.cpp
+++ b/hmailserver/source/Server/Common/Application/Reinitializator.cpp
@@ -42,6 +42,14 @@ namespace HM
          return;
       }
 
+      // The previous restart's thread has finished (is_running_ says so) but was
+      // never joined. Move-assigning over a joinable boost::thread detaches it
+      // silently under the default thread version and terminates the process
+      // under BOOST_THREAD_VERSION 3 and later; either way the handle is reaped
+      // here first, and joining a finished thread returns at once.
+      if (worker_thread_.joinable())
+         worker_thread_.join();
+
       std::function<void ()> func = std::bind( &Reinitializator::WorkerFunc, this );
 
       worker_thread_ = boost::thread(func);

--- a/hmailserver/source/Server/Common/Util/AcmeClient.cpp
+++ b/hmailserver/source/Server/Common/Util/AcmeClient.cpp
@@ -536,6 +536,10 @@ namespace HM
             resolver.resolve(std::string(host.c_str()), std::string(port.c_str()));
 
          boost::asio::ssl::context sslContext(boost::asio::ssl::context::tls_client);
+         // An HTTPS client of a web service: TLS 1.2 is the floor whatever the mail
+         // protocol toggles allow, since there is no 2008-era CA, token issuer or
+         // policy host to accommodate.
+         sslContext.set_options(boost::asio::ssl::context::default_workarounds | boost::asio::ssl::context::no_sslv2 | boost::asio::ssl::context::no_sslv3 | boost::asio::ssl::context::no_tlsv1 | boost::asio::ssl::context::no_tlsv1_1);
          sslContext.set_default_verify_paths();
 
          // Through the shared client initialiser, for the same reason the optional
@@ -1130,11 +1134,16 @@ namespace HM
       {
          AnsiString keyPath = AnsiString(GetCertificateDirectory() + _T("\\privkey.pem"));
 
-         FILE *keyFile = nullptr;
-         if (fopen_s(&keyFile, keyPath.c_str(), "rb") == 0 && keyFile != nullptr)
+         // A BIO, not a FILE*: see GetCertificateTlsa for why a FILE* of this
+         // executable's C runtime handed to the OpenSSL DLL ends the process
+         // (issue #93). This is the renewal half of that: with an existing key on
+         // disk - every renewal, under the default AcmeReuseKey - the process
+         // died here, before the order was even finalised.
+         BIO *keyBio = BIO_new_file(keyPath.c_str(), "r");
+         if (keyBio != nullptr)
          {
-            domainKey = PEM_read_PrivateKey(keyFile, nullptr, nullptr, nullptr);
-            fclose(keyFile);
+            domainKey = PEM_read_bio_PrivateKey(keyBio, nullptr, nullptr, nullptr);
+            BIO_free(keyBio);
 
             if (domainKey != nullptr)
                LOG_APPLICATION("ACME: Reusing the existing certificate key (keeps published TLSA records valid).");
@@ -1463,13 +1472,23 @@ namespace HM
 
       LOG_APPLICATION("ACME: Certificate issued successfully: " + GetCertificateDirectory() + _T("\\fullchain.pem"));
 
+      // Deployment first: the certificate record, the port assignments and the
+      // restart are what the renewal exists for. The TLSA line below is a
+      // convenience for the administrators who publish DANE, and issue #93 was
+      // that convenience taking the service down before the deployment had run.
+      // Make the new certificate take effect without manual steps.
+      ApplyCertificate_();
+
       // Publish-ready DANE record for administrators running inbound DANE.
       AnsiString spkiHex;
       if (GetCertificateTlsa(GetCertificateDirectory() + _T("\\fullchain.pem"), spkiHex))
+      {
          LOG_APPLICATION("ACME: DANE TLSA record for this certificate: _25._tcp.<mx-host>. IN TLSA 3 1 1 " + String(spkiHex));
-
-      // Make the new certificate take effect without manual steps.
-      ApplyCertificate_();
+      }
+      else
+      {
+         LOG_APPLICATION("ACME: The DANE TLSA record for the new certificate could not be computed from fullchain.pem. The certificate itself is installed; only this log line is missing.");
+      }
 
       AcmeChallengeStore::Clear();
 
@@ -1481,14 +1500,28 @@ namespace HM
    {
       spki_sha256_hex = "";
 
+      // Through a BIO that OpenSSL opens itself, never a FILE* of ours. On
+      // Windows a FILE* handed to the OpenSSL DLL is read through its "uplink"
+      // table, which routes every stdio call back into the executable's own C
+      // runtime by way of an OPENSSL_Applink export the executable has to provide
+      // (openssl/applink.c). This executable provides none, and the DLL's answer
+      // to that is not an error return: the first fread lands in a stub that
+      // writes "OPENSSL_Uplink(...): no OPENSSL_Applink" to the Windows
+      // Application log under the source "OpenSSL" and calls TerminateProcess.
+      // That was issue #93 - the service gone the instant a certificate had been
+      // issued, an OpenSSL event that looked empty beside a 7031 from the service
+      // control manager in the same second, and no "ACME (automatic)" record
+      // because this ran before the deployment. Every other file this client
+      // reads or writes already goes through BIO_new_file; this function and
+      // the key reuse in FinalizeOrder_ were the two that did not.
       AnsiString narrowPath = certificate_file;
 
-      FILE *file = nullptr;
-      if (fopen_s(&file, narrowPath.c_str(), "rb") != 0 || file == nullptr)
+      BIO *bio = BIO_new_file(narrowPath.c_str(), "r");
+      if (bio == nullptr)
          return false;
 
-      X509 *certificate = PEM_read_X509(file, nullptr, nullptr, nullptr);
-      fclose(file);
+      X509 *certificate = PEM_read_bio_X509(bio, nullptr, nullptr, nullptr);
+      BIO_free(bio);
 
       if (certificate == nullptr)
          return false;

--- a/hmailserver/source/Server/Common/Util/ClassTester.cpp
+++ b/hmailserver/source/Server/Common/Util/ClassTester.cpp
@@ -13,6 +13,8 @@
 #include "../Util/Utilities.h"
 #include "../Util/MessageUtilities.h"
 #include "../Util/AcmeClient.h"
+#include "../Util/FileUtilities.h"
+#include "../Application/IniFileSettings.h"
 #include "../Util/Charset.h"
 #include "../Util/RegularExpression.h"
 #include "../TCPIP/LocalIPAddresses.h"
@@ -351,6 +353,61 @@ namespace HM
       OutputDebugString(_T("hMailServer: Testing Base64\n"));
       Base64Tester base64Tester;
       base64Tester.Test();
+
+      OutputDebugString(_T("hMailServer: Testing the ACME TLSA record\n"));
+      {
+         // Issue #93. GetCertificateTlsa read the certificate through a FILE* of
+         // this executable's C runtime, and on Windows the OpenSSL DLL reads such
+         // a FILE* through its "uplink" table, which needs an OPENSSL_Applink
+         // export this executable does not have. The DLL's answer to the missing
+         // export is TerminateProcess, so the service died the moment a
+         // certificate had been issued. This runs the same function on a
+         // certificate written to the temp directory: with the FILE* code it
+         // kills the process, which no test framework can miss. The expected
+         // digest is the SHA-256 of the certificate's DER SubjectPublicKeyInfo,
+         // computed independently with the openssl command line:
+         //   openssl x509 -pubkey -noout | openssl pkey -pubin -outform DER | openssl dgst -sha256
+         const char *fixture =
+            "-----BEGIN CERTIFICATE-----\n"
+            "MIIBnTCCAUOgAwIBAgIUTt9dEsQtTAfFIIM+5viNWZ1No2wwCgYIKoZIzj0EAwIw\n"
+            "JDEiMCAGA1UEAwwZdGxzYS1maXh0dXJlLmV4YW1wbGUudGVzdDAeFw0yNjA5MDYw\n"
+            "MTE5NDlaFw00NjA5MDEwMTE5NDlaMCQxIjAgBgNVBAMMGXRsc2EtZml4dHVyZS5l\n"
+            "eGFtcGxlLnRlc3QwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAARcQAyXS3jMUHe7\n"
+            "R1o4DUn+iwKaVorSVrb/ajttx1R+PcKDb2ftkaDapR7MHbBRLTNrY02KJjzoreKa\n"
+            "mGx4JxOJo1MwUTAdBgNVHQ4EFgQU+KRDFDaeMDV/BbibOpNAb0tBARswHwYDVR0j\n"
+            "BBgwFoAU+KRDFDaeMDV/BbibOpNAb0tBARswDwYDVR0TAQH/BAUwAwEB/zAKBggq\n"
+            "hkjOPQQDAgNIADBFAiEAoRJcE3fgMRiHhf3LglFlRkznZENHdc9SwMOGjNpsUokC\n"
+            "IHt+CXzwoEOtys7tKUt6k5y/Qftj4xirfGPZCy00rzX/\n"
+            "-----END CERTIFICATE-----\n";
+
+         String path = IniFileSettings::Instance()->GetTempDirectory() + _T("\\tlsa-fixture.pem");
+         if (!FileUtilities::WriteToFile(path, AnsiString(fixture)))
+            throw 0;
+
+         AnsiString hex;
+         bool computed = AcmeClient::GetCertificateTlsa(path, hex);
+         FileUtilities::DeleteFile(path);
+
+         if (!computed)
+            throw 0;
+         if (hex != "fece5d0297fa1a2bd1a4e510275367f904fc631c70a3e2a5515e554e1ab67a38")
+            throw 0;
+
+         // A file that is not a certificate is a false, not a crash, and leaves
+         // the answer empty.
+         if (!FileUtilities::WriteToFile(path, AnsiString("not a certificate\n")))
+            throw 0;
+
+         bool rejected = !AcmeClient::GetCertificateTlsa(path, hex);
+         FileUtilities::DeleteFile(path);
+
+         if (!rejected || !hex.IsEmpty())
+            throw 0;
+
+         // And so is a file that does not exist.
+         if (AcmeClient::GetCertificateTlsa(path, hex))
+            throw 0;
+      }
 
       OutputDebugString(_T("hMailServer: Testing the ACME challenge locator\n"));
       {


### PR DESCRIPTION
Fixes #93. Two calls in `AcmeClient` handed the OpenSSL DLL a `FILE*` opened by this executable's C runtime: `PEM_read_X509` in `GetCertificateTlsa` (the DANE TLSA line logged straight after issuance) and `PEM_read_PrivateKey` in `FinalizeOrder_` (key reuse at the start of every renewal). On Windows the DLL routes such a `FILE*` through its uplink table, which needs an `OPENSSL_Applink` export this executable has never provided; the DLL's answer is a "no OPENSSL_Applink" event under the source "OpenSSL" (event id 0) and `TerminateProcess` - the reporter's OpenSSL event, the 7031 in the same second, no dump, and no "ACME (automatic)" record because the TLSA line ran before the deployment. Both calls now go through `BIO_new_file` like every other file the client touches. Deployment runs before the TLSA line; a TLSA that cannot be computed is logged rather than silent; `Reinitializator` joins the previous restart thread before starting another. `ClassTester` (run by `Utilities.RunTestSuite` in the suite) computes the TLSA of a fixture certificate against an independently computed digest, then a non-certificate and a missing file. Verification: the fixtures around the ACME client, the self-test and the discovery endpoints 27/27 (MainOperations, ClientDiscovery, TlsAcmeRenewal, SecurityTxt, ListenerTlsConfiguration, ListenerIpv6), then the full regression gate on the Release build carrying this change together with the code-scanning change that follows it: 2000 tests, 1993 passed, 0 failed, the 7 explicit skips.
