### PR TITLE
Seventy defects the per-string checkers cannot see, found by reading the catalogues against each other rather than one at a time, and fixed in fourteen languages

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -78,6 +78,14 @@ jobs:
       - name: The Control Panel's translation catalogues match the source
         run: python3 build/check-localisation.py
 
+      # What a per-string check cannot see: the English a caption must keep
+      # because the server writes it that way (its own log stage names, INI and
+      # setting names, INBOX, the syntax a user types back), a page named in
+      # prose by something other than that page's own translated title, and a
+      # number the translation dropped.
+      - name: The catalogues keep the server's own words, the numbers and the page names
+        run: python3 build/check-catalogues.py
+
       # "May account A do X to folder F" is answered by ACLManager and nowhere else;
       # a second decision-maker is how mail servers serve other people's mail.
       - name: Every folder-access decision is ACLManager's

--- a/build/check-catalogues.py
+++ b/build/check-catalogues.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Christopher Holloway / Progressive Robot Ltd and the hMailServer contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""What a translation can lose that a per-string check cannot see.
+
+check-localisation.py judges one string against its English: the placeholders,
+the Alt key, whether it is there at all. Three properties are invisible from
+there, because seeing them means reading the string against the rest of the
+catalogue, or against what the server does at run time:
+
+  literals  Some English in a caption is not language. The server logs its
+            accept-pipeline stages under fixed names - spam-protection,
+            script/save - and the stalled-mail page lists them so that an
+            administrator can match the page against the log; a translated
+            copy matches nothing. The same holds for setting and INI names,
+            file names, %TOKEN% and <token>, INBOX, and the syntax a user
+            types verbatim. These have to survive translation unchanged.
+
+  pages     Where a caption says "on the Transport security page", the
+            translation has to name that page the way that page's own title
+            is translated. Naming it anything else sends the reader looking
+            for a page that is not in the navigation. Only a reference that
+            actually points at a page is checked: "the IP ranges page", not
+            the ordinary words "no IP ranges are configured", which a
+            translation is right to render as ordinary words.
+
+  numbers   Every RFC number, port, size and count the English states is
+            stated by the translation too. Digit-group separators differ
+            between languages, so the comparison is on the digits alone -
+            210,000 and 210 000 are the same number. A dropped digit is the
+            kind of defect that reads perfectly well.
+
+Exits 1 with the language, the catalogue key and what is wrong.
+"""
+import os
+import re
+import sys
+import xml.etree.ElementTree as ET
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+RESOURCES = os.path.join(ROOT, "hmailserver", "source", "Tools", "ControlPanel", "Resources")
+
+# The pages a caption points at. Each is a catalogue key in its own right, so
+# the translated title is looked up rather than written here.
+PAGE_TITLES = [
+   "Anti-spam settings", "Anti-virus settings", "Blocked attachments",
+   "Delivery of e-mail", "Transport security", "TCP/IP ports", "IP ranges",
+   "SSL certificates", "Live logs", "External setup", "Event scripts",
+   "Web services & autoconfiguration", "Auto-ban", "Logging", "Domains",
+   "API & monitoring", "Authentication", "App passwords", "Advanced",
+   "REST API keys", "Message trace", "Quarantine", "Delivery queue",
+   "Public folders", "External accounts", "Routes", "Rules", "Diagnostics",
+   "Backup", "Groups",
+]
+
+# What the server writes, and what the user types back verbatim.
+LITERALS = [
+   "spam-protection", "done spam-protection", "script/save", "header-parsing",
+   "message-modifications", "AEAD-ONLY", ":hours", "HMBackup",
+   "hm_metricsamples", "v=DMARC1", "v=spf1", "v=STSv1", "v=TLSRPTv1",
+   "multipart/mixed", "multipart/alternative", "rsa-sha1", "rsa-sha256",
+   "objectCategory", "sAMAccountName", "strongAuthRequired", "/api/v1",
+   "/metrics", "/livez", "/readyz", "/healthz", "/portal", ".well-known",
+   "127.0.0.1", "INBOX", "identd",
+]
+
+# An INI or setting name: two or more CamelCase words run together.
+SETTING = re.compile(r"\b(?:[A-Z][a-z0-9]+){2,}\b")
+FILENAME = re.compile(r"\b[\w.\\-]+\.(?:INI|ini|exe|log|xml|dll|py|ps1|md|resx)\b")
+PERCENT = re.compile(r"%[A-Za-z]+%")
+ANGLED = re.compile(r"<[a-z][a-z0-9\\_.-]*>")
+PLACEHOLDER = re.compile(r"\{\d+(?:[:,][^}]*)?\}")
+# Digits, optionally in groups of three. "451. 0" is two numbers, not 4510.
+NUMBER = re.compile(r"\d+(?:[ ,. ]\d{3})*")
+
+# CamelCase that is a product or a class rather than a setting a user types,
+# and that a translation may reasonably render in its own words.
+SETTING_SKIP = {"ControlPanel", "OpenSSL", "OpenTelemetry", "SpamAssassin",
+                "ClamWin", "PowerShell", "LiveCharts", "SkiaSharp", "MimeBody",
+                "MessageData", "ManageSieve", "LocalSystem", "ChaCha",
+                "Postfix", "HAProxy", "AutoDiscover", "AutoConfig",
+                "MailServer", "ProgressiveRobot"}
+
+
+def read_resx(path):
+   """{key: value} for one catalogue; a missing file is an empty one."""
+   if not os.path.exists(path):
+      return {}
+   out = {}
+   for data in ET.parse(path).getroot().findall("data"):
+      value = data.find("value")
+      out[data.get("name")] = (value.text or "") if value is not None else ""
+   return out
+
+
+def without_mnemonic(text):
+   """The caption as it is read, with the Alt-key underscore taken out.
+
+   The underscore may land inside an identifier - "Timeo_utSeconds" is how a
+   collision in that scope was resolved - and the setting name is still on
+   screen, so the literal checks accept either form.
+   """
+   index = 0
+   while index < len(text):
+      if text[index] != "_":
+         index += 1
+         continue
+      if index + 1 < len(text) and text[index + 1] == "_":
+         index += 2
+         continue
+      return text[:index] + text[index + 1:]
+   return text
+
+
+def digits(text):
+   return re.sub(r"[^0-9]", "", text)
+
+
+def check(tag, catalogue):
+   titles = {}
+   for title in PAGE_TITLES:
+      if title in catalogue and catalogue[title]:
+         titles[title] = catalogue[title]
+
+   findings = []
+   for source, target in sorted(catalogue.items()):
+      if not source or not target:
+         continue
+
+      plain = without_mnemonic(target)
+      bare = PLACEHOLDER.sub(" ", source)
+
+      wanted = {digits(m.group(0)) for m in NUMBER.finditer(bare)}
+      have = {digits(m.group(0)) for m in NUMBER.finditer(PLACEHOLDER.sub(" ", target))}
+      for number in sorted(w for w in wanted - have if len(w) >= 2):
+         findings.append((source, "the number %s is not in the translation" % number))
+
+      for literal in LITERALS:
+         if literal in source and literal not in target and literal not in plain:
+            findings.append((source, "%r is what the server writes; the translation changed it" % literal))
+
+      for name in sorted(set(SETTING.findall(source)) - SETTING_SKIP):
+         if name not in target and name not in plain:
+            findings.append((source, "the setting name %r is not in the translation" % name))
+
+      for pattern in (FILENAME, PERCENT, ANGLED):
+         for match in sorted(set(pattern.findall(source))):
+            if match not in target and match not in plain:
+               findings.append((source, "%r is a literal; the translation changed it" % match))
+
+      if len(source) > 40:
+         for title, translated in sorted(titles.items()):
+            if source == title or translated in target:
+               continue
+            pointer = r"(?:the |on the |see the |Open )" + re.escape(title) + r"(?: page| tab)(?![\w-])"
+            if re.search(pointer, source):
+               findings.append((source, "names the %r page as something other than %r" % (title, translated)))
+
+   return findings
+
+
+def main():
+   if not os.path.isdir(RESOURCES):
+      print("No Resources directory at %s" % RESOURCES)
+      return 1
+
+   english = read_resx(os.path.join(RESOURCES, "Strings.resx"))
+   if not english:
+      print("Strings.resx is empty or missing; run check-localisation.py --write first.")
+      return 1
+
+   total = 0
+   for name in sorted(os.listdir(RESOURCES)):
+      match = re.match(r"^Strings\.([A-Za-z-]+)\.resx$", name)
+      if not match:
+         continue
+      tag = match.group(1)
+      catalogue = read_resx(os.path.join(RESOURCES, name))
+      # Only the keys this catalogue actually translates, keyed by the English.
+      catalogue = {key: value for key, value in catalogue.items() if key in english and value}
+      findings = check(tag, catalogue)
+      total += len(findings)
+      for source, what in findings:
+         print("  [%s] %s\n        in %r" % (tag, what, source[:110]))
+
+   if total:
+      print("FAIL: %d problem(s) across the catalogues" % total)
+      return 1
+
+   print("OK    every catalogue keeps the server's own words, the numbers and the page names")
+   return 0
+
+
+if __name__ == "__main__":
+   sys.exit(main())

--- a/hmailserver/source/Tools/ControlPanel/Resources/Strings.cs.resx
+++ b/hmailserver/source/Tools/ControlPanel/Resources/Strings.cs.resx
@@ -1261,7 +1261,7 @@ Restartovat nyní Control Panel? Volbou Ne se pokusíte pokračovat v práci.</v
     <value>Automatické certifikáty (ACME)</value>
   </data>
   <data name="Automatic lockout of an address that keeps failing to log on. The ban itself is an expiring IP range, so it is listed on the IP ranges page." xml:space="preserve">
-    <value>Automatické uzamčení adresy, které se opakovaně nedaří přihlásit. Samotný ban je IP rozsah s vypršením platnosti, takže je uveden na stránce IP rozsahy.</value>
+    <value>Automatické uzamčení adresy, které se opakovaně nedaří přihlásit. Samotný ban je IP rozsah s vypršením platnosti, takže je uveden na stránce Rozsahy IP.</value>
   </data>
   <data name="BATV is switched on but no secret is set, so outbound senders are not tagged and returning bounces are not validated - the switch reads enabled while it does nothing. Generate or enter a secret." xml:space="preserve">
     <value>BATV je zapnuto, ale není nastaven žádný tajný klíč, takže odchozí odesílatelé nejsou označováni a vracející se nedoručenky se neověřují – přepínač hlásí, že je zapnuto, přitom nedělá nic. Vygenerujte nebo zadejte tajný klíč.</value>
@@ -1351,7 +1351,7 @@ Restartovat nyní Control Panel? Volbou Ne se pokusíte pokračovat v práci.</v
     <value>Než budete kopírovat —</value>
   </data>
   <data name="Between the 354 and the 250 the server runs the accept pipeline - spam tests, message modifications, archiving, the OnAcceptMessage script and the database save - on a bounded pool of threads, and replies only when it finishes. The log times each stage. Read it as a sequence and look for the last line written: the stage that is stuck is the one after it. Two stages announce themselves with a start line (spam-protection and script/save); message modifications do not, so a stall there shows as &quot;done spam-protection&quot; followed by silence. A stage taking ten seconds or more is logged at application level even without debug logging." xml:space="preserve">
-    <value>Mezi odpovědí 354 a odpovědí 250 server provádí přijímací řetězec – antispamové testy, úpravy zprávy, archivaci, skript OnAcceptMessage a uložení do databáze – na omezeném fondu vláken a odpovídá teprve tehdy, až skončí. Log měří čas každé fáze. Čtěte jej jako posloupnost a hledejte poslední zapsaný řádek: zaseknutá fáze je ta následující. Dvě fáze se ohlašují úvodním řádkem (antispamová ochrana a skript/uložení); úpravy zprávy nikoli, takže zaseknutí v nich vypadá jako „done spam-protection“, po kterém následuje ticho. Fáze trvající deset a více sekund se zapisuje na úrovni aplikace i bez ladicího logování.</value>
+    <value>Mezi odpovědí 354 a odpovědí 250 server provádí přijímací řetězec – antispamové testy, úpravy zprávy, archivaci, skript OnAcceptMessage a uložení do databáze – na omezeném fondu vláken a odpovídá teprve tehdy, až skončí. Log měří čas každé fáze. Čtěte jej jako posloupnost a hledejte poslední zapsaný řádek: zaseknutá fáze je ta následující. Dvě fáze se ohlašují úvodním řádkem (spam-protection a script/save); úpravy zprávy nikoli, takže zaseknutí v nich vypadá jako „done spam-protection“, po kterém následuje ticho. Fáze trvající deset a více sekund se zapisuje na úrovni aplikace i bez ladicího logování.</value>
   </data>
   <data name="Biased upwards on purpose: refusing early costs delivery latency and nothing else, because the refusal is temporary and a sending server retries for days, while a volume that reaches zero costs a database that will not open and a service that will not start." xml:space="preserve">
     <value>Záměrně nastaveno spíše vysoko: odmítnout brzy stojí jen zpoždění doručení a nic víc, protože odmítnutí je dočasné a odesílající server to zkouší znovu celé dny, kdežto svazek, jehož volné místo klesne na nulu, stojí databázi, která se neotevře, a službu, která se nespustí.</value>
@@ -2186,7 +2186,7 @@ Připravený selektor „{0}“ se odebere z konfigurace serveru; podepisování
     <value>Nepodařilo se načíst distribuční seznamy:</value>
   </data>
   <data name="Counted logon failures cleared. Addresses already banned stay banned until their &quot;Auto-ban:&quot; range expires - delete it on the IP ranges page to release one now." xml:space="preserve">
-    <value>Započítaná neúspěšná přihlášení byla vymazána. Adresy, které už jsou zablokované, zůstanou zablokované, dokud jejich rozsah „Auto-ban:“ nevyprší – chcete-li některou uvolnit hned, smažte jej na stránce IP rozsahy.</value>
+    <value>Započítaná neúspěšná přihlášení byla vymazána. Adresy, které už jsou zablokované, zůstanou zablokované, dokud jejich rozsah „Auto-ban:“ nevyprší – chcete-li některou uvolnit hned, smažte jej na stránce Rozsahy IP.</value>
   </data>
   <data name="Counted per account from the last login that was allowed, so a refused attempt does not push the next one further away. It is advertised only while it is set, because announcing a limit that is not enforced is worse than announcing nothing." xml:space="preserve">
     <value>Počítá se pro každý účet od posledního povoleného přihlášení, takže odmítnutý pokus další přihlášení dál neodsune. Oznamuje se jen tehdy, dokud je nastaveno, protože ohlašovat limit, který se nevynucuje, je horší než neohlašovat nic.</value>
@@ -3667,7 +3667,7 @@ Ověřený instalátor se předá pomocníkovi aktualizace: služba se zastaví,
     <value>Už vypršel, takže ho nic úspěšně nepoužívá; odvolání ho odstraní z tohoto seznamu.</value>
   </data>
   <data name="It is bound to {0}, so those passwords cross the network. Either assign a certificate to a TLS-capable mailbox port on the TCP/IP ports page, bind this listener to 127.0.0.1, or put it behind a TLS terminator." xml:space="preserve">
-    <value>Je navázán na {0}, takže tato hesla procházejí sítí. Buď přiřaďte certifikát některému portu poštovní schránky s podporou TLS na stránce TCP/IP porty, navažte tento listener na 127.0.0.1, nebo jej postavte za TLS terminátor.</value>
+    <value>Je navázán na {0}, takže tato hesla procházejí sítí. Buď přiřaďte certifikát některému portu poštovní schránky s podporou TLS na stránce Porty TCP/IP, navažte tento listener na 127.0.0.1, nebo jej postavte za TLS terminátor.</value>
   </data>
   <data name="It is bound to {0}, which keeps it on this machine - that is the supported way to run it without TLS. Assign a certificate to a mailbox port to offer STARTTLS." xml:space="preserve">
     <value>Je navázán na {0}, což jej drží na tomto počítači – to je podporovaný způsob, jak jej provozovat bez TLS. Přiřaďte certifikát některému portu poštovní schránky, aby se nabízel STARTTLS.</value>
@@ -6520,7 +6520,7 @@ Pokračovat?</value>
     <value>Nezávisle na tom tento server odesílá vlastní hlášení jiným doménám jen tehdy, když je TlsRptFromAddress nastaveno v hMailServer.INI na serveru – ten z tohoto počítače přečíst nelze.</value>
   </data>
   <data name="Separately, this server's own SENDING of such reports to other domains is inert: TlsRptFromAddress is empty in hMailServer.INI (the default), so it collects statistics and discards every completed day unsent. Set it on the Transport security page if you want to send reports too." xml:space="preserve">
-    <value>Nezávisle na tom je vlastní ODESÍLÁNÍ takových hlášení jiným doménám nečinné: TlsRptFromAddress je v hMailServer.INI prázdné (výchozí stav), takže server statistiky sbírá a každý dokončený den zahodí, aniž by cokoli odeslal. Chcete-li hlášení také odesílat, nastavte ji na stránce Zabezpečení přenosu.</value>
+    <value>Nezávisle na tom je vlastní ODESÍLÁNÍ takových hlášení jiným doménám nečinné: TlsRptFromAddress je v hMailServer.INI prázdné (výchozí stav), takže server statistiky sbírá a každý dokončený den zahodí, aniž by cokoli odeslal. Chcete-li hlášení také odesílat, nastavte ji na stránce Transportní zabezpečení.</value>
   </data>
   <data name="Serve MTA-STS policies for local domains" xml:space="preserve">
     <value>Poskytovat politiky MTA-STS pro místní domény</value>
@@ -7928,7 +7928,7 @@ Bude to zkoušet dál, zatímco aplikaci používáte.</value>
     <value>Prahy a akce</value>
   </data>
   <data name="Throttle abusive senders submitting to this server. Limits are per minute; 0 disables the limit. (Throttling your own outbound rate to a destination is on the Delivery of e-mail page.)" xml:space="preserve">
-    <value>Přiškrťte zneužívající odesílatele, kteří na tento server odesílají. Limity jsou za minutu; 0 limit vypne. (Přiškrcení vlastní odchozí rychlosti k cíli je na stránce Doručování pošty.)</value>
+    <value>Přiškrťte zneužívající odesílatele, kteří na tento server odesílají. Limity jsou za minutu; 0 limit vypne. (Přiškrcení vlastní odchozí rychlosti k cíli je na stránce Doručování e-mailů.)</value>
   </data>
   <data name="Throttling your own outbound rate to a domain that rate-limits you. Deferred messages consume the retry budget above." xml:space="preserve">
     <value>Přiškrcení vlastní odchozí rychlosti k doméně, která vás omezuje. Odložené zprávy spotřebovávají rozpočet opakování výše.</value>
@@ -9473,7 +9473,7 @@ Bude to zkoušet dál, zatímco aplikaci používáte.</value>
     <value>skenery</value>
   </data>
   <data name="script/save slow" xml:space="preserve">
-    <value>skript/uložení pomalé</value>
+    <value>script/save pomalé</value>
   </data>
   <data name="scrypt (memory-hard, RFC 7914)" xml:space="preserve">
     <value>scrypt (paměťově náročný, RFC 7914)</value>

--- a/hmailserver/source/Tools/ControlPanel/Resources/Strings.da.resx
+++ b/hmailserver/source/Tools/ControlPanel/Resources/Strings.da.resx
@@ -9473,7 +9473,7 @@ Ingen meddelelse slettes, og ingen konto fjernes. Fortsæt?</value>
     <value>scannere</value>
   </data>
   <data name="script/save slow" xml:space="preserve">
-    <value>script/gem langsomt</value>
+    <value>script/save langsomt</value>
   </data>
   <data name="scrypt (memory-hard, RFC 7914)" xml:space="preserve">
     <value>scrypt (hukommelseskrævende, RFC 7914)</value>

--- a/hmailserver/source/Tools/ControlPanel/Resources/Strings.de.resx
+++ b/hmailserver/source/Tools/ControlPanel/Resources/Strings.de.resx
@@ -2,7 +2,7 @@
 <!-- Copyright (c) 2026 Christopher Holloway / Progressive Robot Ltd and the hMailServer contributors
      SPDX-License-Identifier: AGPL-3.0-or-later -->
 <root>
-  <!-- X: the X catalogue. Keys are the English text; values are the translation. Each caption's Alt key (the letter after _) is chosen for X and checked by build/check-mnemonics.py. -->
+  <!-- Deutsch: the Deutsch catalogue. Keys are the English text; values are the translation. Each caption's Alt key (the letter after _) is chosen for Deutsch and checked by build/check-mnemonics.py. -->
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
   </resheader>
@@ -1059,7 +1059,7 @@ Das Control Panel kann Nachrichtendateien nur lesen, wenn es auf demselben Rechn
     <value>Eine ältere, schwächere Option: ein Einmalcode, der nach dem Passwort beim Anmelden an DIESEM Control Panel verlangt und vom Werkzeug selbst geprüft wird, nachdem der Server das Passwort bereits akzeptiert hat. Das Geheimnis wird pro Rechner unter HKLM gespeichert, das Ein- oder Ausschalten braucht also lokale Administratorrechte, und für die REST-API oder Skripte über die COM-API tut es nichts. Bevorzugen Sie den vom Server erzwungenen Faktor oben; dieser bleibt für bestehende Einrichtungen.</value>
   </data>
   <data name="An override replaces the global ceilings for that address; 0:0 exempts it entirely. Without the optional :hours the override uses the global period. A malformed line is ignored with a log entry and the global limit still applies to that account. Comment lines in this INI section are not shown here and are dropped if the list is saved." xml:space="preserve">
-    <value>Eine Ausnahme ersetzt die globalen Obergrenzen für diese Adresse; 0:0 nimmt sie ganz aus. Ohne das optionale :Stunden verwendet die Ausnahme den globalen Zeitraum. Eine fehlerhafte Zeile wird mit einem Protokolleintrag ignoriert und die globale Grenze gilt weiter für dieses Konto. Kommentarzeilen in diesem INI-Abschnitt werden hier nicht angezeigt und beim Speichern der Liste verworfen.</value>
+    <value>Eine Ausnahme ersetzt die globalen Obergrenzen für diese Adresse; 0:0 nimmt sie ganz aus. Ohne das optionale :hours verwendet die Ausnahme den globalen Zeitraum. Eine fehlerhafte Zeile wird mit einem Protokolleintrag ignoriert und die globale Grenze gilt weiter für dieses Konto. Kommentarzeilen in diesem INI-Abschnitt werden hier nicht angezeigt und beim Speichern der Liste verworfen.</value>
   </data>
   <data name="An unexpected error occurred:&#10;&#10;{0}&#10;&#10;The full details were written to:&#10;{1}&#10;&#10;Restart the Control Panel now? Choose No to try to keep working." xml:space="preserve">
     <value>Ein unerwarteter Fehler ist aufgetreten:
@@ -3497,7 +3497,7 @@ Keine Mail wird angerührt - der Index ist daraus abgeleitet - aber bis der Neua
     <value>IMAP</value>
   </data>
   <data name="IMAP - the INBOX, collected once by UID; kept on the server unless Days to keep is 0" xml:space="preserve">
-    <value>IMAP - der Posteingang, einmal per UID abgeholt; bleibt auf dem Server, außer Tage behalten ist 0</value>
+    <value>IMAP - INBOX, einmal per UID abgeholt; bleibt auf dem Server, außer Tage behalten ist 0</value>
   </data>
   <data name="IMAP conversations" xml:space="preserve">
     <value>IMAP-Dialoge</value>

--- a/hmailserver/source/Tools/ControlPanel/Resources/Strings.es.resx
+++ b/hmailserver/source/Tools/ControlPanel/Resources/Strings.es.resx
@@ -2,7 +2,7 @@
 <!-- Copyright (c) 2026 Christopher Holloway / Progressive Robot Ltd and the hMailServer contributors
      SPDX-License-Identifier: AGPL-3.0-or-later -->
 <root>
-  <!-- X: the X catalogue. Keys are the English text; values are the translation. Each caption's Alt key (the letter after _) is chosen for X and checked by build/check-mnemonics.py. -->
+  <!-- Español: the Español catalogue. Keys are the English text; values are the translation. Each caption's Alt key (the letter after _) is chosen for Español and checked by build/check-mnemonics.py. -->
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
   </resheader>
@@ -1351,7 +1351,7 @@ Los detalles completos se escribieron en:
     <value>Antes de copiar —</value>
   </data>
   <data name="Between the 354 and the 250 the server runs the accept pipeline - spam tests, message modifications, archiving, the OnAcceptMessage script and the database save - on a bounded pool of threads, and replies only when it finishes. The log times each stage. Read it as a sequence and look for the last line written: the stage that is stuck is the one after it. Two stages announce themselves with a start line (spam-protection and script/save); message modifications do not, so a stall there shows as &quot;done spam-protection&quot; followed by silence. A stage taking ten seconds or more is logged at application level even without debug logging." xml:space="preserve">
-    <value>Entre el 354 y el 250 el servidor ejecuta la cadena de aceptación - pruebas de spam, modificaciones del mensaje, archivado, el script OnAcceptMessage y el guardado en la base de datos - en un grupo acotado de hilos, y solo responde cuando termina. El registro cronometra cada etapa. Léalo como una secuencia y busque la última línea escrita: la etapa atascada es la siguiente. Dos etapas se anuncian con una línea de inicio (protección antispam y script/guardado); las modificaciones del mensaje no, así que un atasco ahí se ve como "done spam-protection" seguido de silencio. Una etapa que tarda diez segundos o más se registra a nivel de aplicación aunque no haya registro de depuración.</value>
+    <value>Entre el 354 y el 250 el servidor ejecuta la cadena de aceptación - pruebas de spam, modificaciones del mensaje, archivado, el script OnAcceptMessage y el guardado en la base de datos - en un grupo acotado de hilos, y solo responde cuando termina. El registro cronometra cada etapa. Léalo como una secuencia y busque la última línea escrita: la etapa atascada es la siguiente. Dos etapas se anuncian con una línea de inicio (spam-protection y script/save); las modificaciones del mensaje no, así que un atasco ahí se ve como "done spam-protection" seguido de silencio. Una etapa que tarda diez segundos o más se registra a nivel de aplicación aunque no haya registro de depuración.</value>
   </data>
   <data name="Biased upwards on purpose: refusing early costs delivery latency and nothing else, because the refusal is temporary and a sending server retries for days, while a volume that reaches zero costs a database that will not open and a service that will not start." xml:space="preserve">
     <value>Sesgado hacia arriba a propósito: rechazar pronto cuesta latencia de entrega y nada más, porque el rechazo es temporal y un servidor emisor reintenta durante días, mientras que un volumen que llega a cero cuesta una base de datos que no abre y un servicio que no arranca.</value>
@@ -3497,7 +3497,7 @@ No se toca ningún correo - el índice se deriva de él - pero hasta que la reco
     <value>IMAP</value>
   </data>
   <data name="IMAP - the INBOX, collected once by UID; kept on the server unless Days to keep is 0" xml:space="preserve">
-    <value>IMAP - la bandeja de entrada, recogida una vez por UID; se conserva en el servidor a menos que Días que conservar sea 0</value>
+    <value>IMAP - INBOX, recogida una vez por UID; se conserva en el servidor a menos que Días que conservar sea 0</value>
   </data>
   <data name="IMAP conversations" xml:space="preserve">
     <value>Conversaciones IMAP</value>
@@ -9473,7 +9473,7 @@ No se borra ningún mensaje ni se elimina ninguna cuenta. ¿Continuar?</value>
     <value>analizadores</value>
   </data>
   <data name="script/save slow" xml:space="preserve">
-    <value>script/guardado lento</value>
+    <value>script/save lento</value>
   </data>
   <data name="scrypt (memory-hard, RFC 7914)" xml:space="preserve">
     <value>scrypt (intensivo en memoria, RFC 7914)</value>

--- a/hmailserver/source/Tools/ControlPanel/Resources/Strings.fi.resx
+++ b/hmailserver/source/Tools/ControlPanel/Resources/Strings.fi.resx
@@ -1059,7 +1059,7 @@ Control Panel voi lukea viestitiedostoja vain, kun se on käynnissä samalla kon
     <value>Vanhempi ja heikompi vaihtoehto: kertakäyttökoodi, joka kysytään salasanan jälkeen kirjauduttaessa TÄHÄN Control Paneliin ja jonka työkalu itse tarkistaa vasta sen jälkeen kun palvelin on jo hyväksynyt salasanan. Salaisuus tallennetaan konekohtaisesti HKLM:n alle, joten sen käyttöönotto tai käytöstä poisto vaatii paikallisen järjestelmänvalvojan oikeudet, eikä se tee mitään REST API:lle eikä COM API:a käyttäville komentosarjoille. Suosi yllä olevaa palvelimen pakottamaa tekijää; tämä on jäljellä olemassa olevia asennuksia varten.</value>
   </data>
   <data name="An override replaces the global ceilings for that address; 0:0 exempts it entirely. Without the optional :hours the override uses the global period. A malformed line is ignored with a log entry and the global limit still applies to that account. Comment lines in this INI section are not shown here and are dropped if the list is saved." xml:space="preserve">
-    <value>Ohitus korvaa kyseisen osoitteen yleiset ylärajat; 0:0 vapauttaa sen kokonaan. Ilman valinnaista :tunnit-osaa ohitus käyttää yleistä jaksoa. Virheellinen rivi ohitetaan lokimerkinnän kera ja yleinen raja koskee yhä kyseistä tiliä. Tämän INI-osion kommenttirivejä ei näytetä tässä, ja ne katoavat jos lista tallennetaan.</value>
+    <value>Ohitus korvaa kyseisen osoitteen yleiset ylärajat; 0:0 vapauttaa sen kokonaan. Ilman valinnaista :hours-osaa ohitus käyttää yleistä jaksoa. Virheellinen rivi ohitetaan lokimerkinnän kera ja yleinen raja koskee yhä kyseistä tiliä. Tämän INI-osion kommenttirivejä ei näytetä tässä, ja ne katoavat jos lista tallennetaan.</value>
   </data>
   <data name="An unexpected error occurred:&#10;&#10;{0}&#10;&#10;The full details were written to:&#10;{1}&#10;&#10;Restart the Control Panel now? Choose No to try to keep working." xml:space="preserve">
     <value>Tapahtui odottamaton virhe:
@@ -9473,7 +9473,7 @@ Yhtään viestiä ei poisteta eikä yhtään tiliä poisteta. Jatketaanko?</valu
     <value>tarkistinta</value>
   </data>
   <data name="script/save slow" xml:space="preserve">
-    <value>script/save slow</value>
+    <value>script/save hidas</value>
   </data>
   <data name="scrypt (memory-hard, RFC 7914)" xml:space="preserve">
     <value>scrypt (muistiraskas, RFC 7914)</value>

--- a/hmailserver/source/Tools/ControlPanel/Resources/Strings.fr.resx
+++ b/hmailserver/source/Tools/ControlPanel/Resources/Strings.fr.resx
@@ -2,7 +2,7 @@
 <!-- Copyright (c) 2026 Christopher Holloway / Progressive Robot Ltd and the hMailServer contributors
      SPDX-License-Identifier: AGPL-3.0-or-later -->
 <root>
-  <!-- X: the X catalogue. Keys are the English text; values are the translation. Each caption's Alt key (the letter after _) is chosen for X and checked by build/check-mnemonics.py. -->
+  <!-- Français: the Français catalogue. Keys are the English text; values are the translation. Each caption's Alt key (the letter after _) is chosen for Français and checked by build/check-mnemonics.py. -->
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
   </resheader>
@@ -1059,7 +1059,7 @@ Le Control Panel ne peut lire les fichiers de messages que lorsqu'il s'exécute 
     <value>Une option plus ancienne et plus faible : un code à usage unique demandé après le mot de passe à la connexion à CE Control Panel, vérifié par l'outil lui-même après que le serveur a déjà accepté le mot de passe. Le secret est stocké par machine sous HKLM, l'activer ou le désactiver exige donc des droits d'administrateur local, et cela ne fait rien pour l'API REST ni pour les scripts utilisant l'API COM. Préférez le facteur imposé par le serveur ci-dessus ; celui-ci reste pour les installations existantes.</value>
   </data>
   <data name="An override replaces the global ceilings for that address; 0:0 exempts it entirely. Without the optional :hours the override uses the global period. A malformed line is ignored with a log entry and the global limit still applies to that account. Comment lines in this INI section are not shown here and are dropped if the list is saved." xml:space="preserve">
-    <value>Une dérogation remplace les plafonds globaux pour cette adresse ; 0:0 l'exempte entièrement. Sans le :heures facultatif, la dérogation utilise la période globale. Une ligne mal formée est ignorée avec une entrée de journal et la limite globale s'applique toujours à ce compte. Les lignes de commentaire de cette section INI ne sont pas affichées ici et sont perdues si la liste est enregistrée.</value>
+    <value>Une dérogation remplace les plafonds globaux pour cette adresse ; 0:0 l'exempte entièrement. Sans le :hours facultatif, la dérogation utilise la période globale. Une ligne mal formée est ignorée avec une entrée de journal et la limite globale s'applique toujours à ce compte. Les lignes de commentaire de cette section INI ne sont pas affichées ici et sont perdues si la liste est enregistrée.</value>
   </data>
   <data name="An unexpected error occurred:&#10;&#10;{0}&#10;&#10;The full details were written to:&#10;{1}&#10;&#10;Restart the Control Panel now? Choose No to try to keep working." xml:space="preserve">
     <value>Une erreur inattendue s'est produite :
@@ -1351,7 +1351,7 @@ Redémarrer le Control Panel maintenant ? Choisissez Non pour essayer de continu
     <value>Avant de copier —</value>
   </data>
   <data name="Between the 354 and the 250 the server runs the accept pipeline - spam tests, message modifications, archiving, the OnAcceptMessage script and the database save - on a bounded pool of threads, and replies only when it finishes. The log times each stage. Read it as a sequence and look for the last line written: the stage that is stuck is the one after it. Two stages announce themselves with a start line (spam-protection and script/save); message modifications do not, so a stall there shows as &quot;done spam-protection&quot; followed by silence. A stage taking ten seconds or more is logged at application level even without debug logging." xml:space="preserve">
-    <value>Entre le 354 et le 250, le serveur exécute le pipeline d'acceptation - tests anti-spam, modifications du message, archivage, script OnAcceptMessage et enregistrement en base - sur un pool de threads borné, et ne répond qu'une fois terminé. Le journal chronomètre chaque étape. Lisez-le comme une séquence et cherchez la dernière ligne écrite : l'étape bloquée est celle qui suit. Deux étapes s'annoncent par une ligne de début (protection anti-spam et script/enregistrement) ; les modifications du message non, un blocage à cet endroit apparaît donc comme « done spam-protection » suivi de silence. Une étape qui prend dix secondes ou plus est journalisée au niveau application même sans journalisation de débogage.</value>
+    <value>Entre le 354 et le 250, le serveur exécute le pipeline d'acceptation - tests anti-spam, modifications du message, archivage, script OnAcceptMessage et enregistrement en base - sur un pool de threads borné, et ne répond qu'une fois terminé. Le journal chronomètre chaque étape. Lisez-le comme une séquence et cherchez la dernière ligne écrite : l'étape bloquée est celle qui suit. Deux étapes s'annoncent par une ligne de début (spam-protection et script/save) ; les modifications du message non, un blocage à cet endroit apparaît donc comme « done spam-protection » suivi de silence. Une étape qui prend dix secondes ou plus est journalisée au niveau application même sans journalisation de débogage.</value>
   </data>
   <data name="Biased upwards on purpose: refusing early costs delivery latency and nothing else, because the refusal is temporary and a sending server retries for days, while a volume that reaches zero costs a database that will not open and a service that will not start." xml:space="preserve">
     <value>Volontairement biaisé vers le haut : refuser tôt coûte de la latence de livraison et rien d'autre, parce que le refus est temporaire et qu'un serveur expéditeur réessaie pendant des jours, tandis qu'un volume qui atteint zéro coûte une base de données qui ne s'ouvre plus et un service qui ne démarre plus.</value>
@@ -3497,7 +3497,7 @@ Aucun courrier n'est touché - l'index en est dérivé - mais jusqu'à ce que la
     <value>IMAP</value>
   </data>
   <data name="IMAP - the INBOX, collected once by UID; kept on the server unless Days to keep is 0" xml:space="preserve">
-    <value>IMAP - la boîte de réception, relevée une fois par UID ; gardée sur le serveur sauf si Jours à conserver est 0</value>
+    <value>IMAP - INBOX, relevée une fois par UID ; gardée sur le serveur sauf si Jours à conserver est 0</value>
   </data>
   <data name="IMAP conversations" xml:space="preserve">
     <value>Conversations IMAP</value>
@@ -5044,7 +5044,7 @@ L'installateur vérifié est remis à l'assistant de mise à jour : le service s
     <value>Sécurité de la livraison sortante (après la recherche MX)</value>
   </data>
   <data name="Outbound delivery, retries and throttling. Keeping forwarded mail SPF-aligned (SRS) and bounce tagging (BATV) are on the Transport security page." xml:space="preserve">
-    <value>Livraison sortante, nouvelles tentatives et limitation de débit. Garder le courrier transféré aligné avec SPF (SRS) et le marquage des rebonds (BATV) sont sur la page Sécurité du transport.</value>
+    <value>Livraison sortante, nouvelles tentatives et limitation de débit. Garder le courrier transféré aligné avec SPF (SRS) et le marquage des rebonds (BATV) sont sur la page Sécurité de transport.</value>
   </data>
   <data name="Outbound mail authentication and encryption policies (hMailServer.INI). Changes take effect after a service restart." xml:space="preserve">
     <value>Politiques d'authentification et de chiffrement du courrier sortant (hMailServer.INI). Les changements prennent effet après un redémarrage du service.</value>
@@ -5196,7 +5196,7 @@ Aucune nouvelle connexion ne sera acceptée et aucun courrier ne sera livré jus
     <value>Limites d'envoi par compte</value>
   </data>
   <data name="Per-address overrides, one per line: address=messages:recipients[:hours]" xml:space="preserve">
-    <value>Surcharges par adresse, une par ligne : adresse=messages:destinataires[:heures]</value>
+    <value>Surcharges par adresse, une par ligne : address=messages:recipients[:hours]</value>
   </data>
   <data name="Per-name lockout" xml:space="preserve">
     <value>Verrouillage par nom</value>
@@ -5422,7 +5422,7 @@ Laissez l'ANCIEN enregistrement DNS ({2}) publié pendant au moins quelques jour
     <value>Publié, plus strict que le point de départ</value>
   </data>
   <data name="Publishes https://mta-sts.&lt;domain&gt;/.well-known/mta-sts.txt so other servers require TLS when they deliver to you. Honouring other domains' policies is on the Transport security page." xml:space="preserve">
-    <value>Publie https://mta-sts.&lt;domain&gt;/.well-known/mta-sts.txt pour que les autres serveurs exigent TLS quand ils vous livrent. Le respect des politiques des autres domaines est sur la page Sécurité du transport.</value>
+    <value>Publie https://mta-sts.&lt;domain&gt;/.well-known/mta-sts.txt pour que les autres serveurs exigent TLS quand ils vous livrent. Le respect des politiques des autres domaines est sur la page Sécurité de transport.</value>
   </data>
   <data name="Publishing this record asks every server that delivers to {0} to e-mail you a daily report when TLS to you fails or is downgraded. The reports go to the rua= mailbox, which must exist and accept mail from strangers. This works regardless of any hMailServer setting - the senders do the reporting." xml:space="preserve">
     <value>Publier cet enregistrement demande à chaque serveur qui livre à {0} de vous envoyer par e-mail un rapport quotidien quand le TLS vers vous échoue ou est rétrogradé. Les rapports vont à la boîte rua=, qui doit exister et accepter le courrier d'inconnus. Cela fonctionne quel que soit le réglage de hMailServer - ce sont les expéditeurs qui rapportent.</value>
@@ -6520,7 +6520,7 @@ Continuer ?</value>
     <value>Par ailleurs, ce serveur n'envoie ses propres rapports à d'autres domaines que si TlsRptFromAddress est défini dans hMailServer.INI sur le serveur - non lisible depuis cette machine.</value>
   </data>
   <data name="Separately, this server's own SENDING of such reports to other domains is inert: TlsRptFromAddress is empty in hMailServer.INI (the default), so it collects statistics and discards every completed day unsent. Set it on the Transport security page if you want to send reports too." xml:space="preserve">
-    <value>Par ailleurs, l'ENVOI par ce serveur de tels rapports à d'autres domaines est inerte : TlsRptFromAddress est vide dans hMailServer.INI (la valeur par défaut), il collecte donc des statistiques et jette chaque journée terminée sans l'envoyer. Définissez-le sur la page Sécurité du transport si vous voulez envoyer des rapports vous aussi.</value>
+    <value>Par ailleurs, l'ENVOI par ce serveur de tels rapports à d'autres domaines est inerte : TlsRptFromAddress est vide dans hMailServer.INI (la valeur par défaut), il collecte donc des statistiques et jette chaque journée terminée sans l'envoyer. Définissez-le sur la page Sécurité de transport si vous voulez envoyer des rapports vous aussi.</value>
   </data>
   <data name="Serve MTA-STS policies for local domains" xml:space="preserve">
     <value>Servir les politiques MTA-STS pour les domaines locaux</value>
@@ -9473,7 +9473,7 @@ Aucun message n'est supprimé et aucun compte n'est retiré. Continuer ?</value>
     <value>analyseurs</value>
   </data>
   <data name="script/save slow" xml:space="preserve">
-    <value>script/enregistrement lent</value>
+    <value>script/save lent</value>
   </data>
   <data name="scrypt (memory-hard, RFC 7914)" xml:space="preserve">
     <value>scrypt (coûteux en mémoire, RFC 7914)</value>

--- a/hmailserver/source/Tools/ControlPanel/Resources/Strings.it.resx
+++ b/hmailserver/source/Tools/ControlPanel/Resources/Strings.it.resx
@@ -2,7 +2,7 @@
 <!-- Copyright (c) 2026 Christopher Holloway / Progressive Robot Ltd and the hMailServer contributors
      SPDX-License-Identifier: AGPL-3.0-or-later -->
 <root>
-  <!-- X: the X catalogue. Keys are the English text; values are the translation. Each caption's Alt key (the letter after _) is chosen for X and checked by build/check-mnemonics.py. -->
+  <!-- Italiano: the Italiano catalogue. Keys are the English text; values are the translation. Each caption's Alt key (the letter after _) is chosen for Italiano and checked by build/check-mnemonics.py. -->
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
   </resheader>
@@ -1059,7 +1059,7 @@ Il Control Panel può leggere i file dei messaggi solo quando è in esecuzione s
     <value>Un'opzione più vecchia e più debole: un codice monouso chiesto dopo la password all'accesso a QUESTO Control Panel, verificato dallo strumento stesso dopo che il server ha già accettato la password. Il segreto è memorizzato per macchina sotto HKLM, quindi attivarlo o disattivarlo richiede diritti di amministratore locale, e non fa nulla per l'API REST o per gli script che usano l'API COM. Preferisci il fattore imposto dal server qui sopra; questo resta per le configurazioni esistenti.</value>
   </data>
   <data name="An override replaces the global ceilings for that address; 0:0 exempts it entirely. Without the optional :hours the override uses the global period. A malformed line is ignored with a log entry and the global limit still applies to that account. Comment lines in this INI section are not shown here and are dropped if the list is saved." xml:space="preserve">
-    <value>Un'eccezione sostituisce i limiti globali per quell'indirizzo; 0:0 lo esenta del tutto. Senza il :ore facoltativo l'eccezione usa il periodo globale. Una riga malformata viene ignorata con una voce nel registro e il limite globale continua ad applicarsi a quell'account. Le righe di commento in questa sezione INI non sono mostrate qui e vengono perse se l'elenco viene salvato.</value>
+    <value>Un'eccezione sostituisce i limiti globali per quell'indirizzo; 0:0 lo esenta del tutto. Senza il :hours facoltativo l'eccezione usa il periodo globale. Una riga malformata viene ignorata con una voce nel registro e il limite globale continua ad applicarsi a quell'account. Le righe di commento in questa sezione INI non sono mostrate qui e vengono perse se l'elenco viene salvato.</value>
   </data>
   <data name="An unexpected error occurred:&#10;&#10;{0}&#10;&#10;The full details were written to:&#10;{1}&#10;&#10;Restart the Control Panel now? Choose No to try to keep working." xml:space="preserve">
     <value>Si è verificato un errore imprevisto:
@@ -1351,7 +1351,7 @@ Riavviare il Control Panel adesso? Scegli No per provare a continuare a lavorare
     <value>Prima di copiare — </value>
   </data>
   <data name="Between the 354 and the 250 the server runs the accept pipeline - spam tests, message modifications, archiving, the OnAcceptMessage script and the database save - on a bounded pool of threads, and replies only when it finishes. The log times each stage. Read it as a sequence and look for the last line written: the stage that is stuck is the one after it. Two stages announce themselves with a start line (spam-protection and script/save); message modifications do not, so a stall there shows as &quot;done spam-protection&quot; followed by silence. A stage taking ten seconds or more is logged at application level even without debug logging." xml:space="preserve">
-    <value>Tra il 354 e il 250 il server esegue la pipeline di accettazione - test antispam, modifiche al messaggio, archiviazione, lo script OnAcceptMessage e il salvataggio nel database - su un pool limitato di thread, e risponde solo quando ha finito. Il registro cronometra ogni fase. Leggilo come una sequenza e cerca l'ultima riga scritta: la fase bloccata è quella successiva. Due fasi si annunciano con una riga di inizio (spam-protection e script/salvataggio); le modifiche al messaggio no, quindi un blocco lì appare come "done spam-protection" seguito dal silenzio. Una fase che richiede dieci secondi o più viene registrata a livello applicazione anche senza la registrazione di debug.</value>
+    <value>Tra il 354 e il 250 il server esegue la pipeline di accettazione - test antispam, modifiche al messaggio, archiviazione, lo script OnAcceptMessage e il salvataggio nel database - su un pool limitato di thread, e risponde solo quando ha finito. Il registro cronometra ogni fase. Leggilo come una sequenza e cerca l'ultima riga scritta: la fase bloccata è quella successiva. Due fasi si annunciano con una riga di inizio (spam-protection e script/save); le modifiche al messaggio no, quindi un blocco lì appare come "done spam-protection" seguito dal silenzio. Una fase che richiede dieci secondi o più viene registrata a livello applicazione anche senza la registrazione di debug.</value>
   </data>
   <data name="Biased upwards on purpose: refusing early costs delivery latency and nothing else, because the refusal is temporary and a sending server retries for days, while a volume that reaches zero costs a database that will not open and a service that will not start." xml:space="preserve">
     <value>Sbilanciato verso l'alto di proposito: rifiutare presto costa latenza di consegna e nient'altro, perché il rifiuto è temporaneo e un server mittente riprova per giorni, mentre un volume che arriva a zero costa un database che non si apre e un servizio che non si avvia.</value>
@@ -2636,7 +2636,7 @@ Nessuna posta viene toccata - l'indice ne è derivato - ma finché la ricostruzi
     <value>Disconnetti i client che inviano troppi comandi non validi</value>
   </data>
   <data name="Discovers and enforces recipient MTA-STS policies before delivering over TLS (RFC 8461). To publish a policy for your own domains, see the Web services &amp; autoconfiguration page." xml:space="preserve">
-    <value>Individua e applica i criteri MTA-STS dei destinatari prima di consegnare su TLS (RFC 8461). Per pubblicare un criterio per i tuoi domini, vedi la pagina Servizi web e autoconfigurazione.</value>
+    <value>Individua e applica i criteri MTA-STS dei destinatari prima di consegnare su TLS (RFC 8461). Per pubblicare un criterio per i tuoi domini, vedi la pagina Servizi web e configurazione automatica.</value>
   </data>
   <data name="Disk space" xml:space="preserve">
     <value>Spazio su disco</value>
@@ -3284,7 +3284,7 @@ Nessuna posta viene toccata - l'indice ne è derivato - ma finché la ricostruzi
     <value>Vai alla pagina correlata {0}</value>
   </data>
   <data name="Graceful shutdown behaviour for unattended / clustered operation. (Log retention is on the Logging page.)" xml:space="preserve">
-    <value>Comportamento di arresto ordinato per il funzionamento non presidiato o in cluster. (La conservazione dei registri si trova nella pagina Registri.)</value>
+    <value>Comportamento di arresto ordinato per il funzionamento non presidiato o in cluster. (La conservazione dei registri si trova nella pagina Registrazione.)</value>
   </data>
   <data name="Greylisting" xml:space="preserve">
     <value>Greylisting</value>
@@ -5196,7 +5196,7 @@ Non verrà accettata alcuna nuova connessione e non verrà consegnata alcuna pos
     <value>Limiti di invio per singolo account</value>
   </data>
   <data name="Per-address overrides, one per line: address=messages:recipients[:hours]" xml:space="preserve">
-    <value>Eccezioni per singolo indirizzo, una per riga: indirizzo=messaggi:destinatari[:ore]</value>
+    <value>Eccezioni per singolo indirizzo, una per riga: address=messages:recipients[:hours]</value>
   </data>
   <data name="Per-name lockout" xml:space="preserve">
     <value>Blocco per nome</value>
@@ -5467,7 +5467,7 @@ Lascia pubblicato il VECCHIO record DNS ({2}) per almeno qualche giorno. La post
     <value>API REST di amministrazione + Web Control Deck</value>
   </data>
   <data name="REST administration API, Prometheus metrics and remote script management. The public web services listener (autoconfiguration, MTA-STS hosting) is on the Web services &amp; autoconfiguration page; OAuth2 token authentication is on the Authentication page." xml:space="preserve">
-    <value>API REST di amministrazione, metriche Prometheus e gestione remota degli script. Il listener pubblico dei servizi web (autoconfigurazione, hosting MTA-STS) si trova nella pagina Servizi web e autoconfigurazione; l'autenticazione con token OAuth2 si trova nella pagina Autenticazione.</value>
+    <value>API REST di amministrazione, metriche Prometheus e gestione remota degli script. Il listener pubblico dei servizi web (autoconfigurazione, hosting MTA-STS) si trova nella pagina Servizi web e configurazione automatica; l'autenticazione con token OAuth2 si trova nella pagina Autenticazione.</value>
   </data>
   <data name="REST listener settings…" xml:space="preserve">
     <value>Impostazioni del listener REST…</value>
@@ -9473,7 +9473,7 @@ Nessun messaggio viene eliminato e nessun account viene rimosso. Continuare?</va
     <value>scanner</value>
   </data>
   <data name="script/save slow" xml:space="preserve">
-    <value>script/salvataggio lento</value>
+    <value>script/save lento</value>
   </data>
   <data name="scrypt (memory-hard, RFC 7914)" xml:space="preserve">
     <value>scrypt (a uso intensivo di memoria, RFC 7914)</value>

--- a/hmailserver/source/Tools/ControlPanel/Resources/Strings.nb.resx
+++ b/hmailserver/source/Tools/ControlPanel/Resources/Strings.nb.resx
@@ -8333,7 +8333,7 @@ Ingen melding slettes, og ingen konto fjernes. Fortsette?</value>
     <value>Hva serveren gjør etter hvert som meldingslagervolumet fylles. Begge verdiene er absolutte megabyte, ikke prosenter, fordi det som avgjør om neste melding får plass, er hvor mange byte som er igjen, ikke hvilken brøkdel av volumet de utgjør. Gjelder etter omstart av tjenesten.</value>
   </data>
   <data name="What the server writes to its log files (viewable on the Live logs page)." xml:space="preserve">
-    <value>Hva serveren skriver til loggfilene sine (kan ses på siden Levende logger).</value>
+    <value>Hva serveren skriver til loggfilene sine (kan ses på siden Direktelogger).</value>
   </data>
   <data name="What this key is for, e.g. &quot;Grafana probe&quot;" xml:space="preserve">
     <value>Hva denne nøkkelen er til, f.eks. "Grafana probe"</value>
@@ -9473,7 +9473,7 @@ Ingen melding slettes, og ingen konto fjernes. Fortsette?</value>
     <value>skannere</value>
   </data>
   <data name="script/save slow" xml:space="preserve">
-    <value>skript/lagring tregt</value>
+    <value>script/save tregt</value>
   </data>
   <data name="scrypt (memory-hard, RFC 7914)" xml:space="preserve">
     <value>scrypt (minnekrevende, RFC 7914)</value>

--- a/hmailserver/source/Tools/ControlPanel/Resources/Strings.nl.resx
+++ b/hmailserver/source/Tools/ControlPanel/Resources/Strings.nl.resx
@@ -2,7 +2,7 @@
 <!-- Copyright (c) 2026 Christopher Holloway / Progressive Robot Ltd and the hMailServer contributors
      SPDX-License-Identifier: AGPL-3.0-or-later -->
 <root>
-  <!-- X: the X catalogue. Keys are the English text; values are the translation. Each caption's Alt key (the letter after _) is chosen for X and checked by build/check-mnemonics.py. -->
+  <!-- Nederlands: the Nederlands catalogue. Keys are the English text; values are the translation. Each caption's Alt key (the letter after _) is chosen for Nederlands and checked by build/check-mnemonics.py. -->
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
   </resheader>
@@ -1059,7 +1059,7 @@ Het Control Panel kan berichtbestanden alleen lezen wanneer het op dezelfde mach
     <value>Een oudere, zwakkere optie: een eenmalige code die na het wachtwoord wordt gevraagd bij het aanmelden bij DIT Control Panel, gecontroleerd door het hulpmiddel zelf nadat de server het wachtwoord al heeft geaccepteerd. Het geheim wordt per machine onder HKLM opgeslagen, dus in- of uitschakelen vereist lokale beheerdersrechten, en het doet niets voor de REST-API of voor scripts die de COM-API gebruiken. Geef de voorkeur aan de door de server afgedwongen factor hierboven; deze blijft voor bestaande installaties.</value>
   </data>
   <data name="An override replaces the global ceilings for that address; 0:0 exempts it entirely. Without the optional :hours the override uses the global period. A malformed line is ignored with a log entry and the global limit still applies to that account. Comment lines in this INI section are not shown here and are dropped if the list is saved." xml:space="preserve">
-    <value>Een uitzondering vervangt de globale plafonds voor dat adres; 0:0 stelt het volledig vrij. Zonder de optionele :uren gebruikt de uitzondering de globale periode. Een verkeerd gevormde regel wordt genegeerd met een logvermelding en de globale limiet blijft voor dat account gelden. Commentaarregels in deze INI-sectie worden hier niet getoond en vallen weg als de lijst wordt opgeslagen.</value>
+    <value>Een uitzondering vervangt de globale plafonds voor dat adres; 0:0 stelt het volledig vrij. Zonder de optionele :hours gebruikt de uitzondering de globale periode. Een verkeerd gevormde regel wordt genegeerd met een logvermelding en de globale limiet blijft voor dat account gelden. Commentaarregels in deze INI-sectie worden hier niet getoond en vallen weg als de lijst wordt opgeslagen.</value>
   </data>
   <data name="An unexpected error occurred:&#10;&#10;{0}&#10;&#10;The full details were written to:&#10;{1}&#10;&#10;Restart the Control Panel now? Choose No to try to keep working." xml:space="preserve">
     <value>Er is een onverwachte fout opgetreden:
@@ -3284,7 +3284,7 @@ Er wordt geen mail aangeraakt - de index is ervan afgeleid - maar totdat het opn
     <value>Ga naar de bijbehorende pagina {0}</value>
   </data>
   <data name="Graceful shutdown behaviour for unattended / clustered operation. (Log retention is on the Logging page.)" xml:space="preserve">
-    <value>Gedrag bij netjes afsluiten voor onbeheerd of geclusterd bedrijf. (Het bewaren van logboeken staat op de pagina Logboeken.)</value>
+    <value>Gedrag bij netjes afsluiten voor onbeheerd of geclusterd bedrijf. (Het bewaren van logboeken staat op de pagina Logboekregistratie.)</value>
   </data>
   <data name="Greylisting" xml:space="preserve">
     <value>Greylisting</value>
@@ -5196,7 +5196,7 @@ Er worden geen nieuwe verbindingen geaccepteerd en er wordt geen mail bezorgd to
     <value>Verzendlimieten per account</value>
   </data>
   <data name="Per-address overrides, one per line: address=messages:recipients[:hours]" xml:space="preserve">
-    <value>Uitzonderingen per adres, één per regel: adres=berichten:ontvangers[:uren]</value>
+    <value>Uitzonderingen per adres, één per regel: address=messages:recipients[:hours]</value>
   </data>
   <data name="Per-name lockout" xml:space="preserve">
     <value>Vergrendeling per naam</value>
@@ -5340,7 +5340,7 @@ Er worden geen nieuwe verbindingen geaccepteerd en er wordt geen mail bezorgd to
     <value>Progressive Robot Ltd is een software-engineeringbedrijf dat productiesoftware bouwt en moderniseert — het neemt volgroeide systemen uit de praktijk en brengt ze op het huidige niveau van beveiliging, betrouwbaarheid en gereedschap.</value>
   </data>
   <data name="Prometheus metrics (/metrics), OpenTelemetry export of traces, metrics and logs (one endpoint per signal, each off until set), a slow-query log, and JSON-structured log output for log aggregators (on the Logging page)." xml:space="preserve">
-    <value>Prometheus-metrics (/metrics), OpenTelemetry-export van traces, metrics en logboeken (één eindpunt per signaal, elk uit totdat het is ingesteld), een logboek van trage query's, en JSON-gestructureerde loguitvoer voor logaggregators (op de pagina Logboekinstellingen).</value>
+    <value>Prometheus-metrics (/metrics), OpenTelemetry-export van traces, metrics en logboeken (één eindpunt per signaal, elk uit totdat het is ingesteld), een logboek van trage query's, en JSON-gestructureerde loguitvoer voor logaggregators (op de pagina Logboekregistratie).</value>
   </data>
   <data name="Prometheus metrics, health endpoints and the REST API are enabled here." xml:space="preserve">
     <value>Prometheus-metrics, gezondheidseindpunten en de REST-API worden hier ingeschakeld.</value>
@@ -9473,7 +9473,7 @@ Er wordt geen bericht verwijderd en er wordt geen account verwijderd. Doorgaan?<
     <value>scanners</value>
   </data>
   <data name="script/save slow" xml:space="preserve">
-    <value>script/opslaan traag</value>
+    <value>script/save traag</value>
   </data>
   <data name="scrypt (memory-hard, RFC 7914)" xml:space="preserve">
     <value>scrypt (geheugenintensief, RFC 7914)</value>

--- a/hmailserver/source/Tools/ControlPanel/Resources/Strings.pl.resx
+++ b/hmailserver/source/Tools/ControlPanel/Resources/Strings.pl.resx
@@ -2,7 +2,7 @@
 <!-- Copyright (c) 2026 Christopher Holloway / Progressive Robot Ltd and the hMailServer contributors
      SPDX-License-Identifier: AGPL-3.0-or-later -->
 <root>
-  <!-- X: the X catalogue. Keys are the English text; values are the translation. Each caption's Alt key (the letter after _) is chosen for X and checked by build/check-mnemonics.py. -->
+  <!-- Polski: the Polski catalogue. Keys are the English text; values are the translation. Each caption's Alt key (the letter after _) is chosen for Polski and checked by build/check-mnemonics.py. -->
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
   </resheader>
@@ -1351,7 +1351,7 @@ Uruchomić teraz ponownie aplikację Control Panel? Wybierz Nie, aby spróbować
     <value>Przed skopiowaniem — </value>
   </data>
   <data name="Between the 354 and the 250 the server runs the accept pipeline - spam tests, message modifications, archiving, the OnAcceptMessage script and the database save - on a bounded pool of threads, and replies only when it finishes. The log times each stage. Read it as a sequence and look for the last line written: the stage that is stuck is the one after it. Two stages announce themselves with a start line (spam-protection and script/save); message modifications do not, so a stall there shows as &quot;done spam-protection&quot; followed by silence. A stage taking ten seconds or more is logged at application level even without debug logging." xml:space="preserve">
-    <value>Między odpowiedzią 354 a 250 serwer przeprowadza potok przyjmowania - testy antyspamowe, modyfikacje wiadomości, archiwizację, skrypt OnAcceptMessage i zapis do bazy danych - w ograniczonej puli wątków i odpowiada dopiero po jego zakończeniu. Dziennik mierzy czas każdego etapu. Należy czytać go jako sekwencję i szukać ostatniego zapisanego wiersza: zablokowany jest ten etap, który następuje po nim. Dwa etapy zapowiadają się wierszem początkowym (ochrona antyspamowa oraz skrypt/zapis); modyfikacje wiadomości nie, więc zatrzymanie w tym miejscu objawia się jako „done spam-protection”, po którym zapada cisza. Etap trwający dziesięć sekund lub dłużej jest zapisywany na poziomie aplikacji nawet bez rejestrowania diagnostycznego.</value>
+    <value>Między odpowiedzią 354 a 250 serwer przeprowadza potok przyjmowania - testy antyspamowe, modyfikacje wiadomości, archiwizację, skrypt OnAcceptMessage i zapis do bazy danych - w ograniczonej puli wątków i odpowiada dopiero po jego zakończeniu. Dziennik mierzy czas każdego etapu. Należy czytać go jako sekwencję i szukać ostatniego zapisanego wiersza: zablokowany jest ten etap, który następuje po nim. Dwa etapy zapowiadają się wierszem początkowym (spam-protection oraz script/save); modyfikacje wiadomości nie, więc zatrzymanie w tym miejscu objawia się jako „done spam-protection”, po którym zapada cisza. Etap trwający dziesięć sekund lub dłużej jest zapisywany na poziomie aplikacji nawet bez rejestrowania diagnostycznego.</value>
   </data>
   <data name="Biased upwards on purpose: refusing early costs delivery latency and nothing else, because the refusal is temporary and a sending server retries for days, while a volume that reaches zero costs a database that will not open and a service that will not start." xml:space="preserve">
     <value>Celowo zawyżone: wczesna odmowa kosztuje jedynie opóźnienie dostarczenia i nic poza tym, ponieważ odmowa jest tymczasowa, a serwer wysyłający ponawia próby przez wiele dni, natomiast wolumin, na którym miejsce spadnie do zera, kosztuje bazę danych, która się nie otworzy, i usługę, która się nie uruchomi.</value>
@@ -2636,7 +2636,7 @@ Poczta nie jest ruszana - indeks jest z niej wyprowadzany - ale dopóki odbudowa
     <value>Rozłączaj klientów wysyłających zbyt wiele nieprawidłowych poleceń</value>
   </data>
   <data name="Discovers and enforces recipient MTA-STS policies before delivering over TLS (RFC 8461). To publish a policy for your own domains, see the Web services &amp; autoconfiguration page." xml:space="preserve">
-    <value>Wykrywa i egzekwuje polityki MTA-STS odbiorcy przed dostarczeniem przez TLS (RFC 8461). Publikowanie polityki dla własnych domen opisuje strona Usługi sieciowe i autokonfiguracja.</value>
+    <value>Wykrywa i egzekwuje polityki MTA-STS odbiorcy przed dostarczeniem przez TLS (RFC 8461). Publikowanie polityki dla własnych domen opisuje strona Usługi webowe i autokonfiguracja.</value>
   </data>
   <data name="Disk space" xml:space="preserve">
     <value>Miejsce na dysku</value>
@@ -2831,7 +2831,7 @@ Poczta nie jest ruszana - indeks jest z niej wyprowadzany - ale dopóki odbudowa
     <value>Włącz anty_wirus dla tego zakresu</value>
   </data>
   <data name="Enable attachment blocking (manage list on the Blocked attachments page)" xml:space="preserve">
-    <value>Włącz blokowanie załączników (listą zarządza się na stronie Blokowane załączniki)</value>
+    <value>Włącz blokowanie załączników (listą zarządza się na stronie Zablokowane załączniki)</value>
   </data>
   <data name="Enable auto-ban" xml:space="preserve">
     <value>Włącz automatyczną blokadę</value>
@@ -3284,7 +3284,7 @@ Poczta nie jest ruszana - indeks jest z niej wyprowadzany - ale dopóki odbudowa
     <value>Przejdź do powiązanej strony {0}</value>
   </data>
   <data name="Graceful shutdown behaviour for unattended / clustered operation. (Log retention is on the Logging page.)" xml:space="preserve">
-    <value>Zachowanie przy łagodnym zamykaniu, na potrzeby pracy bez nadzoru / w klastrze. (Przechowywanie dzienników znajduje się na stronie Dzienniki.)</value>
+    <value>Zachowanie przy łagodnym zamykaniu, na potrzeby pracy bez nadzoru / w klastrze. (Przechowywanie dzienników znajduje się na stronie Rejestrowanie w dzienniku.)</value>
   </data>
   <data name="Greylisting" xml:space="preserve">
     <value>Greylisting</value>
@@ -3673,7 +3673,7 @@ Zweryfikowany instalator zostaje przekazany pomocnikowi aktualizacji: usługa je
     <value>Jest powiązany z {0}, co zatrzymuje go na tym komputerze - i to jest obsługiwany sposób uruchamiania go bez TLS. Aby oferować STARTTLS, należy przypisać certyfikat do portu skrzynek pocztowych.</value>
   </data>
   <data name="JSON API under /api/v1 plus the browser-based Control Deck at the listener root. Authenticated with the administrator password, or with a scoped API key - a key can be read-only, limited to named domains and source addresses, given an expiry and revoked on its own, none of which the administrator password can. Keys are managed on the REST API keys page. TLS is required unless the listener is bound to 127.0.0.1." xml:space="preserve">
-    <value>API w formacie JSON pod /api/v1 oraz działający w przeglądarce Control Deck w katalogu głównym nasłuchu. Uwierzytelnianie hasłem administratora albo kluczem API o ograniczonym zakresie - klucz może być tylko do odczytu, ograniczony do wskazanych domen i adresów źródłowych, opatrzony terminem wygaśnięcia i unieważniony osobno, czego hasło administratora nie potrafi. Kluczami zarządza się na stronie Klucze API REST. TLS jest wymagany, chyba że nasłuch jest powiązany z 127.0.0.1.</value>
+    <value>API w formacie JSON pod /api/v1 oraz działający w przeglądarce Control Deck w katalogu głównym nasłuchu. Uwierzytelnianie hasłem administratora albo kluczem API o ograniczonym zakresie - klucz może być tylko do odczytu, ograniczony do wskazanych domen i adresów źródłowych, opatrzony terminem wygaśnięcia i unieważniony osobno, czego hasło administratora nie potrafi. Kluczami zarządza się na stronie Klucze REST API. TLS jest wymagany, chyba że nasłuch jest powiązany z 127.0.0.1.</value>
   </data>
   <data name="JWK Set URL (the provider's published signing keys; empty = the key file only)" xml:space="preserve">
     <value>Adres URL zestawu JWK (opublikowane klucze podpisujące dostawcy; puste = tylko plik klucza)</value>
@@ -5340,7 +5340,7 @@ Do czasu wznowienia nie będą przyjmowane nowe połączenia ani dostarczana poc
     <value>Progressive Robot Ltd to firma inżynierii oprogramowania, która tworzy i modernizuje oprogramowanie produkcyjne — bierze dojrzałe systemy działające w praktyce i doprowadza je do dzisiejszych standardów bezpieczeństwa, niezawodności i narzędzi.</value>
   </data>
   <data name="Prometheus metrics (/metrics), OpenTelemetry export of traces, metrics and logs (one endpoint per signal, each off until set), a slow-query log, and JSON-structured log output for log aggregators (on the Logging page)." xml:space="preserve">
-    <value>Metryki Prometheusa (/metrics), eksport śladów, metryk i dzienników przez OpenTelemetry (jeden punkt końcowy na sygnał, każdy wyłączony do czasu ustawienia), dziennik wolnych zapytań oraz zapis dzienników w strukturze JSON dla systemów agregujących dzienniki (na stronie Dzienniki).</value>
+    <value>Metryki Prometheusa (/metrics), eksport śladów, metryk i dzienników przez OpenTelemetry (jeden punkt końcowy na sygnał, każdy wyłączony do czasu ustawienia), dziennik wolnych zapytań oraz zapis dzienników w strukturze JSON dla systemów agregujących dzienniki (na stronie Rejestrowanie w dzienniku).</value>
   </data>
   <data name="Prometheus metrics, health endpoints and the REST API are enabled here." xml:space="preserve">
     <value>Tutaj włącza się metryki Prometheusa, punkty końcowe stanu i REST API.</value>
@@ -5467,7 +5467,7 @@ STARY rekord DNS ({2}) należy pozostawić opublikowany jeszcze przez co najmnie
     <value>Administracyjne REST API + Web Control Deck</value>
   </data>
   <data name="REST administration API, Prometheus metrics and remote script management. The public web services listener (autoconfiguration, MTA-STS hosting) is on the Web services &amp; autoconfiguration page; OAuth2 token authentication is on the Authentication page." xml:space="preserve">
-    <value>Administracyjne REST API, metryki Prometheusa i zdalne zarządzanie skryptami. Publiczny nasłuch usług sieciowych (autokonfiguracja, udostępnianie MTA-STS) znajduje się na stronie Usługi sieciowe i autokonfiguracja; uwierzytelnianie tokenami OAuth2 - na stronie Uwierzytelnianie.</value>
+    <value>Administracyjne REST API, metryki Prometheusa i zdalne zarządzanie skryptami. Publiczny nasłuch usług sieciowych (autokonfiguracja, udostępnianie MTA-STS) znajduje się na stronie Usługi webowe i autokonfiguracja; uwierzytelnianie tokenami OAuth2 - na stronie Uwierzytelnianie.</value>
   </data>
   <data name="REST listener settings…" xml:space="preserve">
     <value>Ustawienia nasłuchu REST…</value>
@@ -9473,7 +9473,7 @@ Będzie próbował dalej podczas korzystania z aplikacji.</value>
     <value>skanery</value>
   </data>
   <data name="script/save slow" xml:space="preserve">
-    <value>wolny skrypt lub zapis</value>
+    <value>wolny etap script/save</value>
   </data>
   <data name="scrypt (memory-hard, RFC 7914)" xml:space="preserve">
     <value>scrypt (wymagający dużej pamięci, RFC 7914)</value>

--- a/hmailserver/source/Tools/ControlPanel/Resources/Strings.pt-BR.resx
+++ b/hmailserver/source/Tools/ControlPanel/Resources/Strings.pt-BR.resx
@@ -2,7 +2,7 @@
 <!-- Copyright (c) 2026 Christopher Holloway / Progressive Robot Ltd and the hMailServer contributors
      SPDX-License-Identifier: AGPL-3.0-or-later -->
 <root>
-  <!-- X: the X catalogue. Keys are the English text; values are the translation. Each caption's Alt key (the letter after _) is chosen for X and checked by build/check-mnemonics.py. -->
+  <!-- Português (Brasil): the Português (Brasil) catalogue. Keys are the English text; values are the translation. Each caption's Alt key (the letter after _) is chosen for Português (Brasil) and checked by build/check-mnemonics.py. -->
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
   </resheader>
@@ -1059,7 +1059,7 @@ O Control Panel só consegue ler arquivos de mensagens quando roda na mesma máq
     <value>Uma opção mais antiga e mais fraca: um código de uso único pedido após a senha ao entrar NESTE Control Panel, verificado pela própria ferramenta depois que o servidor já aceitou a senha. O segredo é armazenado por máquina em HKLM, então ativar ou desativar exige direitos de administrador local, e não faz nada pela API REST ou por scripts que usam a API COM. Prefira o fator imposto pelo servidor acima; este permanece para instalações existentes.</value>
   </data>
   <data name="An override replaces the global ceilings for that address; 0:0 exempts it entirely. Without the optional :hours the override uses the global period. A malformed line is ignored with a log entry and the global limit still applies to that account. Comment lines in this INI section are not shown here and are dropped if the list is saved." xml:space="preserve">
-    <value>Uma exceção substitui os tetos globais para aquele endereço; 0:0 o isenta por completo. Sem o :horas opcional, a exceção usa o período global. Uma linha malformada é ignorada com uma entrada de log e o limite global continua valendo para aquela conta. Linhas de comentário nesta seção INI não são mostradas aqui e são descartadas se a lista for salva.</value>
+    <value>Uma exceção substitui os tetos globais para aquele endereço; 0:0 o isenta por completo. Sem o :hours opcional, a exceção usa o período global. Uma linha malformada é ignorada com uma entrada de log e o limite global continua valendo para aquela conta. Linhas de comentário nesta seção INI não são mostradas aqui e são descartadas se a lista for salva.</value>
   </data>
   <data name="An unexpected error occurred:&#10;&#10;{0}&#10;&#10;The full details were written to:&#10;{1}&#10;&#10;Restart the Control Panel now? Choose No to try to keep working." xml:space="preserve">
     <value>Ocorreu um erro inesperado:
@@ -3284,7 +3284,7 @@ Nenhum e-mail é tocado - o índice é derivado deles - mas até a reconstruçã
     <value>Ir para a página relacionada {0}</value>
   </data>
   <data name="Graceful shutdown behaviour for unattended / clustered operation. (Log retention is on the Logging page.)" xml:space="preserve">
-    <value>Comportamento de desligamento gracioso para operação não assistida / em cluster. (A retenção de logs fica na página Logs.)</value>
+    <value>Comportamento de desligamento gracioso para operação não assistida / em cluster. (A retenção de logs fica na página Registro em log.)</value>
   </data>
   <data name="Greylisting" xml:space="preserve">
     <value>Greylisting</value>
@@ -5196,7 +5196,7 @@ Nenhuma conexão nova será aceita e nenhum e-mail será entregue até que ele s
     <value>Limites de envio por conta</value>
   </data>
   <data name="Per-address overrides, one per line: address=messages:recipients[:hours]" xml:space="preserve">
-    <value>Substituições por endereço, uma por linha: endereço=mensagens:destinatários[:horas]</value>
+    <value>Substituições por endereço, uma por linha: address=messages:recipients[:hours]</value>
   </data>
   <data name="Per-name lockout" xml:space="preserve">
     <value>Bloqueio por nome</value>
@@ -5340,7 +5340,7 @@ Nenhuma conexão nova será aceita e nenhum e-mail será entregue até que ele s
     <value>A Progressive Robot Ltd é uma empresa de engenharia de software que constrói e moderniza software de produção — pega sistemas maduros, do mundo real, e os traz aos padrões atuais de segurança, confiabilidade e ferramental.</value>
   </data>
   <data name="Prometheus metrics (/metrics), OpenTelemetry export of traces, metrics and logs (one endpoint per signal, each off until set), a slow-query log, and JSON-structured log output for log aggregators (on the Logging page)." xml:space="preserve">
-    <value>Métricas do Prometheus (/metrics), exportação de rastreamentos, métricas e logs pelo OpenTelemetry (um endpoint por sinal, cada um desligado até ser definido), um log de consultas lentas e saída de log estruturada em JSON para agregadores de logs (na página Logs).</value>
+    <value>Métricas do Prometheus (/metrics), exportação de rastreamentos, métricas e logs pelo OpenTelemetry (um endpoint por sinal, cada um desligado até ser definido), um log de consultas lentas e saída de log estruturada em JSON para agregadores de logs (na página Registro em log).</value>
   </data>
   <data name="Prometheus metrics, health endpoints and the REST API are enabled here." xml:space="preserve">
     <value>As métricas do Prometheus, os endpoints de saúde e a API REST são ativados aqui.</value>
@@ -5959,7 +5959,7 @@ Continuar?</value>
     <value>Execute uma prévia primeiro: as opções mudaram desde a última, então ela não descreve mais o que isto faria.</value>
   </data>
   <data name="Run an external command; a configured return value indicates an infected message. Use %FILE% where the file to scan should be passed on the command line. For engines without a CLI (HTTP/API, DLP, SIEM), use an OnAcceptMessage handler on the Event scripts page instead." xml:space="preserve">
-    <value>Execute um comando externo; um valor de retorno configurado indica uma mensagem infectada. Use %FILE% onde o arquivo a verificar deve ser passado na linha de comando. Para mecanismos sem CLI (HTTP/API, DLP, SIEM), use em vez disso um manipulador OnAcceptMessage na página Scripts de evento.</value>
+    <value>Execute um comando externo; um valor de retorno configurado indica uma mensagem infectada. Use %FILE% onde o arquivo a verificar deve ser passado na linha de comando. Para mecanismos sem CLI (HTTP/API, DLP, SIEM), use em vez disso um manipulador OnAcceptMessage na página Scripts de eventos.</value>
   </data>
   <data name="Run anti-spam on downloaded mail" xml:space="preserve">
     <value>Executar o anti-spam nos e-mails baixados</value>
@@ -5986,7 +5986,7 @@ Continuar?</value>
     <value>Executando os diagnósticos...</value>
   </data>
   <data name="Runs event scripts (OnAcceptMessage, OnDeliveryStart...) from the Events folder; the script itself is edited on the Event scripts page. The engine reloads when you save." xml:space="preserve">
-    <value>Executa scripts de evento (OnAcceptMessage, OnDeliveryStart...) da pasta Events; o próprio script é editado na página Scripts de evento. O mecanismo recarrega quando você salva.</value>
+    <value>Executa scripts de evento (OnAcceptMessage, OnDeliveryStart...) da pasta Events; o próprio script é editado na página Scripts de eventos. O mecanismo recarrega quando você salva.</value>
   </data>
   <data name="Runs the same steps the server runs, in the same order, using the values in the editors above as they stand: connect, protect the transport, bind the service credential, search for the user - and, only if a password is typed below, bind as that user to prove it. The password is used once and never stored, and the test refuses to run any configuration that would put a password on the network unprotected. One honest caveat: the test runs from this computer, so a firewall that treats this machine and the hMailServer service differently can make the two disagree." xml:space="preserve">
     <value>Executa os mesmos passos que o servidor executa, na mesma ordem, usando os valores dos editores acima como estão: conectar, proteger o transporte, fazer o bind com a credencial de serviço, buscar o usuário - e, somente se uma senha for digitada abaixo, fazer o bind como esse usuário para prová-lo. A senha é usada uma vez e nunca armazenada, e o teste se recusa a executar qualquer configuração que colocaria uma senha desprotegida na rede. Uma ressalva honesta: o teste roda a partir deste computador, então um firewall que trate esta máquina e o serviço hMailServer de forma diferente pode fazer os dois discordarem.</value>
@@ -9473,7 +9473,7 @@ Nenhuma mensagem é excluída e nenhuma conta é removida. Continuar?</value>
     <value>verificadores</value>
   </data>
   <data name="script/save slow" xml:space="preserve">
-    <value>script/salvamento lento</value>
+    <value>script/save lento</value>
   </data>
   <data name="scrypt (memory-hard, RFC 7914)" xml:space="preserve">
     <value>scrypt (exigente em memória, RFC 7914)</value>

--- a/hmailserver/source/Tools/ControlPanel/Resources/Strings.ru.resx
+++ b/hmailserver/source/Tools/ControlPanel/Resources/Strings.ru.resx
@@ -2,7 +2,7 @@
 <!-- Copyright (c) 2026 Christopher Holloway / Progressive Robot Ltd and the hMailServer contributors
      SPDX-License-Identifier: AGPL-3.0-or-later -->
 <root>
-  <!-- X: the X catalogue. Keys are the English text; values are the translation. Each caption's Alt key (the letter after _) is chosen for X and checked by build/check-mnemonics.py. -->
+  <!-- Русский: the Русский catalogue. Keys are the English text; values are the translation. Each caption's Alt key (the letter after _) is chosen for Русский and checked by build/check-mnemonics.py. -->
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
   </resheader>
@@ -1059,7 +1059,7 @@ Control Panel может читать файлы сообщений только
     <value>Более старый и более слабый вариант: одноразовый код, запрашиваемый после пароля при входе именно в ЭТОТ Control Panel и проверяемый самим приложением уже после того, как сервер принял пароль. Секрет хранится отдельно на каждом компьютере в HKLM, поэтому его включение и отключение требуют прав локального администратора, а для REST API и для сценариев на COM API он не даёт ничего. Предпочитайте фактор, обеспечиваемый сервером, выше; этот остаётся ради существующих установок.</value>
   </data>
   <data name="An override replaces the global ceilings for that address; 0:0 exempts it entirely. Without the optional :hours the override uses the global period. A malformed line is ignored with a log entry and the global limit still applies to that account. Comment lines in this INI section are not shown here and are dropped if the list is saved." xml:space="preserve">
-    <value>Переопределение заменяет глобальные пределы для этого адреса; 0:0 полностью освобождает его от них. Без необязательной части :часы переопределение использует глобальный период. Строка с ошибкой формата игнорируется с записью в журнал, и к этой учётной записи по-прежнему применяется глобальное ограничение. Строки комментариев в этом разделе INI здесь не показываются и теряются при сохранении списка.</value>
+    <value>Переопределение заменяет глобальные пределы для этого адреса; 0:0 полностью освобождает его от них. Без необязательной части :hours переопределение использует глобальный период. Строка с ошибкой формата игнорируется с записью в журнал, и к этой учётной записи по-прежнему применяется глобальное ограничение. Строки комментариев в этом разделе INI здесь не показываются и теряются при сохранении списка.</value>
   </data>
   <data name="An unexpected error occurred:&#10;&#10;{0}&#10;&#10;The full details were written to:&#10;{1}&#10;&#10;Restart the Control Panel now? Choose No to try to keep working." xml:space="preserve">
     <value>Произошла непредвиденная ошибка:
@@ -1351,7 +1351,7 @@ Control Panel может читать файлы сообщений только
     <value>Прежде чем копировать — </value>
   </data>
   <data name="Between the 354 and the 250 the server runs the accept pipeline - spam tests, message modifications, archiving, the OnAcceptMessage script and the database save - on a bounded pool of threads, and replies only when it finishes. The log times each stage. Read it as a sequence and look for the last line written: the stage that is stuck is the one after it. Two stages announce themselves with a start line (spam-protection and script/save); message modifications do not, so a stall there shows as &quot;done spam-protection&quot; followed by silence. A stage taking ten seconds or more is logged at application level even without debug logging." xml:space="preserve">
-    <value>Между ответами 354 и 250 сервер выполняет конвейер приёма — проверки на спам, изменения сообщения, архивирование, сценарий OnAcceptMessage и сохранение в базу данных — на ограниченном пуле потоков и отвечает лишь после того, как закончит. Журнал отмечает время каждого этапа. Читайте его как последовательность и смотрите на последнюю записанную строку: застрял тот этап, который идёт после неё. Два этапа объявляют о себе строкой начала (защита от спама и сценарий/сохранение), а изменения сообщения — нет, поэтому затор на них выглядит как «done spam-protection», за которым следует тишина. Этап, занявший десять секунд или больше, записывается на уровне журнала приложения даже без отладочного журналирования.</value>
+    <value>Между ответами 354 и 250 сервер выполняет конвейер приёма — проверки на спам, изменения сообщения, архивирование, сценарий OnAcceptMessage и сохранение в базу данных — на ограниченном пуле потоков и отвечает лишь после того, как закончит. Журнал отмечает время каждого этапа. Читайте его как последовательность и смотрите на последнюю записанную строку: застрял тот этап, который идёт после неё. Два этапа объявляют о себе строкой начала (spam-protection и script/save), а изменения сообщения — нет, поэтому затор на них выглядит как «done spam-protection», за которым следует тишина. Этап, занявший десять секунд или больше, записывается на уровне журнала приложения даже без отладочного журналирования.</value>
   </data>
   <data name="Biased upwards on purpose: refusing early costs delivery latency and nothing else, because the refusal is temporary and a sending server retries for days, while a volume that reaches zero costs a database that will not open and a service that will not start." xml:space="preserve">
     <value>Значение намеренно смещено в большую сторону: ранний отказ стоит только задержки доставки и ничего больше, потому что отказ временный, а отправляющий сервер повторяет попытки сутками; том же, свободное место на котором дошло до нуля, стоит базы данных, которая не откроется, и службы, которая не запустится.</value>
@@ -2636,7 +2636,7 @@ Control Panel может читать файлы сообщений только
     <value>Отключать клиентов, отправляющих слишком много недопустимых команд</value>
   </data>
   <data name="Discovers and enforces recipient MTA-STS policies before delivering over TLS (RFC 8461). To publish a policy for your own domains, see the Web services &amp; autoconfiguration page." xml:space="preserve">
-    <value>Обнаруживает и применяет политики MTA-STS получателя перед доставкой по TLS (RFC 8461). Чтобы опубликовать политику для своих доменов, откройте страницу «Веб-службы и автонастройка».</value>
+    <value>Обнаруживает и применяет политики MTA-STS получателя перед доставкой по TLS (RFC 8461). Чтобы опубликовать политику для своих доменов, откройте страницу «Веб-службы и автоконфигурация».</value>
   </data>
   <data name="Disk space" xml:space="preserve">
     <value>Дисковое пространство</value>
@@ -3284,7 +3284,7 @@ Control Panel может читать файлы сообщений только
     <value>Перейти на связанную страницу {0}</value>
   </data>
   <data name="Graceful shutdown behaviour for unattended / clustered operation. (Log retention is on the Logging page.)" xml:space="preserve">
-    <value>Поведение при корректном завершении работы для необслуживаемой / кластерной эксплуатации. (Срок хранения журналов задаётся на странице «Журналы».)</value>
+    <value>Поведение при корректном завершении работы для необслуживаемой / кластерной эксплуатации. (Срок хранения журналов задаётся на странице «Журналирование».)</value>
   </data>
   <data name="Greylisting" xml:space="preserve">
     <value>Серые списки</value>
@@ -5467,7 +5467,7 @@ Control Panel может читать файлы сообщений только
     <value>REST API администрирования + Web Control Deck</value>
   </data>
   <data name="REST administration API, Prometheus metrics and remote script management. The public web services listener (autoconfiguration, MTA-STS hosting) is on the Web services &amp; autoconfiguration page; OAuth2 token authentication is on the Authentication page." xml:space="preserve">
-    <value>REST API администрирования, метрики Prometheus и удалённое управление сценариями. Общедоступный прослушиватель веб-служб (автонастройка, размещение MTA-STS) находится на странице «Веб-службы и автонастройка»; аутентификация по токенам OAuth2 — на странице «Аутентификация».</value>
+    <value>REST API администрирования, метрики Prometheus и удалённое управление сценариями. Общедоступный прослушиватель веб-служб (автонастройка, размещение MTA-STS) находится на странице «Веб-службы и автоконфигурация»; аутентификация по токенам OAuth2 — на странице «Аутентификация».</value>
   </data>
   <data name="REST listener settings…" xml:space="preserve">
     <value>Параметры прослушивателя REST…</value>
@@ -8333,7 +8333,7 @@ SMTP 25 и 587, POP3 110, IMAP 143 — без защиты подключени�
     <value>Что делает сервер по мере заполнения тома хранилища сообщений. Оба значения - абсолютные мегабайты, а не проценты, потому что вместится ли следующее сообщение, решает число оставшихся байтов, а не их доля от тома. Применяется после перезапуска службы.</value>
   </data>
   <data name="What the server writes to its log files (viewable on the Live logs page)." xml:space="preserve">
-    <value>Что сервер пишет в файлы журналов (смотреть на странице «Живые журналы»).</value>
+    <value>Что сервер пишет в файлы журналов (смотреть на странице «Журналы в реальном времени»).</value>
   </data>
   <data name="What this key is for, e.g. &quot;Grafana probe&quot;" xml:space="preserve">
     <value>Для чего этот ключ, например «Grafana probe»</value>
@@ -9473,7 +9473,7 @@ SMTP 25 и 587, POP3 110, IMAP 143 — без защиты подключени�
     <value>сканеров</value>
   </data>
   <data name="script/save slow" xml:space="preserve">
-    <value>медленно работают сценарии и сохранение</value>
+    <value>этап script/save выполняется медленно</value>
   </data>
   <data name="scrypt (memory-hard, RFC 7914)" xml:space="preserve">
     <value>scrypt (требователен к памяти, RFC 7914)</value>

--- a/hmailserver/source/Tools/ControlPanel/Resources/Strings.sv.resx
+++ b/hmailserver/source/Tools/ControlPanel/Resources/Strings.sv.resx
@@ -1059,7 +1059,7 @@ Kontrollpanelen kan bara läsa meddelandefiler när den körs på samma dator so
     <value>Ett äldre, svagare alternativ: en engångskod som efterfrågas efter lösenordet vid inloggning i DEN HÄR Kontrollpanelen, kontrollerad av verktyget självt efter att servern redan har godtagit lösenordet. Hemligheten lagras per dator under HKLM, så att aktivera eller inaktivera den kräver lokala administratörsrättigheter, och den gör inget för REST API:et eller för skript som använder COM API:et. Föredra den serverkontrollerade faktorn ovan; den här finns kvar för befintliga installationer.</value>
   </data>
   <data name="An override replaces the global ceilings for that address; 0:0 exempts it entirely. Without the optional :hours the override uses the global period. A malformed line is ignored with a log entry and the global limit still applies to that account. Comment lines in this INI section are not shown here and are dropped if the list is saved." xml:space="preserve">
-    <value>En åsidosättning ersätter de globala taken för den adressen; 0:0 undantar den helt. Utan det valfria :timmar använder åsidosättningen den globala perioden. En felformad rad ignoreras med en loggpost och den globala gränsen gäller fortfarande för det kontot. Kommentarsrader i den här INI-sektionen visas inte här och tas bort om listan sparas.</value>
+    <value>En åsidosättning ersätter de globala taken för den adressen; 0:0 undantar den helt. Utan det valfria :hours använder åsidosättningen den globala perioden. En felformad rad ignoreras med en loggpost och den globala gränsen gäller fortfarande för det kontot. Kommentarsrader i den här INI-sektionen visas inte här och tas bort om listan sparas.</value>
   </data>
   <data name="An unexpected error occurred:&#10;&#10;{0}&#10;&#10;The full details were written to:&#10;{1}&#10;&#10;Restart the Control Panel now? Choose No to try to keep working." xml:space="preserve">
     <value>Ett oväntat fel inträffade:
@@ -1201,7 +1201,7 @@ Starta om Kontrollpanelen nu? Välj Nej för att försöka fortsätta arbeta.</v
     <value>Högst {0} skanningar körs samtidigt. Utöver det väntar leveranstrådarna — och efter 60 sekunders väntan ger servern upp väntandet och skannar ändå, så en långsam skanner visar sig som långsam post snarare än som oskannad post.</value>
   </data>
   <data name="At your DNS host, publish a TXT record named &lt;selector&gt;._domainkey.&lt;domain&gt; containing the public key (v=DKIM1; k=rsa; p=...). This page looks the record up through the Windows resolver, and where the key file is readable it also checks that the published key is the RIGHT key - a wrong value cannot be fixed by waiting." xml:space="preserve">
-    <value>Publicera hos din DNS-leverantör en TXT-post med namnet &lt;selektor&gt;._domainkey.&lt;domän&gt; som innehåller den publika nyckeln (v=DKIM1; k=rsa; p=...). Den här sidan slår upp posten genom Windows-resolvern, och där nyckelfilen är läsbar kontrollerar den också att den publicerade nyckeln är RÄTT nyckel - ett felaktigt värde kan inte åtgärdas genom att vänta.</value>
+    <value>Publicera hos din DNS-leverantör en TXT-post med namnet &lt;selector&gt;._domainkey.&lt;domain&gt; som innehåller den publika nyckeln (v=DKIM1; k=rsa; p=...). Den här sidan slår upp posten genom Windows-resolvern, och där nyckelfilen är läsbar kontrollerar den också att den publicerade nyckeln är RÄTT nyckel - ett felaktigt värde kan inte åtgärdas genom att vänta.</value>
   </data>
   <data name="Attachment blocking is switched on with no patterns to block, so it does nothing at all." xml:space="preserve">
     <value>Bilageblockering är påslagen utan några mönster att blockera, så den gör ingenting alls.</value>
@@ -1399,7 +1399,7 @@ Starta om Kontrollpanelen nu? Välj Nej för att försöka fortsätta arbeta.</v
     <value>Båda trösklarna är 0, så ingen poäng kan markera eller avvisa något - servern testar dem med "större än 0" innan den använder dem. Den slutar också testa så snart den löpande summan når den högre tröskeln, som är 0, så exakt en kontroll körs i varje fas och dess resultat kastas.</value>
   </data>
   <data name="Bounces and virus notifications are sent from mailer-daemon@&lt;domain&gt;. This overrides the &lt;domain&gt; part. Left empty, the server uses its own host name, then the local domain the message involves, then this computer's name. It is not a delivery setting and does not change where mail is routed." xml:space="preserve">
-    <value>Studsar och virusaviseringar skickas från mailer-daemon@&lt;domän&gt;. Detta åsidosätter delen &lt;domän&gt;. Lämnat tomt använder servern sitt eget värdnamn, sedan den lokala domän meddelandet gäller, sedan den här datorns namn. Det är inte en leveransinställning och ändrar inte vart post dirigeras.</value>
+    <value>Studsar och virusaviseringar skickas från mailer-daemon@&lt;domain&gt;. Detta åsidosätter delen &lt;domain&gt;. Lämnat tomt använder servern sitt eget värdnamn, sedan den lokala domän meddelandet gäller, sedan den här datorns namn. Det är inte en leveransinställning och ändrar inte vart post dirigeras.</value>
   </data>
   <data name="Browse Active Directory" xml:space="preserve">
     <value>Bläddra i Active Directory</value>
@@ -2192,7 +2192,7 @@ Den förberedda selektorn "{0}" tas bort från serverkonfigurationen; signeringe
     <value>Räknas per konto från den senaste inloggning som tilläts, så ett avvisat försök skjuter inte nästa längre bort. Den annonseras bara medan den är satt, eftersom att annonsera en gräns som inte upprätthålls är värre än att inte annonsera något.</value>
   </data>
   <data name="Counted per connecting IP address across every protocol that authenticates - SMTP AUTH, POP3, IMAP, ManageSieve and the REST API all feed the same counter. On reaching the limit the server clears that address's counted failures and creates an IP range named &quot;Auto-ban: &lt;user&gt;&quot; at priority 100 covering that one address, which expires on its own." xml:space="preserve">
-    <value>Räknas per anslutande IP-adress över varje protokoll som autentiserar - SMTP AUTH, POP3, IMAP, ManageSieve och REST API:et matar alla samma räknare. När gränsen nås nollställer servern adressens räknade misslyckanden och skapar ett IP-intervall med namnet "Auto-ban: &lt;användare&gt;" med prioritet 100 som täcker just den adressen, och som går ut av sig självt.</value>
+    <value>Räknas per anslutande IP-adress över varje protokoll som autentiserar - SMTP AUTH, POP3, IMAP, ManageSieve och REST API:et matar alla samma räknare. När gränsen nås nollställer servern adressens räknade misslyckanden och skapar ett IP-intervall med namnet "Auto-ban: &lt;user&gt;" med prioritet 100 som täcker just den adressen, och som går ut av sig självt.</value>
   </data>
   <data name="Counted per user name rather than per address, across every protocol that authenticates, so a botnet spreading its guesses over thousands of addresses still locks the mailbox it is guessing at. A locked name is refused with the ordinary invalid-credentials reply and cannot be unlocked by typing the right password - the lock is checked first - so the ceiling is worth setting with the cost in mind. Failures against a name that does not exist lock that name too, deliberately: doing otherwise would let an attacker use the lockout to discover which accounts are real." xml:space="preserve">
     <value>Räknas per användarnamn snarare än per adress, över varje protokoll som autentiserar, så ett botnät som sprider sina gissningar över tusentals adresser låser ändå den brevlåda det gissar på. Ett låst namn avvisas med det vanliga svaret för ogiltiga uppgifter och kan inte låsas upp genom att skriva rätt lösenord - låset kontrolleras först - så taket är värt att sätta med kostnaden i åtanke. Misslyckanden mot ett namn som inte finns låser det namnet också, med avsikt: annars kunde en angripare använda utestängningen för att ta reda på vilka konton som är riktiga.</value>
@@ -3338,7 +3338,7 @@ Ingen post rörs - indexet härleds från den - men tills ombyggnaden kommer ika
     <value>Lämnar varje godtaget meddelande till en motor över HTTP och använder poängen den returnerar. Meddelandet är begärans kropp och kuvertet, den anslutande adressen och HELO reser som begäranrubriker, vilket är vad rspamds egen kontrollslutpunkt redan förväntar sig - så att peka detta på rspamd kräver ingen adapter, och att peka det på något du skrivit själv kräver bara ett program som svarar med JSON.</value>
   </data>
   <data name="Hands mail clients the right host names, ports and security settings automatically: Thunderbird-style autoconfig and Outlook autodiscover, for every local domain. Point autoconfig.&lt;domain&gt; and autodiscover.&lt;domain&gt; at this server in DNS." xml:space="preserve">
-    <value>Ger e-postklienter rätt värdnamn, portar och säkerhetsinställningar automatiskt: autoconfig i Thunderbirds stil och Outlooks autodiscover, för varje lokal domän. Peka autoconfig.&lt;domän&gt; och autodiscover.&lt;domän&gt; på den här servern i DNS.</value>
+    <value>Ger e-postklienter rätt värdnamn, portar och säkerhetsinställningar automatiskt: autoconfig i Thunderbirds stil och Outlooks autodiscover, för varje lokal domän. Peka autoconfig.&lt;domain&gt; och autodiscover.&lt;domain&gt; på den här servern i DNS.</value>
   </data>
   <data name="Hands the verified installer to the update helper. The service stops and starts; if it does not come back, the previous version is reinstalled. The outcome is reported here when the service is back." xml:space="preserve">
     <value>Lämnar över det verifierade installationsprogrammet till uppdateringshjälpen. Tjänsten stoppas och startas; om den inte kommer tillbaka installeras den tidigare versionen om. Resultatet rapporteras här när tjänsten är tillbaka.</value>
@@ -3563,7 +3563,7 @@ Ingen post rörs - indexet härleds från den - men tills ombyggnaden kommer ika
     <value>Ignoreras av servern - den sparade digesten är inte ett användbart SHA-256-värde, så den här sektionen autentiserar ingenting. Återkalla den och skapa en ersättning.</value>
   </data>
   <data name="In a DNSSEC-signed zone, publish a TLSA record (usually usage 3, selector 1, matching type 1 - '3 1 1' with the SHA-256 of your certificate's public key) at _25._tcp.&lt;mx-host&gt; for each MX host. Verify with: nslookup -type=TLSA _25._tcp.&lt;mx-host&gt;. hMailServer cannot publish DNS records or sign your zone, and this panel has no TLSA lookup to check them with." xml:space="preserve">
-    <value>Publicera i en DNSSEC-signerad zon en TLSA-post (vanligen usage 3, selector 1, matching type 1 - '3 1 1' med SHA-256 av ditt certifikats publika nyckel) på _25._tcp.&lt;mx-värd&gt; för varje MX-värd. Verifiera med: nslookup -type=TLSA _25._tcp.&lt;mx-värd&gt;. hMailServer kan inte publicera DNS-poster eller signera din zon, och den här panelen har ingen TLSA-uppslagning att kontrollera dem med.</value>
+    <value>Publicera i en DNSSEC-signerad zon en TLSA-post (vanligen usage 3, selector 1, matching type 1 - '3 1 1' med SHA-256 av ditt certifikats publika nyckel) på _25._tcp.&lt;mx-host&gt; för varje MX-värd. Verifiera med: nslookup -type=TLSA _25._tcp.&lt;mx-host&gt;. hMailServer kan inte publicera DNS-poster eller signera din zon, och den här panelen har ingen TLSA-uppslagning att kontrollera dem med.</value>
   </data>
   <data name="In queue" xml:space="preserve">
     <value>I kö</value>
@@ -3697,7 +3697,7 @@ Det verifierade installationsprogrammet lämnas över till uppdateringshjälpen:
     <value>Att behålla flera generationer av meddelanden kräver komprimering: utan 'Komprimera målfilerna (zip)' skriver varje säkerhetskopiering sina meddelandefiler till samma DataBackup-mapp och skriver över den förra körningens, så gallringen kan bara behålla generationer av de små arkiven med inställningar och domäner.</value>
   </data>
   <data name="Keeps a copy of every message received over SMTP in a folder tree, in addition to delivering it as normal - it does not divert or hold back mail. Mail from a local sender is filed under &lt;domain&gt;\&lt;mailbox&gt;, mail from elsewhere under Inbound, and messages with no envelope sender (bounces and delivery reports) under Error, plus a copy in the folder of each local recipient." xml:space="preserve">
-    <value>Behåller en kopia av varje meddelande som tas emot över SMTP i ett mappträd, utöver att leverera det som vanligt - det avleder eller håller inte tillbaka post. Post från en lokal avsändare arkiveras under &lt;domän&gt;\&lt;brevlåda&gt;, post från annat håll under Inbound, och meddelanden utan kuvertavsändare (studsar och leveransrapporter) under Error, plus en kopia i mappen för varje lokal mottagare.</value>
+    <value>Behåller en kopia av varje meddelande som tas emot över SMTP i ett mappträd, utöver att leverera det som vanligt - det avleder eller håller inte tillbaka post. Post från en lokal avsändare arkiveras under &lt;domain&gt;\&lt;mailbox&gt;, post från annat håll under Inbound, och meddelanden utan kuvertavsändare (studsar och leveransrapporter) under Error, plus en kopia i mappen för varje lokal mottagare.</value>
   </data>
   <data name="Key file present" xml:space="preserve">
     <value>Nyckelfil finns</value>
@@ -4948,7 +4948,7 @@ Det verifierade installationsprogrammet lämnas över till uppdateringshjälpen:
     <value>Öppna TCP/IP-portar, som äger säkerhetsinställningen per lyssnare</value>
   </data>
   <data name="Open an issue with: the log from the 354 (or from the delivery attempt) onwards, including the stage timing lines; the ERROR_hmailserver_&lt;date&gt;.log for the same window; which scanners and event scripts are enabled; and whether the message eventually arrives, arrives twice, or never arrives." xml:space="preserve">
-    <value>Öppna ett ärende med: loggen från 354 (eller från leveransförsöket) och framåt, inklusive stegtidsraderna; ERROR_hmailserver_&lt;datum&gt;.log för samma fönster; vilka skannrar och händelseskript som är aktiverade; och om meddelandet till slut kommer fram, kommer fram två gånger, eller aldrig kommer fram.</value>
+    <value>Öppna ett ärende med: loggen från 354 (eller från leveransförsöket) och framåt, inklusive stegtidsraderna; ERROR_hmailserver_&lt;date&gt;.log för samma fönster; vilka skannrar och händelseskript som är aktiverade; och om meddelandet till slut kommer fram, kommer fram två gånger, eller aldrig kommer fram.</value>
   </data>
   <data name="Open log folder" xml:space="preserve">
     <value>Öppna loggmappen</value>
@@ -5196,7 +5196,7 @@ Inga nya anslutningar tas emot och ingen post levereras förrän den återupptas
     <value>Sändgränser per konto</value>
   </data>
   <data name="Per-address overrides, one per line: address=messages:recipients[:hours]" xml:space="preserve">
-    <value>Åsidosättningar per adress, en per rad: adress=meddelanden:mottagare[:timmar]</value>
+    <value>Åsidosättningar per adress, en per rad: adress=meddelanden:mottagare[:hours]</value>
   </data>
   <data name="Per-name lockout" xml:space="preserve">
     <value>Utestängning per namn</value>
@@ -5422,7 +5422,7 @@ Låt den GAMLA DNS-posten ({2}) vara publicerad i minst några dagar. Post signe
     <value>Publicerad, strängare än utgångspunkten</value>
   </data>
   <data name="Publishes https://mta-sts.&lt;domain&gt;/.well-known/mta-sts.txt so other servers require TLS when they deliver to you. Honouring other domains' policies is on the Transport security page." xml:space="preserve">
-    <value>Publicerar https://mta-sts.&lt;domän&gt;/.well-known/mta-sts.txt så att andra servrar kräver TLS när de levererar till dig. Att respektera andra domäners policyer finns på sidan Transportsäkerhet.</value>
+    <value>Publicerar https://mta-sts.&lt;domain&gt;/.well-known/mta-sts.txt så att andra servrar kräver TLS när de levererar till dig. Att respektera andra domäners policyer finns på sidan Transportsäkerhet.</value>
   </data>
   <data name="Publishing this record asks every server that delivers to {0} to e-mail you a daily report when TLS to you fails or is downgraded. The reports go to the rua= mailbox, which must exist and accept mail from strangers. This works regardless of any hMailServer setting - the senders do the reporting." xml:space="preserve">
     <value>Att publicera den här posten ber varje server som levererar till {0} att e-posta dig en daglig rapport när TLS till dig misslyckas eller nedgraderas. Rapporterna går till rua=-brevlådan, som måste finnas och ta emot post från främlingar. Detta fungerar oavsett hMailServer-inställningar - avsändarna sköter rapporteringen.</value>
@@ -6643,10 +6643,10 @@ Fortsätt?</value>
     <value>Sätt TlsRptFromAddress i sektionen [Settings] i hMailServer.ini till en brevlåda rapporter ska skickas från. Att lämna den tom är ett giltigt val - det betyder bara att den insamlade statistiken kastas och inga rapporter någonsin skickas.</value>
   </data>
   <data name="Set WebServicesHttpPort and/or WebServicesHttpsPort in hMailServer.ini so the URLs answer, then publish autoconfig.&lt;domain&gt; and autodiscover.&lt;domain&gt; DNS records for each mail domain, pointing at this server. These are address records, and this page checks TXT records only, so they cannot be confirmed from here." xml:space="preserve">
-    <value>Sätt WebServicesHttpPort och/eller WebServicesHttpsPort i hMailServer.ini så att URL:erna svarar, och publicera sedan DNS-posterna autoconfig.&lt;domän&gt; och autodiscover.&lt;domän&gt; för varje e-postdomän, pekande på den här servern. Det är adressposter, och den här sidan kontrollerar bara TXT-poster, så de kan inte bekräftas härifrån.</value>
+    <value>Sätt WebServicesHttpPort och/eller WebServicesHttpsPort i hMailServer.ini så att URL:erna svarar, och publicera sedan DNS-posterna autoconfig.&lt;domain&gt; och autodiscover.&lt;domain&gt; för varje e-postdomän, pekande på den här servern. Det är adressposter, och den här sidan kontrollerar bara TXT-poster, så de kan inte bekräftas härifrån.</value>
   </data>
   <data name="Set WebServicesHttpsPort in hMailServer.ini (RFC 8461 requires the policy over HTTPS), give the listener a certificate that covers mta-sts.&lt;domain&gt;, then for each domain publish an A/AAAA (or CNAME) record for mta-sts.&lt;domain&gt; pointing at this server and a TXT record at _mta-sts.&lt;domain&gt; (v=STSv1; id=...). This page checks the TXT record; the address record and the certificate's name coverage cannot be checked from here." xml:space="preserve">
-    <value>Sätt WebServicesHttpsPort i hMailServer.ini (RFC 8461 kräver policyn över HTTPS), ge lyssnaren ett certifikat som täcker mta-sts.&lt;domän&gt;, och publicera sedan för varje domän en A-/AAAA-post (eller CNAME) för mta-sts.&lt;domän&gt; som pekar på den här servern och en TXT-post på _mta-sts.&lt;domän&gt; (v=STSv1; id=...). Den här sidan kontrollerar TXT-posten; adressposten och certifikatets namntäckning kan inte kontrolleras härifrån.</value>
+    <value>Sätt WebServicesHttpsPort i hMailServer.ini (RFC 8461 kräver policyn över HTTPS), ge lyssnaren ett certifikat som täcker mta-sts.&lt;domain&gt;, och publicera sedan för varje domän en A-/AAAA-post (eller CNAME) för mta-sts.&lt;domain&gt; som pekar på den här servern och en TXT-post på _mta-sts.&lt;domain&gt; (v=STSv1; id=...). Den här sidan kontrollerar TXT-posten; adressposten och certifikatets namntäckning kan inte kontrolleras härifrån.</value>
   </data>
   <data name="Set a new server administration password." xml:space="preserve">
     <value>Sätt ett nytt administrationslösenord för servern.</value>
@@ -7504,7 +7504,7 @@ kunde inte läsas in. Meddelandet har troligen levererats och finns inte längre
     <value>Raderna den här sidan hänvisar till skrivs på felsökningsnivå; de långsamma skrivs också på programnivå, så med enbart programloggning ser du ändå de viktiga. Återskapa problemet en gång, läs sedan loggen. Kom ihåg att stänga av felsökningsloggningen efteråt på en upptagen server.</value>
   </data>
   <data name="The listener is configured. What remains is outside the server: publish autoconfig.&lt;domain&gt; and autodiscover.&lt;domain&gt; records for each mail domain, then test from a client machine." xml:space="preserve">
-    <value>Lyssnaren är konfigurerad. Det som återstår finns utanför servern: publicera posterna autoconfig.&lt;domän&gt; och autodiscover.&lt;domän&gt; för varje e-postdomän, och testa sedan från en klientdator.</value>
+    <value>Lyssnaren är konfigurerad. Det som återstår finns utanför servern: publicera posterna autoconfig.&lt;domain&gt; och autodiscover.&lt;domain&gt; för varje e-postdomän, och testa sedan från en klientdator.</value>
   </data>
   <data name="The lists behind the checks" xml:space="preserve">
     <value>Listorna bakom kontrollerna</value>

--- a/hmailserver/source/Tools/ControlPanel/Resources/Strings.tr.resx
+++ b/hmailserver/source/Tools/ControlPanel/Resources/Strings.tr.resx
@@ -603,7 +603,7 @@ Bu zayıf parola yine de kaydedilsin mi?</value>
     <value>ACME kapalı (AcmeEnabled=0, varsayılan); bu nedenle dışarıdan hiçbir şey gerekmez.</value>
   </data>
   <data name="ACME is switched on but no certificate has been issued yet - fullchain.pem and privkey.pem are not both in {0}. Issue happens on the server's own schedule, so this is normal for a few minutes after enabling it; if it persists, the CA could not reach this server, and the External setup page checks exactly that." xml:space="preserve">
-    <value>ACME açık ama henüz sertifika verilmemiş - fullchain.pem ve privkey.pem dosyalarının ikisi birden {0} içinde değil. Sertifika verme işlemi sunucunun kendi zamanlamasına göre olur; bu yüzden özelliği açtıktan sonraki birkaç dakika boyunca bu normaldir. Sürerse, CA bu sunucuya ulaşamamış demektir ve Harici kurulum sayfası tam olarak bunu denetler.</value>
+    <value>ACME açık ama henüz sertifika verilmemiş - fullchain.pem ve privkey.pem dosyalarının ikisi birden {0} içinde değil. Sertifika verme işlemi sunucunun kendi zamanlamasına göre olur; bu yüzden özelliği açtıktan sonraki birkaç dakika boyunca bu normaldir. Sürerse, CA bu sunucuya ulaşamamış demektir ve Dış kurulum sayfası tam olarak bunu denetler.</value>
   </data>
   <data name="AD do_main of that user" xml:space="preserve">
     <value>Bu kullanıcının AD etki ala_nı</value>
@@ -1059,7 +1059,7 @@ Denetim Masası, ileti dosyalarını yalnızca sunucuyla aynı makinede ve yeter
     <value>Daha eski ve daha zayıf bir seçenek: BU Denetim Masası'nda oturum açarken paroladan sonra istenen ve sunucu parolayı kabul ettikten sonra aracın kendisi tarafından denetlenen tek kullanımlık kod. Gizli anahtar makine başına HKLM altında saklanır; bu nedenle açmak veya kapatmak yerel yönetici hakları gerektirir ve bu seçenek REST API için ya da COM API'sini kullanan betikler için hiçbir şey yapmaz. Yukarıdaki, sunucunun zorunlu kıldığı faktörü tercih edin; bu seçenek mevcut kurulumlar için duruyor.</value>
   </data>
   <data name="An override replaces the global ceilings for that address; 0:0 exempts it entirely. Without the optional :hours the override uses the global period. A malformed line is ignored with a log entry and the global limit still applies to that account. Comment lines in this INI section are not shown here and are dropped if the list is saved." xml:space="preserve">
-    <value>Bir geçersiz kılma, o adres için genel üst sınırların yerine geçer; 0:0 adresi tamamen muaf tutar. İsteğe bağlı :saat kısmı olmadan geçersiz kılma genel dönemi kullanır. Bozuk bir satır, bir günlük girdisiyle yoksayılır ve o hesap için genel sınır geçerli olmayı sürdürür. Bu INI bölümündeki açıklama satırları burada gösterilmez ve liste kaydedilirse atılır.</value>
+    <value>Bir geçersiz kılma, o adres için genel üst sınırların yerine geçer; 0:0 adresi tamamen muaf tutar. İsteğe bağlı :hours kısmı olmadan geçersiz kılma genel dönemi kullanır. Bozuk bir satır, bir günlük girdisiyle yoksayılır ve o hesap için genel sınır geçerli olmayı sürdürür. Bu INI bölümündeki açıklama satırları burada gösterilmez ve liste kaydedilirse atılır.</value>
   </data>
   <data name="An unexpected error occurred:&#10;&#10;{0}&#10;&#10;The full details were written to:&#10;{1}&#10;&#10;Restart the Control Panel now? Choose No to try to keep working." xml:space="preserve">
     <value>Beklenmeyen bir hata oluştu:
@@ -9473,7 +9473,7 @@ Hiçbir ileti silinmez ve hiçbir hesap kaldırılmaz. Devam edilsin mi?</value>
     <value>tarayıcı</value>
   </data>
   <data name="script/save slow" xml:space="preserve">
-    <value>betik/kaydetme yavaş</value>
+    <value>script/save yavaş</value>
   </data>
   <data name="scrypt (memory-hard, RFC 7914)" xml:space="preserve">
     <value>scrypt (bellek yoğun, RFC 7914)</value>

--- a/hmailserver/source/Tools/ControlPanel/Resources/Strings.uk.resx
+++ b/hmailserver/source/Tools/ControlPanel/Resources/Strings.uk.resx
@@ -1059,7 +1059,7 @@
     <value>Старіший, слабший варіант: одноразовий код, який запитується після пароля під час входу САМЕ в цю Панель керування й перевіряється самим засобом уже після того, як сервер прийняв пароль. Секрет зберігається для кожного комп’ютера окремо в HKLM, тому для ввімкнення чи вимкнення потрібні права локального адміністратора, і для REST API або сценаріїв на COM API це не дає нічого. Надавайте перевагу описаному вище фактору, який застосовує сервер; цей залишено для наявних конфігурацій.</value>
   </data>
   <data name="An override replaces the global ceilings for that address; 0:0 exempts it entirely. Without the optional :hours the override uses the global period. A malformed line is ignored with a log entry and the global limit still applies to that account. Comment lines in this INI section are not shown here and are dropped if the list is saved." xml:space="preserve">
-    <value>Перевизначення замінює глобальні межі для цієї адреси; 0:0 повністю звільняє її від обмежень. Без необов’язкової частини :години перевизначення використовує глобальний період. Неправильно сформований рядок ігнорується із записом до журналу, і до цього облікового запису й далі застосовується глобальне обмеження. Рядки коментарів у цьому розділі INI тут не показано, і вони втрачаються, якщо список зберегти.</value>
+    <value>Перевизначення замінює глобальні межі для цієї адреси; 0:0 повністю звільняє її від обмежень. Без необов’язкової частини :hours перевизначення використовує глобальний період. Неправильно сформований рядок ігнорується із записом до журналу, і до цього облікового запису й далі застосовується глобальне обмеження. Рядки коментарів у цьому розділі INI тут не показано, і вони втрачаються, якщо список зберегти.</value>
   </data>
   <data name="An unexpected error occurred:&#10;&#10;{0}&#10;&#10;The full details were written to:&#10;{1}&#10;&#10;Restart the Control Panel now? Choose No to try to keep working." xml:space="preserve">
     <value>Сталася неочікувана помилка:
@@ -1261,7 +1261,7 @@
     <value>Автоматичні сертифікати (ACME)</value>
   </data>
   <data name="Automatic lockout of an address that keeps failing to log on. The ban itself is an expiring IP range, so it is listed on the IP ranges page." xml:space="preserve">
-    <value>Автоматичне блокування адреси, з якої входи раз за разом не вдаються. Саме блокування — це IP-діапазон із терміном дії, тому воно перелічене на сторінці «IP-діапазони».</value>
+    <value>Автоматичне блокування адреси, з якої входи раз за разом не вдаються. Саме блокування — це IP-діапазон із терміном дії, тому воно перелічене на сторінці «Діапазони IP».</value>
   </data>
   <data name="BATV is switched on but no secret is set, so outbound senders are not tagged and returning bounces are not validated - the switch reads enabled while it does nothing. Generate or enter a secret." xml:space="preserve">
     <value>BATV увімкнено, але секрет не задано, тому вихідні відправники не позначаються, а повідомлення про недоставку, що повертаються, не перевіряються — перемикач показує «увімкнено», хоча нічого не робить. Створіть або введіть секрет.</value>
@@ -1351,7 +1351,7 @@
     <value>Перш ніж копіювати —</value>
   </data>
   <data name="Between the 354 and the 250 the server runs the accept pipeline - spam tests, message modifications, archiving, the OnAcceptMessage script and the database save - on a bounded pool of threads, and replies only when it finishes. The log times each stage. Read it as a sequence and look for the last line written: the stage that is stuck is the one after it. Two stages announce themselves with a start line (spam-protection and script/save); message modifications do not, so a stall there shows as &quot;done spam-protection&quot; followed by silence. A stage taking ten seconds or more is logged at application level even without debug logging." xml:space="preserve">
-    <value>Між відповідями 354 і 250 сервер виконує конвеєр приймання — перевірки на спам, зміни повідомлення, архівування, сценарій OnAcceptMessage і збереження в базі даних — на обмеженому пулі потоків і відповідає лише після його завершення. Журнал фіксує час кожного етапу. Читайте його як послідовність і знайдіть останній записаний рядок: заклинив саме той етап, який іде після нього. Два етапи оголошують себе рядком про початок (захист від спаму та сценарій/збереження); зміни повідомлення — ні, тож зупинка на них має вигляд «done spam-protection», після якого настає тиша. Етап, що триває десять секунд або довше, записується на рівні журналу програми навіть без журналювання налагодження.</value>
+    <value>Між відповідями 354 і 250 сервер виконує конвеєр приймання — перевірки на спам, зміни повідомлення, архівування, сценарій OnAcceptMessage і збереження в базі даних — на обмеженому пулі потоків і відповідає лише після його завершення. Журнал фіксує час кожного етапу. Читайте його як послідовність і знайдіть останній записаний рядок: заклинив саме той етап, який іде після нього. Два етапи оголошують себе рядком про початок (spam-protection та script/save); зміни повідомлення — ні, тож зупинка на них має вигляд «done spam-protection», після якого настає тиша. Етап, що триває десять секунд або довше, записується на рівні журналу програми навіть без журналювання налагодження.</value>
   </data>
   <data name="Biased upwards on purpose: refusing early costs delivery latency and nothing else, because the refusal is temporary and a sending server retries for days, while a volume that reaches zero costs a database that will not open and a service that will not start." xml:space="preserve">
     <value>Значення навмисно завищене: рання відмова коштує лише затримки доставки і нічого більше, бо відмова тимчасова, а сервер-відправник повторює спроби днями; натомість том, на якому місце добігло нуля, коштує бази даних, яка не відкриється, і служби, яка не запуститься.</value>
@@ -2186,7 +2186,7 @@
     <value>Не вдалося завантажити списки розсилки:</value>
   </data>
   <data name="Counted logon failures cleared. Addresses already banned stay banned until their &quot;Auto-ban:&quot; range expires - delete it on the IP ranges page to release one now." xml:space="preserve">
-    <value>Лічильники невдалих входів очищено. Адреси, які вже заблоковано, залишаються заблокованими, доки не спливе термін дії їхнього діапазону «Auto-ban:», — щоб звільнити якусь із них зараз, видаліть цей діапазон на сторінці «IP-діапазони».</value>
+    <value>Лічильники невдалих входів очищено. Адреси, які вже заблоковано, залишаються заблокованими, доки не спливе термін дії їхнього діапазону «Auto-ban:», — щоб звільнити якусь із них зараз, видаліть цей діапазон на сторінці «Діапазони IP».</value>
   </data>
   <data name="Counted per account from the last login that was allowed, so a refused attempt does not push the next one further away. It is advertised only while it is set, because announcing a limit that is not enforced is worse than announcing nothing." xml:space="preserve">
     <value>Відлічується для кожного облікового запису від останнього дозволеного входу, тож відхилена спроба не відсуває наступну ще далі. Значення оголошується лише тоді, коли його задано, бо оголосити обмеження, якого не застосовують, гірше, ніж не оголошувати нічого.</value>
@@ -3497,7 +3497,7 @@
     <value>IMAP</value>
   </data>
   <data name="IMAP - the INBOX, collected once by UID; kept on the server unless Days to keep is 0" xml:space="preserve">
-    <value>IMAP - вхідні, збираються один раз за UID; зберігаються на сервері, якщо «Днів зберігати» не дорівнює 0</value>
+    <value>IMAP - INBOX, збираються один раз за UID; зберігаються на сервері, якщо «Днів зберігати» не дорівнює 0</value>
   </data>
   <data name="IMAP conversations" xml:space="preserve">
     <value>Діалоги IMAP</value>
@@ -9473,7 +9473,7 @@ SMTP 25 і 587, POP3 110, IMAP 143 — без захисту підключен�
     <value>сканерів</value>
   </data>
   <data name="script/save slow" xml:space="preserve">
-    <value>сценарії та збереження працюють повільно</value>
+    <value>етап script/save виконується повільно</value>
   </data>
   <data name="scrypt (memory-hard, RFC 7914)" xml:space="preserve">
     <value>scrypt (вимогливий до пам’яті, RFC 7914)</value>


### PR DESCRIPTION
The three checks that ran on every translation until now judge one string in isolation: its placeholders, its Alt key, its newline count. Three properties are invisible from there, because seeing them means comparing a string with the English it came from, or with another string in the same catalogue. A script now makes all three, over every catalogue at once, and everything it found is fixed.

The strings the server itself writes. hMailServer logs its accept-pipeline stages under fixed English names - spam-protection, script/save, header-parsing, message-modifications, mirror - and the stalled-mail page lists them so an administrator can match the page against the log. Twelve languages had translated "script/save slow" into their own words, and seven had translated the pair "(spam-protection and script/save)" in the paragraph that explains how to read the log. An administrator following the translated page would have searched the log for a string that never appears in it. The same class caught the syntax the user types verbatim: nine languages had translated the optional ":hours" of a rate-limit override, four had translated the whole template address=messages:recipients[:hours], and five had translated INBOX, which is an IMAP folder name and not a word.

Pages named by a name that is not their name. Where the English says "on the Transport security page", the translation has to use that page's own translated title, or the reader is sent to a page whose name they cannot find in the navigation. Thirty-two references across eleven languages named a page in words other than its title - Czech pointing at "IP rozsahy" for a page called "Rozsahy IP", French at "Sécurité du transport" for "Sécurité de transport", Polish at "Dzienniki" for "Rejestrowanie w dzienniku", Brazilian Portuguese at "Scripts de evento" for "Scripts de eventos", Russian at "Веб-службы и автонастройка" for "Веб-службы и автоконфигурация", Ukrainian at "IP-діапазони" for "Діапазони IP".

Numbers. Every RFC number, port, size and count the English states is now checked to be stated by the translation too, comparing digits so that 210,000 and 210 000 are the same number. Nothing was wrong: every figure survives in every language. The check stays because a dropped digit is exactly the kind of defect that reads perfectly well.

Swedish, the first translation and the one that predates the suite, had never been read this way: it had translated the metavariables a reader substitutes into something they type or publish - <domain>, <selector>, <mx-host>, <mailbox>, <date> - where all fourteen later catalogues kept them, and the :hours of the override template with them. Twenty-two occurrences, now English again.

The script is build/check-catalogues.py and it runs in CI beside the other two, so a new translation is held to this as well.

Verification: the Control Panel builds warning-free in Release, 681 tests pass, check-localisation.py reports all fifteen catalogues at 3354 of 3354, check-mnemonics.py reports no missing or colliding mnemonic, and the new checker reports nothing outstanding.