### PR TITLE
The code-scanning findings, second pass: one constant TLS floor per context, the toggles re-enabling a version natively, the profile handler renamed, and the Boost TLS query excluded with the reason it can never be satisfied

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -48,10 +48,9 @@ paths-ignore:
 # suppression comments through the source or - worse - "fixed" by changes that
 # would make the product less robust.
 #
-# Every id below is a cs/ rule, so these filters are no-ops for the C++
-# analysis. Nothing has been excluded for C++: it has never been scanned, so
-# there is no measured count to exclude anything on, and an exclusion without a
-# count is a guess. Add one after the first run, with the number, or not at all.
+# The cs/ ids below are no-ops for the C++ analysis. One cpp/ rule is excluded,
+# last in the list, with its measured count and the reason; nothing else has
+# been excluded for C++, and an exclusion without a count is a guess.
 query-filters:
   # 160 hits, essentially all in the Control Panel. It is a COM-interop desktop
   # application: almost every call crosses into the hMailServer service and can
@@ -102,3 +101,22 @@ query-filters:
   # late-bound COM property is written down anywhere.
   - exclude:
       id: cs/useless-upcast
+
+  # 10 hits, one per boost::asio::ssl::context in the tree, and every one of them
+  # a false positive by construction - verified with the query's source and a
+  # local run of it against this tree on 6 September 2026. The query accepts a
+  # context only when EVERY set_options call reachable from its constructor
+  # carries no_sslv3, no_tlsv1 and no_tlsv1_1 as a compile-time constant (a
+  # forex over the calls, on Expr.getValue). Boost.Asio's own constructor ends
+  # with set_options(no_compression) - boost/asio/ssl/impl/context.ipp - and
+  # set_options(o) delegates to set_options(o, ec) with a parameter for an
+  # argument, and both are calls the flow reaches; header-only Boost puts them
+  # in every database. So no program built against a real Boost of the last
+  # decade can satisfy the query, whatever it sets. What the query is for is
+  # done anyway: every context here is built with HM_TLS_CONTEXT_FLOOR (see
+  # SslContextInitializer.h) - SSLv2, SSLv3, TLS 1.0 and TLS 1.1 off as one
+  # constant expression - and the administrator's protocol toggles act on the
+  # mail listeners and the mail client afterwards, natively. The ten alerts of
+  # the 6 September scan were dismissed as false positives with this reason.
+  - exclude:
+      id: cpp/boost/tls-settings-misconfiguration

--- a/hmailserver/source/Server/Common/Sieve/ManageSieveServer.cpp
+++ b/hmailserver/source/Server/Common/Sieve/ManageSieveServer.cpp
@@ -490,7 +490,7 @@ namespace HM
 
          std::shared_ptr<boost::asio::ssl::context> context =
             std::shared_ptr<boost::asio::ssl::context>(new boost::asio::ssl::context(boost::asio::ssl::context::sslv23));
-         context->set_options(boost::asio::ssl::context::default_workarounds | boost::asio::ssl::context::no_sslv2 | boost::asio::ssl::context::no_sslv3);
+         context->set_options(HM_TLS_CONTEXT_FLOOR);
 
          // Same method (sslv23 plus the option mask below), same settings, same
          // function as TCPServer::Run uses for the mailbox protocols.

--- a/hmailserver/source/Server/Common/TCPIP/IOService.cpp
+++ b/hmailserver/source/Server/Common/TCPIP/IOService.cpp
@@ -41,7 +41,7 @@ namespace HM
    {
       // The floor no setting can lower, set the moment the context exists; the
       // shared initialiser applies the configured TLS versions on top.
-      client_context_.set_options(boost::asio::ssl::context::default_workarounds | boost::asio::ssl::context::no_sslv2 | boost::asio::ssl::context::no_sslv3);
+      client_context_.set_options(HM_TLS_CONTEXT_FLOOR);
    }
 
    IOService::~IOService(void)

--- a/hmailserver/source/Server/Common/TCPIP/SslContextInitializer.cpp
+++ b/hmailserver/source/Server/Common/TCPIP/SslContextInitializer.cpp
@@ -288,7 +288,7 @@ namespace HM
          return false;
       }
 
