### PR TITLE
A certificate the ACME client issued but never deployed is deployed at the next check, the state issue #93 left affected installations in

### DIFF
--- a/fuzz/Find-ClangCl.ps1
+++ b/fuzz/Find-ClangCl.ps1
@@ -108,8 +108,12 @@ function Test-ClangSanitizerRuntime {
 
 # True when the current process already has the MSVC build environment.
 function Test-VsDevEnvironment {
-    if ($env:VCToolsInstallDir) { return $true }
-    return [bool](Get-Command link.exe -ErrorAction SilentlyContinue)
+    # VCToolsInstallDir is what vcvars64.bat sets, and the only reliable sign.
+    # This used to accept "link.exe is on PATH" as well, and an LLVM or Swift
+    # toolchain puts a link.exe on PATH without any of the MSVC library paths -
+    # so the import was skipped, clang-cl found the CRT by its own detection,
+    # and the link failed on stl_asan.lib, which lives only in the MSVC lib dir.
+    return [bool]$env:VCToolsInstallDir
 }
 
 # Runs vcvars64.bat in a child cmd and copies the resulting environment into this

--- a/fuzz/harness/shim/stdafx.h
+++ b/fuzz/harness/shim/stdafx.h
@@ -46,6 +46,11 @@
 
 #pragma once
 
+// Says "this is the fuzz harness" to the one production header that has to know:
+// Common/Application/ErrorManager.h, which Mime.cpp includes directly and which
+// would otherwise redefine the stand-in ErrorManager below.
+#define HM_FUZZ_HARNESS 1
+
 #if !defined(UNICODE) || !defined(_UNICODE)
    #error "The fuzz build must define UNICODE and _UNICODE, matching hMailServer.vcxproj. Without them HM::String changes width and you are not fuzzing the shipped parser. Use build-fuzz.ps1."
 #endif
@@ -274,7 +279,18 @@ namespace HM
       static bool Copy(const String &, const String &, bool = false) { return false; }
       static bool WriteToFile(const String &, const String &, bool) { return false; }
       static bool WriteToFile(const String &, const AnsiString &) { return false; }
+      // MimeBody::SaveAllToFile writes through this since the delivery hard-link
+      // change (temporary file, then a replacing rename). The harness never saves
+      // a message, so it answers the way the other writers here do.
+      static bool WriteToFileAtomically(const String &, const AnsiString &) { return false; }
    };
+
+   // The server's LOG_* macros come from Application/Logger.h through its
+   // precompiled header. The parser logs the file it is about to rewrite, and
+   // nothing else; here the argument is evaluated for its side effects (none)
+   // and dropped.
+   #define LOG_DEBUG(s) ((void)(s))
+   #define LOG_APPLICATION(s) ((void)(s))
 
    // Only StringParser::IsValidIPAddress needs this, and nothing the MIME parser
    // does reaches that function - but StringParser.cpp is compiled whole, so the

--- a/hmailserver/source/Server/Common/Application/Application.cpp
+++ b/hmailserver/source/Server/Common/Application/Application.cpp
@@ -817,16 +817,19 @@ namespace HM
       // Automatic certificate renewal via ACME (Let's Encrypt).
       if (IniFileSettings::Instance()->GetAcmeEnabled())
       {
-         // Check immediately at startup...
-         std::shared_ptr<AcmeRenewalTask> acmeStartupTask = std::shared_ptr<AcmeRenewalTask>(new AcmeRenewalTask);
-         acmeStartupTask->SetReoccurance(ScheduledTask::RunOnce);
-         scheduler_->ScheduleTask(acmeStartupTask);
-
-         // ...and then once an hour.
+         // Once an hour...
          std::shared_ptr<AcmeRenewalTask> acmeTask = std::shared_ptr<AcmeRenewalTask>(new AcmeRenewalTask);
          acmeTask->SetReoccurance(ScheduledTask::RunInfinitely);
          acmeTask->SetMinutesBetweenRun(60);
          scheduler_->ScheduleTask(acmeTask);
+
+         // ...and immediately at startup. Queued last: a RunOnce task goes straight
+         // onto the maintenance queue, and this one can end in a restart of the
+         // servers (a certificate issued but never deployed is deployed by it),
+         // which must not race the scheduling still going on here.
+         std::shared_ptr<AcmeRenewalTask> acmeStartupTask = std::shared_ptr<AcmeRenewalTask>(new AcmeRenewalTask);
+         acmeStartupTask->SetReoccurance(ScheduledTask::RunOnce);
+         scheduler_->ScheduleTask(acmeStartupTask);
       }
 
    }
