### PR TITLE
A fresh SQL Server Compact install could not create its database and an upgrade stopped at 6029: the archive-index statements were one command, and the foreign keys used a syntax Compact Edition lacks

### DIFF
--- a/hmailserver/source/DBScripts/CreateTablesMSSQL.sql
+++ b/hmailserver/source/DBScripts/CreateTablesMSSQL.sql
@@ -1168,42 +1168,45 @@ create table hm_archiveindex
 	archivesize bigint not null,
 	archivehold int not null
 )
+
 ALTER TABLE hm_archiveindex ADD CONSTRAINT hm_archiveindex_pk PRIMARY KEY NONCLUSTERED (archiveid)
+
 CREATE CLUSTERED INDEX idx_hm_archiveindex_domain_time ON hm_archiveindex (archivedomain, archivetime)
+
 CREATE INDEX idx_hm_archiveindex_path ON hm_archiveindex (archivepath)
 
-ALTER TABLE hm_accounts WITH CHECK ADD CONSTRAINT fk_hm_accounts_domain FOREIGN KEY (accountdomainid) REFERENCES hm_domains (domainid) ON DELETE CASCADE
+ALTER TABLE hm_accounts ADD CONSTRAINT fk_hm_accounts_domain FOREIGN KEY (accountdomainid) REFERENCES hm_domains (domainid) ON DELETE CASCADE
 
-ALTER TABLE hm_aliases WITH CHECK ADD CONSTRAINT fk_hm_aliases_domain FOREIGN KEY (aliasdomainid) REFERENCES hm_domains (domainid) ON DELETE CASCADE
+ALTER TABLE hm_aliases ADD CONSTRAINT fk_hm_aliases_domain FOREIGN KEY (aliasdomainid) REFERENCES hm_domains (domainid) ON DELETE CASCADE
 
-ALTER TABLE hm_domain_aliases WITH CHECK ADD CONSTRAINT fk_hm_domain_aliases_domain FOREIGN KEY (dadomainid) REFERENCES hm_domains (domainid) ON DELETE CASCADE
+ALTER TABLE hm_domain_aliases ADD CONSTRAINT fk_hm_domain_aliases_domain FOREIGN KEY (dadomainid) REFERENCES hm_domains (domainid) ON DELETE CASCADE
 
-ALTER TABLE hm_distributionlists WITH CHECK ADD CONSTRAINT fk_hm_distributionlists_domain FOREIGN KEY (distributionlistdomainid) REFERENCES hm_domains (domainid) ON DELETE CASCADE
+ALTER TABLE hm_distributionlists ADD CONSTRAINT fk_hm_distributionlists_domain FOREIGN KEY (distributionlistdomainid) REFERENCES hm_domains (domainid) ON DELETE CASCADE
 
-ALTER TABLE hm_distributionlistsrecipients WITH CHECK ADD CONSTRAINT fk_hm_dlrecipients_list FOREIGN KEY (distributionlistrecipientlistid) REFERENCES hm_distributionlists (distributionlistid) ON DELETE CASCADE
+ALTER TABLE hm_distributionlistsrecipients ADD CONSTRAINT fk_hm_dlrecipients_list FOREIGN KEY (distributionlistrecipientlistid) REFERENCES hm_distributionlists (distributionlistid) ON DELETE CASCADE
 
-ALTER TABLE hm_routeaddresses WITH CHECK ADD CONSTRAINT fk_hm_routeaddresses_route FOREIGN KEY (routeaddressrouteid) REFERENCES hm_routes (routeid) ON DELETE CASCADE
+ALTER TABLE hm_routeaddresses ADD CONSTRAINT fk_hm_routeaddresses_route FOREIGN KEY (routeaddressrouteid) REFERENCES hm_routes (routeid) ON DELETE CASCADE
 
-ALTER TABLE hm_fetchaccounts WITH CHECK ADD CONSTRAINT fk_hm_fetchaccounts_account FOREIGN KEY (faaccountid) REFERENCES hm_accounts (accountid) ON DELETE CASCADE
+ALTER TABLE hm_fetchaccounts ADD CONSTRAINT fk_hm_fetchaccounts_account FOREIGN KEY (faaccountid) REFERENCES hm_accounts (accountid) ON DELETE CASCADE
 
-ALTER TABLE hm_fetchaccounts_uids WITH CHECK ADD CONSTRAINT fk_hm_fetchaccounts_uids_fa FOREIGN KEY (uidfaid) REFERENCES hm_fetchaccounts (faid) ON DELETE CASCADE
+ALTER TABLE hm_fetchaccounts_uids ADD CONSTRAINT fk_hm_fetchaccounts_uids_fa FOREIGN KEY (uidfaid) REFERENCES hm_fetchaccounts (faid) ON DELETE CASCADE
 