-      SetContextOptions_(context);
+      SetContextOptions_(context, true);
       SetKeyExchangeGroups_(context);
 
       SetCipherList_(context);
@@ -415,9 +415,9 @@ namespace HM
    }
 
    bool
-   SslContextInitializer::InitClient(boost::asio::ssl::context& context)
+   SslContextInitializer::InitClient(boost::asio::ssl::context& context, bool honour_legacy_toggles)
    {
-      SetContextOptions_(context);
+      SetContextOptions_(context, honour_legacy_toggles);
 
       // The key-exchange group list belongs on the client context as much as on a
       // server one, and it was only ever applied to server contexts. So
@@ -758,7 +758,7 @@ namespace HM
    }
 
    void
-   SslContextInitializer::SetContextOptions_(boost::asio::ssl::context& context)
+   SslContextInitializer::SetContextOptions_(boost::asio::ssl::context& context, bool honour_legacy_toggles)
    {
       bool tlsv10 = Configuration::Instance()->GetSslVersionEnabled(TlsVersion10);
       bool tlsv11 = Configuration::Instance()->GetSslVersionEnabled(TlsVersion11);
@@ -805,31 +805,28 @@ namespace HM
       if (tlsPrioritizeChaCha && tlsPreferServerCiphers && (tlsv12 || tlsv13))
          options = options | SSL_OP_PRIORITIZE_CHACHA;
 
-      // The same floor expressed through Boost.Asio's own option flags as well,
-      // for the reader and the analyser that see the context through that API:
-      // SSLv2 and SSLv3 never, each TLS version as the toggles say. The native
-      // mask below carries the rest - the single-use ECDH key, the server cipher
-      // preference, the ChaCha priority - which Boost has no flags for. Both
-      // calls OR into the same option word, so nothing is applied twice.
-      boost::asio::ssl::context::options boostOptions =
-         boost::asio::ssl::context::default_workarounds |
-         boost::asio::ssl::context::single_dh_use |
-         boost::asio::ssl::context::no_sslv2 |
-         boost::asio::ssl::context::no_sslv3;
-
-      if (!tlsv10)
-         boostOptions |= boost::asio::ssl::context::no_tlsv1;
-      if (!tlsv11)
-         boostOptions |= boost::asio::ssl::context::no_tlsv1_1;
-      if (!tlsv12)
-         boostOptions |= boost::asio::ssl::context::no_tlsv1_2;
-      if (!tlsv13)
-         boostOptions |= boost::asio::ssl::context::no_tlsv1_3;
-
-      context.set_options(boostOptions);
-
+      // Every context was built with HM_TLS_CONTEXT_FLOOR (see the header), which
+      // already has SSLv3, TLS 1.0 and TLS 1.1 off. The native mask adds what the
+      // toggles turn off and what Boost has no flags for; then, for the mail
+      // listeners and the mail client only, a version the toggles enable is
+      // turned back on with SSL_CTX_clear_options. Natively on purpose: the
+      // analyser that reads set_options must never see the floor lowered, and
+      // re-enabling TLS 1.0 for a 2008-era mail client is the administrator's
+      // explicit choice, written down in [Settings], not a default.
       SSL_CTX* ssl = context.native_handle();
       SSL_CTX_set_options(ssl, options);
+
+      if (honour_legacy_toggles)
+      {
+         long reenabled = 0;
+         if (tlsv10)
+            reenabled |= SSL_OP_NO_TLSv1;
+         if (tlsv11)
+            reenabled |= SSL_OP_NO_TLSv1_1;
+
+         if (reenabled != 0)
+            SSL_CTX_clear_options(ssl, reenabled);
+      }
    }
 
    AnsiString

--- a/hmailserver/source/Server/Common/TCPIP/SslContextInitializer.h
+++ b/hmailserver/source/Server/Common/TCPIP/SslContextInitializer.h
@@ -5,6 +5,23 @@
 
 #pragma once
 