@@ -950,6 +953,11 @@ namespace HM
    String
    Application::Reinitialize()
    {
+      // One restart at a time: see the member's comment in Application.h. A
+      // second caller waits for the first to finish and then restarts again,
+      // which is what it asked for.
+      boost::lock_guard<boost::mutex> guard(reinitialize_mutex_);
+
       StopServers();
       ExitInstance();
 

--- a/hmailserver/source/Server/Common/Application/Application.h
+++ b/hmailserver/source/Server/Common/Application/Application.h
@@ -112,6 +112,14 @@ namespace HM
       std::shared_ptr<ExternalFetchManager> external_fetch_manager_;
       std::shared_ptr<BackupManager> backup_manager_;
       std::shared_ptr<Scheduler> scheduler_;
+
+      // Reinitialize() is reachable from a COM client and from the
+      // Reinitializator thread an ACME deployment or a backup restore starts,
+      // and two of them at once tear down and rebuild the same queues under
+      // each other - a RunOnce task queued by one StartServers onto a
+      // maintenance queue the other ExitInstance had just removed was an access
+      // violation. They run one after the other now.
+      boost::mutex reinitialize_mutex_;
       std::shared_ptr<NotificationServer> notification_server_;
       std::shared_ptr<IOService> io_service_;
       std::shared_ptr<FolderManager> folder_manager_;

--- a/hmailserver/source/Server/Common/Application/ErrorManager.h
+++ b/hmailserver/source/Server/Common/Application/ErrorManager.h
@@ -5,6 +5,14 @@
 
 #pragma once
 
+// The fuzz harness (fuzz/harness/shim/stdafx.h) supplies a stand-in ErrorManager
+// of the same name, because the real one reaches the logger, the configuration
+// and the INI settings - an entire server - and defines HM_FUZZ_HARNESS before
+// any source includes this header. Mime.cpp includes it directly, so the shim
+// cannot shadow it through the include path; the guard is what keeps the two
+// definitions apart.
+#ifndef HM_FUZZ_HARNESS
+
 namespace HM
 {
 
@@ -62,3 +70,5 @@ namespace HM
 
    };
 }
+
+#endif // HM_FUZZ_HARNESS

--- a/hmailserver/source/Server/Common/Application/Scheduler.cpp
+++ b/hmailserver/source/Server/Common/Application/Scheduler.cpp
@@ -123,7 +123,18 @@ namespace HM
       // If task should only be run once, run it now.
       if (pTask->GetReoccurance() == ScheduledTask::RunOnce)
       {
-         Application::Instance()->GetMaintenanceWorkQueue()->AddTask(pTask);
+         // GetMaintenanceWorkQueue reports HM5118 and answers an empty pointer
+         // while the servers are being torn down; this used to dereference it.
+         // A start-up task queued into a shutdown has nothing to run on, and
+         // the next start queues it again.
+         std::shared_ptr<WorkQueue> maintenanceQueue = Application::Instance()->GetMaintenanceWorkQueue();
+         if (!maintenanceQueue)
+         {
+            LOG_DEBUG("Scheduler::ScheduleTask - The maintenance queue is not available, so a run-once task is dropped: " + pTask->GetName());
+            return;
+         }
+
+         maintenanceQueue->AddTask(pTask);
          return;
       }
 

--- a/hmailserver/source/Server/Common/Util/AcmeClient.cpp
+++ b/hmailserver/source/Server/Common/Util/AcmeClient.cpp
@@ -1553,6 +1553,38 @@ namespace HM
       return success;
    }
 