-ALTER TABLE hm_apppasswords WITH CHECK ADD CONSTRAINT fk_hm_apppasswords_account FOREIGN KEY (apaccountid) REFERENCES hm_accounts (accountid) ON DELETE CASCADE
+ALTER TABLE hm_apppasswords ADD CONSTRAINT fk_hm_apppasswords_account FOREIGN KEY (apaccountid) REFERENCES hm_accounts (accountid) ON DELETE CASCADE
 
-ALTER TABLE hm_rule_criterias WITH CHECK ADD CONSTRAINT fk_hm_rule_criterias_rule FOREIGN KEY (criteriaruleid) REFERENCES hm_rules (ruleid) ON DELETE CASCADE
+ALTER TABLE hm_rule_criterias ADD CONSTRAINT fk_hm_rule_criterias_rule FOREIGN KEY (criteriaruleid) REFERENCES hm_rules (ruleid) ON DELETE CASCADE
 
-ALTER TABLE hm_rule_actions WITH CHECK ADD CONSTRAINT fk_hm_rule_actions_rule FOREIGN KEY (actionruleid) REFERENCES hm_rules (ruleid) ON DELETE CASCADE
+ALTER TABLE hm_rule_actions ADD CONSTRAINT fk_hm_rule_actions_rule FOREIGN KEY (actionruleid) REFERENCES hm_rules (ruleid) ON DELETE CASCADE
 
-ALTER TABLE hm_group_members WITH CHECK ADD CONSTRAINT fk_hm_group_members_group FOREIGN KEY (membergroupid) REFERENCES hm_groups (groupid) ON DELETE CASCADE
+ALTER TABLE hm_group_members ADD CONSTRAINT fk_hm_group_members_group FOREIGN KEY (membergroupid) REFERENCES hm_groups (groupid) ON DELETE CASCADE
 
-ALTER TABLE hm_passwordhistory WITH CHECK ADD CONSTRAINT fk_hm_passwordhistory_account FOREIGN KEY (phaccountid) REFERENCES hm_accounts (accountid) ON DELETE CASCADE
+ALTER TABLE hm_passwordhistory ADD CONSTRAINT fk_hm_passwordhistory_account FOREIGN KEY (phaccountid) REFERENCES hm_accounts (accountid) ON DELETE CASCADE
 
-ALTER TABLE hm_messagerecipients WITH CHECK ADD CONSTRAINT fk_hm_messagerecipients_message FOREIGN KEY (recipientmessageid) REFERENCES hm_messages (messageid) ON DELETE CASCADE
+ALTER TABLE hm_messagerecipients ADD CONSTRAINT fk_hm_messagerecipients_message FOREIGN KEY (recipientmessageid) REFERENCES hm_messages (messageid) ON DELETE CASCADE
 
-ALTER TABLE hm_message_metadata WITH CHECK ADD CONSTRAINT fk_hm_message_metadata_message FOREIGN KEY (metadata_messageid) REFERENCES hm_messages (messageid) ON DELETE CASCADE
+ALTER TABLE hm_message_metadata ADD CONSTRAINT fk_hm_message_metadata_message FOREIGN KEY (metadata_messageid) REFERENCES hm_messages (messageid) ON DELETE CASCADE
 
-ALTER TABLE hm_imapexpunged WITH CHECK ADD CONSTRAINT fk_hm_imapexpunged_folder FOREIGN KEY (expungedfolderid) REFERENCES hm_imapfolders (folderid) ON DELETE CASCADE
+ALTER TABLE hm_imapexpunged ADD CONSTRAINT fk_hm_imapexpunged_folder FOREIGN KEY (expungedfolderid) REFERENCES hm_imapfolders (folderid) ON DELETE CASCADE
 
-ALTER TABLE hm_messageindexterms WITH CHECK ADD CONSTRAINT fk_hm_messageindexterms_message FOREIGN KEY (mitmessageid) REFERENCES hm_messages (messageid) ON DELETE CASCADE
+ALTER TABLE hm_messageindexterms ADD CONSTRAINT fk_hm_messageindexterms_message FOREIGN KEY (mitmessageid) REFERENCES hm_messages (messageid) ON DELETE CASCADE
 
 insert into hm_dbversion values (6030)

--- a/hmailserver/source/DBScripts/CreateTablesMYSQL.sql
+++ b/hmailserver/source/DBScripts/CreateTablesMYSQL.sql
@@ -972,7 +972,9 @@ create table hm_archiveindex
 	archivesize bigint not null,
 	archivehold int not null
 ) DEFAULT CHARSET=utf8;
+
 CREATE INDEX idx_hm_archiveindex_domain_time ON hm_archiveindex (archivedomain, archivetime);
