### PR TITLE
Every SQL Server Compact upgrade through schema 6030 was reported as failed after it had succeeded: the foreign-key probes crashed the provider (#114)

### DIFF
--- a/build/check-db-scripts.ps1
+++ b/build/check-db-scripts.ps1
@@ -108,6 +108,59 @@ if ($result.Failures -eq 0) {
     $version = $rs.Fields.Item(0).Value
     $rs.Close()
     Write-Host ("  OK    CreateTablesMSSQL.sql builds a database ({0} statements, schema {1})" -f $result.Run, $version)
+
+    # ---- every schema probe, against this correct database, through the same
+    # provider the server uses
+    #
+    # DBUpdater proves each upgrade step with a probe from SchemaVerification.cs, and
+    # a probe has one job: fail only when the object is missing. Run here against a
+    # database that has everything, every probe must succeed - one that fails is a
+    # statement the backend cannot execute, and in the field it reads as a failed
+    # upgrade of a database that is fine. That is what 6.2.25 shipped for SQL Server
+    # Compact (issue #114): the 6030 probes used "case when exists (subquery)", which
+    # takes the Compact Edition OLE DB provider down with an access violation, so every
+    # Compact Edition upgrade through 6030 was reported as having failed after it had
+    # succeeded. A provider crash ends this process too, which fails the check just
+    # as a caught error does.
+    #
+    # The negative control below is the other half: the 6030 probe shape, pointed at
+    # a constraint that does not exist, must FAIL, or the probes prove nothing.
+    $probesSource = Join-Path $repoRoot 'hmailserver\source\Tools\DBUpdater\SchemaVerification.cs'
+    $probesText = Get-Content -LiteralPath $probesSource -Raw
+    $probes = [regex]::Matches($probesText, 'new\s+SchemaProbe\(\s*(\d+)\s*,\s*"([^"]+)"\s*,\s*"([^"]+)"\s*\)')
+    $probeFailures = 0
+    foreach ($probe in $probes) {
+        $statement = $probe.Groups[3].Value
+        try {
+            $conn.Execute($statement) | Out-Null
+        }
+        catch {
+            $probeFailures++
+            $message = $_.Exception.Message
+            try { $message = $conn.Errors.Item(0).Description } catch { }
+            Write-Host ("  FAIL  probe for {0} (schema {1}) fails on a correct database: {2}" -f $probe.Groups[2].Value, $probe.Groups[1].Value, $message) -ForegroundColor Red
+            Write-Host ("        {0}" -f $statement) -ForegroundColor Red
+        }
+    }
+    if ($probeFailures -eq 0) {
+        Write-Host ("  OK    all {0} schema probes succeed on the fresh database" -f $probes.Count)
+    }
+    $failures += $probeFailures
+
+    $control = ($probes | Where-Object { $_.Groups[1].Value -eq '6030' } | Select-Object -First 1).Groups[3].Value
+    if ($control) {
+        $control = $control -replace "constraint_name = '[^']+'", "constraint_name = 'fk_no_such_constraint'"
+        $controlFailed = $false
+        try { $conn.Execute($control) | Out-Null } catch { $controlFailed = $true }
+        if ($controlFailed) {
+            Write-Host '  OK    the constraint probe fails for a constraint that does not exist (negative control)'
+        }
+        else {
+            $failures++
+            Write-Host '  FAIL  the constraint probe SUCCEEDS for a constraint that does not exist - it proves nothing' -ForegroundColor Red
+            Write-Host ("        {0}" -f $control) -ForegroundColor Red
+        }
+    }
 }
 
 $conn.Close()

--- a/hmailserver/source/Tools/DBUpdater/SchemaVerification.cs
+++ b/hmailserver/source/Tools/DBUpdater/SchemaVerification.cs
@@ -327,17 +327,48 @@ namespace DBUpdater
          // Upgrade6029to6030* - the foreign keys. A constraint cannot be proved by a
          // statement that writes nothing, since only a violation makes a database
          // complain, so these ask the catalogue through the one view all four
-         // dialects share and divide by zero when the constraint is absent. The
-         // update writes hm_dbversion's value back to itself when it is present.
+         // dialects share, and fail by dividing by zero when the constraint is
+         // absent: the update touches hm_dbversion's one row only WHERE NOT EXISTS
+         // the constraint, and "value / (value - value)" on that row is a division
+         // by zero on every backend (SQL Server 8134, PostgreSQL 22012, MySQL 1365
+         // in its default strict mode, SQL Server Compact "expression evaluation
+         // caused an overflow"). When the constraint is present no row matches,
+         // nothing is evaluated and nothing is written.
+         //
+         // The shape matters, and this is the second one. The first was
+         // "set value = value / (case when exists (select 1 from ...) then 1 else 0 end)",
+         // which is fine on three backends and takes the SQL Server Compact OLE DB
+         // provider down with an access violation on the fourth - on a correct
+         // database, with every constraint present. The server catches that in
+         // SQLCEConnection::Execute's catch-all and reports it as HM10045 "Unknown
+         // error", DBUpdater reads the failed probe as a missing constraint, and
+         // every Compact Edition upgrade through 6030 failed after having, in fact,
+         // succeeded (issue #114, 6.2.25). Compact Edition also rejects a scalar
+         // subquery in a SET expression outright, so the count of matching rows
+         // cannot be the divisor either; a subquery in the WHERE clause is the one
+         // place it accepts one. Every probe is run against the bench database by
+         // Infrastructure/SchemaProbes.cs and against a fresh database by
+         // build\check-db-scripts.ps1, so a shape the provider cannot execute is
+         // caught before a release rather than by the first upgrade in the field.
          new SchemaProbe(6030, "hm_accounts.fk_hm_accounts_domain",
-                         "update hm_dbversion set value = value / (case when exists (select 1 from information_schema.table_constraints where constraint_name = 'fk_hm_accounts_domain' and constraint_type = 'FOREIGN KEY') then 1 else 0 end)"),
+                         "update hm_dbversion set value = value / (value - value) where not exists (select 1 from information_schema.table_constraints where constraint_name = 'fk_hm_accounts_domain' and constraint_type = 'FOREIGN KEY')"),
          new SchemaProbe(6030, "hm_distributionlistsrecipients.fk_hm_dlrecipients_list",
-                         "update hm_dbversion set value = value / (case when exists (select 1 from information_schema.table_constraints where constraint_name = 'fk_hm_dlrecipients_list' and constraint_type = 'FOREIGN KEY') then 1 else 0 end)"),
+                         "update hm_dbversion set value = value / (value - value) where not exists (select 1 from information_schema.table_constraints where constraint_name = 'fk_hm_dlrecipients_list' and constraint_type = 'FOREIGN KEY')"),
          new SchemaProbe(6030, "hm_messagerecipients.fk_hm_messagerecipients_message",
-                         "update hm_dbversion set value = value / (case when exists (select 1 from information_schema.table_constraints where constraint_name = 'fk_hm_messagerecipients_message' and constraint_type = 'FOREIGN KEY') then 1 else 0 end)"),
+                         "update hm_dbversion set value = value / (value - value) where not exists (select 1 from information_schema.table_constraints where constraint_name = 'fk_hm_messagerecipients_message' and constraint_type = 'FOREIGN KEY')"),
          new SchemaProbe(6030, "hm_messageindexterms.fk_hm_messageindexterms_message",
-                         "update hm_dbversion set value = value / (case when exists (select 1 from information_schema.table_constraints where constraint_name = 'fk_hm_messageindexterms_message' and constraint_type = 'FOREIGN KEY') then 1 else 0 end)")
+                         "update hm_dbversion set value = value / (value - value) where not exists (select 1 from information_schema.table_constraints where constraint_name = 'fk_hm_messageindexterms_message' and constraint_type = 'FOREIGN KEY')")
       };