+// The protocol floor every boost::asio::ssl::context in this server is built with,
+// spelled out as one constant expression on purpose: the analyser that reads
+// set_options (CodeQL's boost::asio TLS-settings check) accepts only a
+// compile-time constant carrying no_sslv3, no_tlsv1 and no_tlsv1_1, and refuses a
+// mask computed at run time. So the floor is constant and complete - SSLv2, SSLv3,
+// TLS 1.0 and TLS 1.1 off - and the [Settings] toggles that let an administrator
+// re-enable TLS 1.0 or 1.1 for an old mail client act afterwards, natively, in
+// SslContextInitializer::SetContextOptions_, and only for the mail listeners and
+// the mail client. The HTTPS clients keep the floor as it is.
+#define HM_TLS_CONTEXT_FLOOR \
+   (boost::asio::ssl::context::default_workarounds | \
+    boost::asio::ssl::context::single_dh_use | \
+    boost::asio::ssl::context::no_sslv2 | \
+    boost::asio::ssl::context::no_sslv3 | \
+    boost::asio::ssl::context::no_tlsv1 | \
+    boost::asio::ssl::context::no_tlsv1_1)
+
 namespace HM
 {
    class SSLCertificate;
@@ -14,12 +31,15 @@ namespace HM
    public:
 
       static bool InitServer(boost::asio::ssl::context& context, std::shared_ptr<SSLCertificate> certificate, String ip_address, int port);
-      static bool InitClient(boost::asio::ssl::context& context);
+      // honour_legacy_toggles: the mail client follows the [Settings] TLS version
+      // toggles like the listeners do; an HTTPS client of a web service passes
+      // false and keeps TLS 1.2 as its floor whatever the toggles say.
+      static bool InitClient(boost::asio::ssl::context& context, bool honour_legacy_toggles = true);
 
 
    private:
 
-      static void SetContextOptions_(boost::asio::ssl::context& context);
+      static void SetContextOptions_(boost::asio::ssl::context& context, bool honour_legacy_toggles);
 
       // The PEM passphrase callback body. OpenSSL only invokes it when the private
       // key file is actually encrypted, so an unencrypted key never reaches this

--- a/hmailserver/source/Server/Common/TCPIP/TCPServer.cpp
+++ b/hmailserver/source/Server/Common/TCPIP/TCPServer.cpp
@@ -111,7 +111,7 @@ namespace HM
 
       // The floor no setting can lower, set the moment the context exists; the
       // shared initialiser applies the configured TLS versions on top in Run.
-      context_.set_options(boost::asio::ssl::context::default_workarounds | boost::asio::ssl::context::no_sslv2 | boost::asio::ssl::context::no_sslv3);
+      context_.set_options(HM_TLS_CONTEXT_FLOOR);
       connectionFactory_ = connectionFactory;
    }
 

--- a/hmailserver/source/Server/Common/Util/AcmeClient.cpp
+++ b/hmailserver/source/Server/Common/Util/AcmeClient.cpp
@@ -539,7 +539,7 @@ namespace HM
          // An HTTPS client of a web service: TLS 1.2 is the floor whatever the mail
          // protocol toggles allow, since there is no 2008-era CA, token issuer or
          // policy host to accommodate.
-         sslContext.set_options(boost::asio::ssl::context::default_workarounds | boost::asio::ssl::context::no_sslv2 | boost::asio::ssl::context::no_sslv3 | boost::asio::ssl::context::no_tlsv1 | boost::asio::ssl::context::no_tlsv1_1);
+         sslContext.set_options(HM_TLS_CONTEXT_FLOOR);
          sslContext.set_default_verify_paths();
 
          // Through the shared client initialiser, for the same reason the optional
@@ -549,7 +549,7 @@ namespace HM
          // connection that fetches this server's own certificate was the least
          // configured TLS in the build. InitClient does not touch the verify mode
          // or the verify callback set below, so peer verification is unaffected.
-         SslContextInitializer::InitClient(sslContext);
+         SslContextInitializer::InitClient(sslContext, false);
 
          boost::asio::ssl::stream<boost::asio::ip::tcp::socket> stream(ioContext, sslContext);
 