+
 CREATE INDEX idx_hm_archiveindex_path ON hm_archiveindex (archivepath(255));
 
 -- Referential integrity (schema 6030): InnoDB enforces these.

--- a/hmailserver/source/DBScripts/CreateTablesPGSQL.sql
+++ b/hmailserver/source/DBScripts/CreateTablesPGSQL.sql
@@ -988,7 +988,9 @@ create table hm_archiveindex
 	archivesize bigint not null,
 	archivehold int not null
 );
+
 CREATE INDEX idx_hm_archiveindex_domain_time ON hm_archiveindex (archivedomain, archivetime);
+
 CREATE INDEX idx_hm_archiveindex_path ON hm_archiveindex (archivepath);
 
 ALTER TABLE hm_accounts ADD CONSTRAINT fk_hm_accounts_domain FOREIGN KEY (accountdomainid) REFERENCES hm_domains (domainid) ON DELETE CASCADE;

--- a/hmailserver/source/DBScripts/Upgrade6028to6029MSSQL.sql
+++ b/hmailserver/source/DBScripts/Upgrade6028to6029MSSQL.sql
@@ -13,8 +13,11 @@ create table hm_archiveindex
 	archivesize bigint not null,
 	archivehold int not null
 )
+
 ALTER TABLE hm_archiveindex ADD CONSTRAINT hm_archiveindex_pk PRIMARY KEY NONCLUSTERED (archiveid)
+
 CREATE CLUSTERED INDEX idx_hm_archiveindex_domain_time ON hm_archiveindex (archivedomain, archivetime)
+
 CREATE INDEX idx_hm_archiveindex_path ON hm_archiveindex (archivepath)
 
 update hm_dbversion set value = 6029

--- a/hmailserver/source/DBScripts/Upgrade6028to6029MSSQLCE.sql
+++ b/hmailserver/source/DBScripts/Upgrade6028to6029MSSQLCE.sql
@@ -13,8 +13,11 @@ create table hm_archiveindex
 	archivesize bigint not null,
 	archivehold int not null
 )
+
 ALTER TABLE hm_archiveindex ADD CONSTRAINT hm_archiveindex_pk PRIMARY KEY (archiveid)
+
 CREATE INDEX idx_hm_archiveindex_domain_time ON hm_archiveindex (archivedomain, archivetime)
+
 CREATE INDEX idx_hm_archiveindex_path ON hm_archiveindex (archivepath)
 
 update hm_dbversion set value = 6029

--- a/hmailserver/source/DBScripts/Upgrade6028to6029MySQL.sql
+++ b/hmailserver/source/DBScripts/Upgrade6028to6029MySQL.sql
@@ -13,7 +13,9 @@ create table hm_archiveindex
 	archivesize bigint not null,
 	archivehold int not null
 ) DEFAULT CHARSET=utf8;
+
 CREATE INDEX idx_hm_archiveindex_domain_time ON hm_archiveindex (archivedomain, archivetime);
+
 CREATE INDEX idx_hm_archiveindex_path ON hm_archiveindex (archivepath(255));
 
 update hm_dbversion set value = 6029;

--- a/hmailserver/source/DBScripts/Upgrade6028to6029PGSQL.sql
+++ b/hmailserver/source/DBScripts/Upgrade6028to6029PGSQL.sql
@@ -13,7 +13,9 @@ create table hm_archiveindex
 	archivesize bigint not null,
 	archivehold int not null
 );
+
 CREATE INDEX idx_hm_archiveindex_domain_time ON hm_archiveindex (archivedomain, archivetime);
+
 CREATE INDEX idx_hm_archiveindex_path ON hm_archiveindex (archivepath);
 
 update hm_dbversion set value = 6029;


### PR DESCRIPTION
Found by RELEASE.md step 6 (`build\check-db-scripts.ps1`), which the two schema waves of 5 September did not run. Schema 6029 wrote the archive index's CREATE TABLE, primary key and two indexes with no blank line between them; the server splits scripts into commands on blank lines, so SQL Server Compact got all four as one command and refused it - a fresh install created no `hm_archiveindex` and an upgrade from 6028 stopped there. MySQL splits the same way. The four statements are four commands in every dialect's create and upgrade script now. Schema 6030's seventeen FOREIGN KEYs were written into `CreateTablesMSSQL.sql` as `ALTER TABLE ... WITH CHECK ADD CONSTRAINT`, which Compact Edition (installed from the same script) does not have; WITH CHECK is SQL Server's default anyway and the words are gone. check-db-scripts: `CreateTablesMSSQL.sql` builds a database (299 statements, schema 6030), 54 Compact Edition upgrade scripts parse into single statements; check-schema-versions: 81 steps, 0 -> 6030, every probe present.