+   bool
+   AcmeClient::ApplyIssuedCertificateIfUnrecorded()
+   {
+      // Issue #93 left installations in exactly this state: 6.2.24 wrote a valid
+      // fullchain.pem and privkey.pem and died before ApplyCertificate_ ran, so
+      // the pair sat on disk with no "ACME (automatic)" record naming it and the
+      // TLS ports pointed at nothing - and because the certificate was not due
+      // for renewal, every later run of the task looked at it and left. A pair
+      // on disk that no record names is deployed here, once, the way a fresh
+      // issuance is; with the record in place this is one look-up and nothing
+      // else. An administrator who deleted the record on purpose gets it back
+      // at the next run, which is the lesser surprise: ACME is enabled, the
+      // certificate is its, and a deleted record was the symptom of #93.
+      String certificateFile = GetCertificateDirectory() + _T("\\fullchain.pem");
+      String privateKeyFile = GetCertificateDirectory() + _T("\\privkey.pem");
+
+      if (!FileUtilities::Exists(certificateFile) || !FileUtilities::Exists(privateKeyFile))
+         return false;
+
+      SSLCertificates certificates;
+      certificates.Refresh();
+
+      if (certificates.GetItemByName(_T("ACME (automatic)")))
+         return false;
+
+      LOG_APPLICATION("ACME: The certificate in " + GetCertificateDirectory() + " has no \"ACME (automatic)\" record - it was issued but never deployed. Deploying it now.");
+
+      ApplyCertificate_();
+
+      return true;
+   }
+
    void
    AcmeClient::ApplyCertificate_()
    {
@@ -1808,7 +1840,12 @@ namespace HM
       AcmeClient client;
 
       if (!client.ShouldRenewNow())
+      {
+         // Not due - but a certificate that was issued and never deployed (issue
+         // #93's aftermath) is deployed on the way out.
+         client.ApplyIssuedCertificateIfUnrecorded();
          return;
+      }
 
       LOG_APPLICATION("ACME: Certificate is missing or due for renewal. Requesting a new certificate.");
 

--- a/hmailserver/source/Server/Common/Util/AcmeClient.h
+++ b/hmailserver/source/Server/Common/Util/AcmeClient.h
@@ -86,6 +86,10 @@ namespace HM
       // Runs the full issuance flow. Returns true on success.
       bool RequestCertificate();
 
+      // A certificate pair on disk that no "ACME (automatic)" record names is
+      // deployed the way a fresh issuance is. Returns true when it did so.
+      bool ApplyIssuedCertificateIfUnrecorded();
+
       // Whether to renew now.
       //
       // Asks the CA through ARI when it offers it, and falls back to the

--- a/hmailserver/test/RegressionTests/Infrastructure/MetricsHistory.cs
+++ b/hmailserver/test/RegressionTests/Infrastructure/MetricsHistory.cs
@@ -124,24 +124,28 @@ namespace RegressionTests.Infrastructure
          // The history outlives the process and the counter does not: samples
          // taken before the last service restart sit in the same hour with larger
          // totals, so "last minus first" across the whole window went negative
-         // whenever a fixture had restarted the service after a busy stretch. The
-         // comparison is between the two samples this test takes, found by their
-         // position after whatever was already there.
-         int before = Values(_application.Utilities.GetMetricHistory("processed_messages_total", 60, 0)).Length;
-
+         // whenever a fixture had restarted the service after a busy stretch - and
+         // counting positions from the start of the window slid by one whenever
+         // the oldest sample aged out of the hour between two reads. So: the
+         // newest sample right after each of the two samples this test takes, and
+         // the difference between them. A scheduled sample landing in between can
+         // only make the newest one larger, since nothing restarts the service here.
+         // Bucket 0 is every sample, not an average - two samples a second apart
+         // would otherwise be one point.
          _application.Utilities.SampleMetricsNow();
+         double[] first = Values(_application.Utilities.GetMetricHistory("processed_messages_total", 60, 0));
+         ClassicAssert.GreaterOrEqual(first.Length, 1, "The sample just taken is in the history.");
+         double beforeDelivery = first[first.Length - 1];
 
          SmtpClientSimulator.StaticSend("sender@example.test", account.Address, "Counted", "One message.");
          Pop3ClientSimulator.AssertMessageCount(account.Address, "test", 1);
 
          _application.Utilities.SampleMetricsNow();
+         double[] second = Values(_application.Utilities.GetMetricHistory("processed_messages_total", 60, 0));
+         ClassicAssert.GreaterOrEqual(second.Length, 2, "Two samples were taken.");
+         double afterDelivery = second[second.Length - 1];
 
-         // Bucket 0: every sample, not an average - two samples a second apart
-         // would otherwise be one point.
-         double[] values = Values(_application.Utilities.GetMetricHistory("processed_messages_total", 60, 0));
-
-         ClassicAssert.GreaterOrEqual(values.Length, before + 2, "Two samples were taken.");
-         ClassicAssert.GreaterOrEqual(values[values.Length - 1] - values[before], 1.0,
+         ClassicAssert.GreaterOrEqual(afterDelivery - beforeDelivery, 1.0,
             "The total must have advanced by at least the one message delivered in between.");
       }
 

--- a/hmailserver/test/RegressionTests/RegressionTests.csproj
+++ b/hmailserver/test/RegressionTests/RegressionTests.csproj
@@ -339,6 +339,7 @@
     <Compile Include="SMTP\EsmtpConformance.cs" />
     <Compile Include="SMTP\StartTlsAlreadyActive.cs" />
     <Compile Include="Security\TlsAcmeRenewal.cs" />
+    <Compile Include="Security\TlsAcmeDeployment.cs" />
     <Compile Include="Security\TlsCertificateValidity.cs" />
     <Compile Include="Security\TlsProtocolVersions.cs" />
     <Compile Include="API\StatusTests.cs" />

--- a/hmailserver/test/RegressionTests/Security/TlsAcmeDeployment.cs
+++ b/hmailserver/test/RegressionTests/Security/TlsAcmeDeployment.cs
@@ -1,0 +1,226 @@
+// Copyright (c) 2026 Christopher Holloway / Progressive Robot Ltd
+// https://www.progressiverobot.com
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using RegressionTests.Infrastructure;
+using RegressionTests.Shared;
+using hMailServer;
+
+namespace RegressionTests.Security
+{
+   /// <summary>
+   ///    A certificate the ACME client issued but never deployed is deployed at the next
+   ///    check. Issue #93 left installations in exactly that state: 6.2.24 wrote a valid
+   ///    fullchain.pem and privkey.pem and ended the process before the "ACME (automatic)"
+   ///    record was created, and because the certificate was not due for renewal every
+   ///    later run of the task looked at it and left. Now a pair on disk that no record
+   ///    names is deployed once, the way a fresh issuance is; with the record in place the
+   ///    check is one look-up and nothing else.
+   /// </summary>
+   [TestFixture]
+   public class TlsAcmeDeployment : TestFixtureBase
+   {
+      // Nothing listens here, so ShouldRenewNow cannot ask the CA for its opinion and
+      // falls back to the certificate's own dates - twenty years of them. Inside this
+      // fixture's assigned port range.
+      private const int UnreachableAcmePort = 9483;
+
+      private const string RecordName = "ACME (automatic)";
+
+      // A self-signed EC P-256 certificate valid until 2046, and its key; the same
+      // fixture the server's self-test computes a TLSA record for.
+      private const string CertificatePem =
+         "-----BEGIN CERTIFICATE-----\n" +
+         "MIIBnTCCAUOgAwIBAgIUTt9dEsQtTAfFIIM+5viNWZ1No2wwCgYIKoZIzj0EAwIw\n" +
+         "JDEiMCAGA1UEAwwZdGxzYS1maXh0dXJlLmV4YW1wbGUudGVzdDAeFw0yNjA5MDYw\n" +
+         "MTE5NDlaFw00NjA5MDEwMTE5NDlaMCQxIjAgBgNVBAMMGXRsc2EtZml4dHVyZS5l\n" +
+         "eGFtcGxlLnRlc3QwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAARcQAyXS3jMUHe7\n" +
+         "R1o4DUn+iwKaVorSVrb/ajttx1R+PcKDb2ftkaDapR7MHbBRLTNrY02KJjzoreKa\n" +
+         "mGx4JxOJo1MwUTAdBgNVHQ4EFgQU+KRDFDaeMDV/BbibOpNAb0tBARswHwYDVR0j\n" +
+         "BBgwFoAU+KRDFDaeMDV/BbibOpNAb0tBARswDwYDVR0TAQH/BAUwAwEB/zAKBggq\n" +
+         "hkjOPQQDAgNIADBFAiEAoRJcE3fgMRiHhf3LglFlRkznZENHdc9SwMOGjNpsUokC\n" +
+         "IHt+CXzwoEOtys7tKUt6k5y/Qftj4xirfGPZCy00rzX/\n" +
+         "-----END CERTIFICATE-----\n";
+
+      private const string PrivateKeyPem =
+         "-----BEGIN PRIVATE KEY-----\n" +
+         "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgGTr14alyWTYqvn3W\n" +
+         "b/ZUSNYvcGhToNmp8nlMVtPoTPqhRANCAARcQAyXS3jMUHe7R1o4DUn+iwKaVorS\n" +
+         "Vrb/ajttx1R+PcKDb2ftkaDapR7MHbBRLTNrY02KJjzoreKamGx4JxOJ\n" +
+         "-----END PRIVATE KEY-----\n";
+
+      // The ports' certificate assignments as this fixture found them: the deployment
+      // assigns the new record to every TLS port that has none, and the bench must be
+      // left as it was.
+      private readonly Dictionary<int, int> _portCertificates = new Dictionary<int, int>();
+
+      // Under the server's own program directory, not the temp directory: the files
+      // have to be readable by the *service*, which need not be running as the account
+      // the tests run as. TlsAcmeRenewal does the same.
+      private string AcmeDirectory
+      {
+         get { return Paths.Combine(_application.Settings.Directories.ProgramDirectory, "hm_acme_deploy_test"); }
+      }
+
+      [SetUp]
+      public void RecordPortCertificates()
+      {
+         _portCertificates.Clear();
+         TCPIPPorts ports = _application.Settings.TCPIPPorts;
+         for (int i = 0; i < ports.Count; i++)
+         {
+            TCPIPPort port = ports[i];
+            _portCertificates[port.ID] = port.SSLCertificateID;
+         }
+      }
+
+      [TearDown]
+      public void DisableAcmeAndRestore()
+      {
+         try
+         {
+            IniFileSetting.Write("AcmeEnabled", null);
+            IniFileSetting.Write("AcmeDomains", null);
+            IniFileSetting.Write("AcmeDirectoryUrl", null);
+            IniFileSetting.Write("AcmeCertificateDirectory", null);
+
+            // Any port the deployment pointed at the record goes back to what it had;
+            // then the record itself goes.
+            TCPIPPorts ports = _application.Settings.TCPIPPorts;
+            ports.Refresh();
+            for (int i = 0; i < ports.Count; i++)
+            {
+               TCPIPPort port = ports[i];
+               int before;
+               if (_portCertificates.TryGetValue(port.ID, out before) && port.SSLCertificateID != before)
+               {
+                  port.SSLCertificateID = before;
+                  port.Save();
+               }
+            }
+
+            SSLCertificate record = FindRecord();
+            while (record != null)
+            {
+               record.Delete();
+               record = FindRecord();
+            }
+
+            _application.Reinitialize();
+         }
+         finally
+         {
+            LogHandler.DeleteErrorLog();
+            try
+            {
+               if (Directory.Exists(AcmeDirectory))
+                  Directory.Delete(AcmeDirectory, true);
+            }
+            catch (IOException)
+            {
+               // Deliberately ignored: best effort only, and the outcome of the surrounding operation does not depend on this succeeding.
+            }
+         }
+      }
+
+      private SSLCertificate FindRecord()
+      {
+         SSLCertificates certificates = _application.Settings.SSLCertificates;
+         certificates.Refresh();
+         for (int i = 0; i < certificates.Count; i++)
+         {
+            SSLCertificate certificate = certificates[i];
+            if (certificate.Name == RecordName)
+               return certificate;
+         }
+         return null;
+      }
+
+      private int CountRecords()
+      {
+         SSLCertificates certificates = _application.Settings.SSLCertificates;
+         certificates.Refresh();
+         int count = 0;
+         for (int i = 0; i < certificates.Count; i++)
+            if (certificates[i].Name == RecordName)
+               count++;
+         return count;
+      }
+
+      private static int CountOccurrences(string text, string needle)
+      {
+         int count = 0;
+         int at = 0;
+         while ((at = text.IndexOf(needle, at, StringComparison.Ordinal)) >= 0)
+         {
+            count++;
+            at += needle.Length;
+         }
+         return count;
+      }
+
+      [Test]
+      [Description("A certificate pair on disk with no \"ACME (automatic)\" record is deployed at the next ACME check, once; a second check finds the record and does nothing")]
+      public void AnIssuedButUndeployedCertificateIsDeployedAtTheNextCheck()
+      {
+         Directory.CreateDirectory(AcmeDirectory);
+         string certificateFile = Paths.Combine(AcmeDirectory, "fullchain.pem");
+         string privateKeyFile = Paths.Combine(AcmeDirectory, "privkey.pem");
+         File.WriteAllText(certificateFile, CertificatePem, new UTF8Encoding(false));
+         File.WriteAllText(privateKeyFile, PrivateKeyPem, new UTF8Encoding(false));
+
+         Assert.IsNull(FindRecord(), "The bench starts with no ACME record.");
+
+         IniFileSetting.Write("AcmeCertificateDirectory", AcmeDirectory);
+         IniFileSetting.Write("AcmeDirectoryUrl", "https://127.0.0.1:" + UnreachableAcmePort + "/directory");
+         IniFileSetting.Write("AcmeDomains", "mail.example.test");
+         IniFileSetting.Write("AcmeEnabled", "1");
+
+         // Reinitialize registers the renewal task afresh, and its startup instance
+         // runs at once. The certificate is not due, so against the build before this
+         // change the task looked at the pair and left; now it deploys it - and the
+         // deployment restarts the servers, which is why the record is polled for.
+         _application.Reinitialize();
+
+         RetryHelper.TryAction(TimeSpan.FromSeconds(60), () =>
+         {
+            SSLCertificate record = FindRecord();
+            if (record == null)
+               throw new Exception("No \"" + RecordName + "\" record yet. Log:\r\n" + LogHandler.ReadCurrentDefaultLog());
+
+            Assert.AreEqual(certificateFile, record.CertificateFile);
+            Assert.AreEqual(privateKeyFile, record.PrivateKeyFile);
+         });
+
+         RetryHelper.TryAction(TimeSpan.FromSeconds(30), () =>
+         {
+            string log = LogHandler.ReadCurrentDefaultLog();
+            if (!log.Contains("issued but never deployed"))
+               throw new Exception("The deployment is not in the log yet. Log:\r\n" + log);
+            if (!log.Contains("Restarting servers to load the new certificate"))
+               throw new Exception("The restart is not in the log yet. Log:\r\n" + log);
+         });
+
+         // The second check: the record exists, so the task does nothing - no second
+         // record, no second deployment line. A Reinitialize runs the startup instance
+         // again, and the deployment's own restart may already have run it once more;
+         // either way the count of records is one and the count of deployments is one.
+         _application.Reinitialize();
+
+         // The startup instance goes straight onto the maintenance queue when
+         // Reinitialize registers it, and the not-due path is a file check and one
+         // database read. A few seconds is generous.
+         System.Threading.Thread.Sleep(3000);
+
+         Assert.AreEqual(1, CountRecords(), "One record, however many checks have run.");
+         Assert.AreEqual(1, CountOccurrences(LogHandler.ReadCurrentDefaultLog(), "issued but never deployed"),
+            "The deployment happens once; with the record in place the check is a look-up.");
+      }
+   }
+}


### PR DESCRIPTION
The aftermath of #93: an installation that died between writing the certificate pair and creating the "ACME (automatic)" record has a valid pair on disk that nothing names, and the task saw a certificate not due for renewal and left it there until the renewal date. `AcmeClient::ApplyIssuedCertificateIfUnrecorded`, on the task's not-due path, deploys such a pair once the way a fresh issuance is (record, port assignments, restart); with the record in place it is one look-up. The startup instance of the task is queued after the hourly one, so the restart it can now trigger has nothing to race. `Security/TlsAcmeDeployment` drives it with a valid pair and an unreachable CA and leaves the bench as found. Found by that test's first run and fixed here too: two `Application::Reinitialize` calls at once - one over COM, one from the `Reinitializator` thread an ACME deployment or a backup restore starts - tore down and rebuilt the same queues under each other, ending in HM5118 and an access violation in `Scheduler::ScheduleTask`; restarts are serialised by a mutex now and `ScheduleTask` checks the maintenance-queue pointer. The fuzz harness builds again (shim additions, `HM_FUZZ_HARNESS` guard in `ErrorManager.h`, `Find-ClangCl` no longer fooled by Git's `link.exe`), and `MetricsHistory.ACounterAdvancesBetweenSamples` compares the newest sample before and after its delivery instead of positions in a sliding window. Verification: TlsAcmeDeployment, TlsAcmeRenewal, MainOperations and BackupRestore 13/13 on the build with the mutex and the guard (the run before them, without, was the crash described above), then the full regression gate on that Release build: 2001 tests, 1993 passed, 1 failed - the metrics-history comparison, fixed above and 6/6 with TlsAcme 2/2 on the same build afterwards - and the 7 explicit skips.