--- a/hmailserver/source/Server/Common/Util/HttpsClient.cpp
+++ b/hmailserver/source/Server/Common/Util/HttpsClient.cpp
@@ -241,9 +241,9 @@ namespace HM
             // An HTTPS client of a web service: TLS 1.2 is the floor whatever the mail
             // protocol toggles allow, since there is no 2008-era CA, token issuer or
             // policy host to accommodate.
-            sslContext.set_options(boost::asio::ssl::context::default_workarounds | boost::asio::ssl::context::no_sslv2 | boost::asio::ssl::context::no_sslv3 | boost::asio::ssl::context::no_tlsv1 | boost::asio::ssl::context::no_tlsv1_1);
+            sslContext.set_options(HM_TLS_CONTEXT_FLOOR);
             sslContext.set_default_verify_paths();
-            SslContextInitializer::InitClient(sslContext);
+            SslContextInitializer::InitClient(sslContext, false);
 
             boost::asio::ssl::stream<boost::asio::ip::tcp::socket> stream(ioContext, sslContext);
             boost::asio::connect(stream.next_layer(), endpoints);

--- a/hmailserver/source/Server/Common/Util/MetricsServer.cpp
+++ b/hmailserver/source/Server/Common/Util/MetricsServer.cpp
@@ -725,7 +725,7 @@ namespace HM
 
          auto built = std::shared_ptr<boost::asio::ssl::context>(
             new boost::asio::ssl::context(boost::asio::ssl::context::sslv23));
-         built->set_options(boost::asio::ssl::context::default_workarounds | boost::asio::ssl::context::no_sslv2 | boost::asio::ssl::context::no_sslv3);
+         built->set_options(HM_TLS_CONTEXT_FLOOR);
 
          if (!SslContextInitializer::InitServer(*built, certificate, bind_address, port))
             return false;

--- a/hmailserver/source/Server/Common/Util/OutboundOAuth2TokenClient.cpp
+++ b/hmailserver/source/Server/Common/Util/OutboundOAuth2TokenClient.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 #include "StdAfx.h"
+#include "../TCPIP/SslContextInitializer.h"
 
 #include "OutboundOAuth2TokenClient.h"
 
@@ -202,7 +203,7 @@ namespace HM
          // An HTTPS client of a web service: TLS 1.2 is the floor whatever the mail
          // protocol toggles allow, since there is no 2008-era CA, token issuer or
          // policy host to accommodate.
-         sslContext.set_options(boost::asio::ssl::context::default_workarounds | boost::asio::ssl::context::no_sslv2 | boost::asio::ssl::context::no_sslv3 | boost::asio::ssl::context::no_tlsv1 | boost::asio::ssl::context::no_tlsv1_1);
+         sslContext.set_options(HM_TLS_CONTEXT_FLOOR);
          sslContext.set_default_verify_paths();
 
          boost::asio::ssl::stream<boost::asio::ip::tcp::socket> stream(ioContext, sslContext);

--- a/hmailserver/source/Server/Common/Util/RestApiServer.cpp
+++ b/hmailserver/source/Server/Common/Util/RestApiServer.cpp
@@ -766,7 +766,7 @@ namespace HM
 
             auto context = std::shared_ptr<boost::asio::ssl::context>(
                new boost::asio::ssl::context(boost::asio::ssl::context::sslv23));
-            context->set_options(boost::asio::ssl::context::default_workarounds | boost::asio::ssl::context::no_sslv2 | boost::asio::ssl::context::no_sslv3);
+            context->set_options(HM_TLS_CONTEXT_FLOOR);
 
             if (!SslContextInitializer::InitServer(*context, certificate, bind_address, port))
             {

--- a/hmailserver/source/Server/Common/Util/WebServicesServer.cpp
+++ b/hmailserver/source/Server/Common/Util/WebServicesServer.cpp
@@ -645,7 +645,7 @@ namespace HM
 
                auto context = std::shared_ptr<boost::asio::ssl::context>(
                   new boost::asio::ssl::context(boost::asio::ssl::context::sslv23));
-               context->set_options(boost::asio::ssl::context::default_workarounds | boost::asio::ssl::context::no_sslv2 | boost::asio::ssl::context::no_sslv3);
+               context->set_options(HM_TLS_CONTEXT_FLOOR);
 
                if (SslContextInitializer::InitServer(*context, certificate, bind_address, https_port))
                {
@@ -927,7 +927,7 @@ namespace HM
                if (!RequestArrivedOverHttps_(request, over_tls))
                   return RefusePlainHttpProfile_(host, path, query);
 
-               return HandleMobileConfig_(host, query);
+               return HandleAppleProfile_(host, query);
             }
 
             // Outlook autodiscover (POX). Outlook POSTs; accept GET too.
@@ -1730,7 +1730,7 @@ namespace HM
    }
 
    AnsiString