+
+      /// <summary>
+      /// Every probe, for the checks that run them all against a database known to
+      /// be correct: a probe that fails there is a probe the backend cannot
+      /// execute, not a missing object.
+      /// </summary>
+      public static IList<SchemaProbe> All
+      {
+         get { return Probes.ToList(); }
+      }
 
       /// <summary>
       /// The probes that must succeed once the database has reached

--- a/hmailserver/source/Tools/DBUpdater/formMain.cs
+++ b/hmailserver/source/Tools/DBUpdater/formMain.cs
@@ -592,12 +592,17 @@ namespace DBUpdater
                }
                catch (Exception e) when (!ExceptionPolicy.IsFatal(e))
                {
-                  // The step's script reported success, so the only way to be
-                  // here is an error that [IGNORE-ERRORS] discarded. Say that
-                  // outright: the operator's next question is always "but it said
-                  // it worked".
+                  // The step's script reported success, so either an error that
+                  // [IGNORE-ERRORS] discarded hid a failed statement, or the probe
+                  // itself is something this backend cannot run - which is what
+                  // happened on SQL Server Compact in 6.2.25 (issue #114), when the
+                  // message below asserted the first cause and was wrong. Say what is
+                  // known - the check failed, with the backend's own words - and name
+                  // both possibilities: the operator's next question is always "but it
+                  // said it worked", and the answer must not send them chasing a
+                  // constraint that is there.
                   error = string.Format(
-                     "{0} did not create {1}. The script reported success because its ALTER statement is marked [IGNORE-ERRORS], which discards every error, not only \"already exists\" - so the real failure was thrown away. The upgrade has been rolled back where the backend allows it. Probe: {2}{3}Error: {4}",
+                     "{0} ran without reporting an error, but the check that {1} exists afterwards failed. Either the script's statement failed and the failure was discarded - its ALTER statements are marked [IGNORE-ERRORS], which discards every error, not only \"already exists\" - or the check itself does not run on this backend; the error text below tells them apart (a division by zero means the object is missing, anything else means the check is at fault and the database is probably fine). The upgrade has been rolled back where the backend allows it. Probe: {2}{3}Error: {4}",
                      Path.GetFileName(GetScriptFileName(script)),
                      probe.Describes,
                      probe.Statement,

--- a/hmailserver/test/RegressionTests/Infrastructure/SchemaProbes.cs
+++ b/hmailserver/test/RegressionTests/Infrastructure/SchemaProbes.cs
@@ -1,0 +1,110 @@
+// Copyright (c) 2026 Christopher Holloway / Progressive Robot Ltd
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using System.Linq;
+using System.Runtime.InteropServices;
+using DBUpdater;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using RegressionTests.Shared;
+using hMailServer;
+
+namespace RegressionTests.Infrastructure
+{
+   /// <summary>
+   ///    DBUpdater proves every upgrade step with a probe - SchemaVerification.cs, compiled
+   ///    into this assembly as a linked file, so the statements tested here are the
+   ///    statements the installer runs. A probe has one job: fail only when the object it
+   ///    names is missing. Against the bench database, which is at the current schema and
+   ///    has everything, every probe must therefore succeed; one that fails is a statement
+   ///    the backend cannot execute, and in the field that reads as a failed upgrade of a
+   ///    database that is fine.
+   ///
+   ///    That is what 6.2.25 shipped for SQL Server Compact (issue #114). The four probes
+   ///    for schema 6030 used "case when exists (subquery)", which takes the Compact
+   ///    Edition OLE DB provider down with an access violation on a correct database; the
+   ///    server caught it as HM10045 "Unknown error", DBUpdater read the failed probe as a
+   ///    missing foreign key, and every Compact Edition upgrade through 6030 was reported
+   ///    as failed after it had, in fact, succeeded. The bench runs Compact Edition, so this
+   ///    fixture runs the probes on exactly the provider that crashed, through exactly the
+   ///    path DBUpdater takes - hMailServer.Database.ExecuteSQL over COM - and would have
+   ///    failed on the shipped statement. build\check-db-scripts.ps1 runs the same probes
+   ///    against a freshly created database before a release.
+   /// </summary>
+   [TestFixture]
+   public class SchemaProbes : TestFixtureBase
+   {
+      private static Database Database
+      {
+         get { return SingletonProvider<TestSetup>.Instance.GetApp().Database; }
+      }
+
+      [Test]
+      [Description("Every probe DBUpdater would run after an upgrade succeeds on a database that has everything the probes name.")]
+      public void EveryProbeSucceedsOnACorrectDatabase()
+      {
+         Database database = Database;
+         Assert.AreEqual(database.RequiredVersion, database.CurrentVersion,
+            "The bench database is not at the schema this build requires, so the probes would name objects it does not have yet.");
+
+         var probes = SchemaVerification.All;
+         Assert.IsTrue(probes.Count > 0, "SchemaVerification.cs registers no probes - the linked file is not what DBUpdater compiles.");
+
+         foreach (SchemaProbe probe in probes)
+         {
+            try
+            {
+               database.ExecuteSQL(probe.Statement);
+            }
+            catch (COMException e)
+            {
+               Assert.Fail("The probe for " + probe.Describes + " (schema " + probe.Version + ") fails on a correct database, so " +
+                           "DBUpdater would report an upgrade to " + probe.Version + " as failed after it succeeded.\r\n" +
+                           probe.Statement + "\r\n" + e.Message);
+            }
+         }
+      }
+
+      [Test]
+      [Description("The constraint probe fails for a constraint that does not exist - the half without which the probes prove nothing - and leaves hm_dbversion as it was.")]
+      public void TheConstraintProbeFailsForAnAbsentConstraint()
+      {
+         SchemaProbe probe = SchemaVerification.GetProbesFor(6030).First(p => p.Describes == "hm_accounts.fk_hm_accounts_domain");
+         string absent = probe.Statement.Replace("constraint_name = 'fk_hm_accounts_domain'", "constraint_name = 'fk_no_such_constraint'");
+         Assert.AreNotEqual(probe.Statement, absent, "The probe no longer names the constraint the way this test rewrites it.");
+
+         Database database = Database;
+         int before = database.CurrentVersion;
+
+         var refused = Assert.Throws<COMException>(() => database.ExecuteSQL(absent),
+            "The probe succeeded for a constraint that does not exist; it would pass a database the upgrade left without its foreign keys.");
+
+         // The failure must be the division, which is the probe working, and not the
+         // backend refusing the statement's shape, which is the probe broken - the
+         // shipped 6.2.25 probe failed too, for the second reason. HM10044 is the
+         // connection reporting the provider's own error; HM10045 is the catch-all that
+         // the provider's access violation reached.
+         StringAssert.Contains("HM10044", refused.Message, "The probe failed for a reason other than the backend evaluating it.");
+         StringAssert.DoesNotContain("HM10045", refused.Message);
+
+         Assert.AreEqual(before, database.CurrentVersion, "A failed probe must not have written hm_dbversion.");
+
+         // The refusal is reported through the API error and also, by the connection
+         // that saw it, to the error log; that line is this test's, not a fault.
+         LogHandler.ReadAndDeleteErrorLog();
+      }
+
+      [Test]
+      [Description("The probe distinguishes a foreign key from a primary key of the same name: the constraint type is part of what it asks.")]
+      public void TheConstraintProbeAsksForTheType()
+      {
+         SchemaProbe probe = SchemaVerification.GetProbesFor(6030).First(p => p.Describes == "hm_accounts.fk_hm_accounts_domain");
+         string primaryKeyNamedLikeAForeignKey = probe.Statement.Replace("constraint_name = 'fk_hm_accounts_domain'", "constraint_name = 'hm_domains_pk'");
+
+         Assert.Throws<COMException>(() => Database.ExecuteSQL(primaryKeyNamedLikeAForeignKey),
+            "hm_domains_pk is a primary key, not a foreign key; a probe that accepts it is not checking the type.");
+
+         LogHandler.ReadAndDeleteErrorLog();
+      }
+   }
+}

--- a/hmailserver/test/RegressionTests/RegressionTests.csproj
+++ b/hmailserver/test/RegressionTests/RegressionTests.csproj
@@ -540,6 +540,10 @@
     <Compile Include="Infrastructure\MetricsHistory.cs" />
     <Compile Include="Infrastructure\ArchiveIndexTests.cs" />
     <Compile Include="Infrastructure\ReferentialIntegrity.cs" />
+    <Compile Include="Infrastructure\SchemaProbes.cs" />
+    <Compile Include="..\..\source\Tools\DBUpdater\SchemaVerification.cs">
+      <Link>Infrastructure\SchemaVerification.cs</Link>
+    </Compile>
     <Compile Include="Infrastructure\DeliveryHardLinks.cs" />
     <Compile Include="Security\AdministratorTwoFactor.cs" />
     <Compile Include="Security\OAuth2Introspection.cs" />


### PR DESCRIPTION
Fixes #114.

**What was wrong.** DBUpdater proves each upgrade step with a probe statement and reads a failed probe as a missing object. The four probes for schema 6030 (the foreign keys) used `case when exists (subquery)` inside the SET expression. That is valid on SQL Server, MySQL and PostgreSQL; on SQL Server Compact it takes the OLE DB provider down with an access violation on a *correct* database. The server catches the fault and reports HM10045 - and two seconds later its crash oracle, treating the memory-safety fault as fatal, terminates the service (Application event 1000, exception 0x40000015), which service recovery restarts. DBUpdater meanwhile reports "did not create fk_hm_accounts_domain" and blames an `[IGNORE-ERRORS]` marker the `ADD CONSTRAINT` statements do not carry, and the installer says the database could not be upgraded. Every Compact Edition upgrade through 6030 failed this way - after having succeeded.

**Reproduced.** A Compact Edition database created at schema 6011 (the create script as of 7eed738e2) and upgraded with the shipped scripts reaches 6030 with all seventeen foreign keys and both key columns `int`; the shipped probe then faults the provider, and no other probe shape does. Compact Edition also rejects a scalar subquery in a SET expression, so the row count cannot be the divisor; a subquery in the WHERE clause is the one place it accepts one.

**The fix.** The probes are now `update hm_dbversion set value = value / (value - value) where not exists (select 1 from information_schema.table_constraints where constraint_name = '…' and constraint_type = 'FOREIGN KEY')`. Present: no row matches, nothing evaluated, nothing written. Absent: the row matches and the division by zero fails on every backend (SQL Server 8134, PostgreSQL 22012, MySQL 1365 strict, Compact Edition "expression evaluation caused an overflow"), leaving `hm_dbversion` untouched. DBUpdater's message no longer asserts a cause it cannot see; it gives the backend's words and says how to read them.

**So it cannot recur.** `build/check-db-scripts.ps1` now runs every probe from `SchemaVerification.cs` against the database it builds from the create script, through the same provider the server uses, plus a negative control that must fail. `Infrastructure/SchemaProbes.cs` does the same through `hMailServer.Database.ExecuteSQL` over COM against the bench database (Compact Edition), with `SchemaVerification.cs` compiled in as a linked file so what is tested is what ships. Both fail on the shipped statement and pass on the new one.

Nothing in the server changes. Verification: check-db-scripts 64 probes OK, negative control fails as it must; check-schema-versions OK; the shipped probe reproduced through the running server and the new one passed on the same connection; the new fixture and ReferentialIntegrity green against the master build.