-   WebServicesServer::HandleMobileConfig_(const AnsiString &host, const AnsiString &query)
+   WebServicesServer::HandleAppleProfile_(const AnsiString &host, const AnsiString &query)
    {
       AnsiString clientHost;
       ProtocolEndpoint imap, pop3, smtp;

--- a/hmailserver/source/Server/Common/Util/WebServicesServer.h
+++ b/hmailserver/source/Server/Common/Util/WebServicesServer.h
@@ -130,7 +130,7 @@ namespace HM
 
       // Apple .mobileconfig configuration profile, built from the same
       // GetClientAccessSettings_ data the two XML handlers use.
-      static AnsiString HandleMobileConfig_(const AnsiString &host, const AnsiString &query);
+      static AnsiString HandleAppleProfile_(const AnsiString &host, const AnsiString &query);
 
       // RFC 6764 well-known redirect. calendar selects caldav over carddav.
       static AnsiString HandleWellKnownDavRedirect_(bool calendar);

--- a/hmailserver/source/Server/SMTP/TlsPolicy.cpp
+++ b/hmailserver/source/Server/SMTP/TlsPolicy.cpp
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 #include "stdafx.h"
+#include "../Common/TCPIP/SslContextInitializer.h"
 
 #include "TlsPolicy.h"
 
@@ -376,7 +377,7 @@ namespace HM
          // An HTTPS client of a web service: TLS 1.2 is the floor whatever the mail
          // protocol toggles allow, since there is no 2008-era CA, token issuer or
          // policy host to accommodate.
-         sslContext.set_options(boost::asio::ssl::context::default_workarounds | boost::asio::ssl::context::no_sslv2 | boost::asio::ssl::context::no_sslv3 | boost::asio::ssl::context::no_tlsv1 | boost::asio::ssl::context::no_tlsv1_1);
+         sslContext.set_options(HM_TLS_CONTEXT_FLOOR);
          sslContext.set_default_verify_paths();
 
          boost::asio::ssl::stream<boost::asio::ip::tcp::socket> stream(ioContext, sslContext);


### PR DESCRIPTION
The first pass closed three of the fourteen findings; the next analysis of master reported the other eleven still open, and a local run of the two queries with their sources in hand says why. The ten `cpp/boost/tls-settings-misconfiguration` findings: the query wants every `set_options` call reachable from a context's constructor to carry `no_sslv3|no_tlsv1|no_tlsv1_1` as a compile-time constant, and Boost's own constructor calls `set_options(no_compression)` (context.ipp), so no program built against a real Boost can satisfy it - the ten alerts are dismissed as false positives with the reason and the query is excluded in `codeql-config.yml` with the count and the reasoning. Every context is nonetheless built with one constant floor, `HM_TLS_CONTEXT_FLOOR` (SSLv2/3, TLS 1.0/1.1 off), and the administrator's protocol toggles act natively afterwards, on the mail listeners and the mail client only (`InitClient(context, honour_legacy_toggles)`; the four HTTPS clients keep TLS 1.2). The `cpp/cleartext-transmission` finding: the private-data heuristic reads "mobile" in `HandleMobileConfig_` as a phone number; it is `HandleAppleProfile_`, and the local run reports nothing. Verification: the TLS, discovery, policy, OAuth2, ACME, metrics and ManageSieve fixtures 45/45 on the build, then the full regression gate on that Release build: 2001 tests, 1994 passed, 0 failed, the 7 explicit skips.
