### PR TITLE
Attachments on send: a submission or a draft carries files, added the way COM adds one, and the HTTP foundation gained a second request cap that a filter grants per request - sixteen megabytes and five minutes for the two routes that take them, 64 KB for everything else

### DIFF
--- a/hmailserver/source/Server/Common/BO/Attachments.cpp
+++ b/hmailserver/source/Server/Common/BO/Attachments.cpp
@@ -70,15 +70,38 @@ namespace HM
    bool
    Attachments::Add(const String &sFilename)
    {
-      if (!FileUtilities::Exists(sFilename))      
+      return Add(sFilename, _T(""));
+   }
+
+   bool
+   Attachments::Add(const String &sFilename, const String &contentType)
+   {
+      if (!FileUtilities::Exists(sFilename))
          return false;
 
-      // Load the attachment
+      // Always created as a part the message cannot mistake for its own body.
+      // CreatePart reads the type it is given: "text/plain" and "text/html"
+      // mean "this is the body", and it rebuilds the message around that - so
+      // creating a text/plain ATTACHMENT with its declared type replaced the
+      // message's body with the attachment, silently. The declared type is
+      // applied below, once the part exists as an attachment.
       std::shared_ptr<MimeBody> pAttachment = msg_data_->CreatePart("application/octet-stream");
       pAttachment->SetTransferEncoding("base64");
 
       if (!pAttachment->ReadFromFile(sFilename))
          return false;
+
+      if (!contentType.IsEmpty() && contentType.CompareNoCase(_T("application/octet-stream")) != 0)
+      {
+         // Setting the field replaces its parameters, so the name ReadFromFile
+         // put there is read first and put back afterwards.
+         AnsiString name = pAttachment->GetParameter(CMimeConst::ContentType(), "name");
+
+         pAttachment->SetContentType(AnsiString(contentType), "");
+
+         if (!name.IsEmpty())
+            pAttachment->SetParameter(CMimeConst::ContentType(), "name", name);
+      }
 
       // Add the attachment to the collection.
       std::shared_ptr<Attachment> pItem = std::shared_ptr<Attachment>(new Attachment(mime_body_, pAttachment));

--- a/hmailserver/source/Server/Common/BO/Attachments.h
+++ b/hmailserver/source/Server/Common/BO/Attachments.h
@@ -18,6 +18,7 @@ namespace HM
       virtual ~Attachments();
 
       bool Add(const String &sFilename);
+      bool Add(const String &sFilename, const String &contentType);
       bool Add(std::shared_ptr<Attachment> pAttachment);
       
       std::shared_ptr<Attachment> GetItem(unsigned int index) const;

--- a/hmailserver/source/Server/Common/BO/MessageData.cpp
+++ b/hmailserver/source/Server/Common/BO/MessageData.cpp
@@ -621,11 +621,16 @@ namespace HM
       // should have been removed from the message already.
       //
       std::shared_ptr<MimeBody> part = mime_mail_->FindFirstPart();
-      std::set<std::shared_ptr<MimeBody> > setAttachments;
+      // In the order they appear in the message, and a part created here is
+      // appended after them. Held in a set until 2026-09-08, which ordered
+      // them by pointer address: the message was rebuilt on every call, so
+      // adding a second attachment could reorder the first one, and which
+      // attachment answered to index 0 was decided by the heap.
+      std::vector<std::shared_ptr<MimeBody> > setAttachments;
       while (part)
       {
          if (part->IsAttachment())
-            setAttachments.insert(part);
+            setAttachments.push_back(part);
 
          part = mime_mail_->FindNextPart();
       }
@@ -691,7 +696,7 @@ namespace HM
       {
          // create a new item. treat as an attachment.
          retValue = std::shared_ptr<MimeBody>(new MimeBody);
-         setAttachments.insert(retValue);
+         setAttachments.push_back(retValue);
       }
 
       AnsiString mainBodyType;

--- a/hmailserver/source/Server/Common/Util/HttpServer.cpp
+++ b/hmailserver/source/Server/Common/Util/HttpServer.cpp
@@ -170,11 +170,12 @@ namespace HM
          limits_(server->limits_),
          handler_(server->handler_),
          error_responder_(server->error_responder_),
+         large_request_filter_(server->large_request_filter_),
          strand_(boost::asio::make_strand(server->io_)),
          socket_(std::move(socket)),
          request_timer_(server->io_),
          connection_timer_(server->io_),
-         buffer_(server->limits_.max_request_bytes + 1),
+         buffer_(std::max(server->limits_.max_request_bytes, server->limits_.max_request_bytes_large) + 1),
          peer_(peer),
          listen_port_(listen_port),
          requests_(0),
@@ -228,11 +229,16 @@ namespace HM
 
       void ArmRequestTimer_()
       {
+         ArmRequestTimer_(limits_.request_seconds);
+      }
+
+      void ArmRequestTimer_(unsigned seconds)
+      {
          std::shared_ptr<HttpConnection> self = shared_from_this();
 
          // expires_after cancels a wait already pending, whose handler then runs
          // with operation_aborted and does nothing.
-         request_timer_.expires_after(std::chrono::seconds(limits_.request_seconds));
+         request_timer_.expires_after(std::chrono::seconds(seconds));
          request_timer_.async_wait(boost::asio::bind_executor(strand_,
             [self](const boost::system::error_code &error)
             {
@@ -324,7 +330,20 @@ namespace HM
             return;
          }
 
-         if (request_.head.size() + content_length_ > limits_.max_request_bytes)
+         // The head alone is held to the first cap whatever the route. The
+         // body may be held to the second when the filter grants it - and
+         // then the request gets the longer timer, since the body is the
+         // point and takes time to arrive.
+         size_t cap = limits_.max_request_bytes;
+         if (request_.head.size() <= limits_.max_request_bytes && limits_.max_request_bytes_large > cap &&
+             large_request_filter_ && large_request_filter_(request_.method, request_.target))
+         {
+            cap = limits_.max_request_bytes_large;
+            if (limits_.request_seconds_large > limits_.request_seconds)
+               ArmRequestTimer_(limits_.request_seconds_large);
+         }
+
+         if (request_.head.size() > limits_.max_request_bytes || request_.head.size() + content_length_ > cap)
          {
             // Refused before the body is read. The client may still be sending
             // it; the close that follows the response resets what is in flight,
@@ -611,6 +630,7 @@ namespace HM
       HttpLimits limits_;
       HttpServer::Handler handler_;
       HttpServer::ErrorResponder error_responder_;
+      HttpServer::LargeRequestFilter large_request_filter_;
       boost::asio::strand<boost::asio::io_context::executor_type> strand_;
       boost::asio::ip::tcp::socket socket_;
       std::unique_ptr<boost::asio::ssl::stream<boost::asio::ip::tcp::socket&>> tls_;
@@ -715,6 +735,12 @@ namespace HM
 
       listeners_.push_back(listener);
       return true;
+   }
+
+   void
+   HttpServer::SetLargeRequestFilter(LargeRequestFilter filter)
+   {
+      large_request_filter_ = filter;
    }
 
    void

--- a/hmailserver/source/Server/Common/Util/HttpServer.h
+++ b/hmailserver/source/Server/Common/Util/HttpServer.h
@@ -71,6 +71,14 @@ namespace HM
       // take it over this is refused before the body is read.
       size_t max_request_bytes = 64 * 1024;
 
+      // A second cap, granted per request by the large-request filter once
+      // the head has been read and has passed max_request_bytes on its own.
+      // Zero means there is no such cap. A request under it gets
+      // request_seconds_large instead of request_seconds, so a body that
+      // takes time to arrive is not cut off by a timer meant for a form.
+      size_t max_request_bytes_large = 0;
+      unsigned request_seconds_large = 0;
+
       // From the moment the server starts waiting for a request (which, on a
       // kept-alive connection, is the moment the previous response was written)
       // to the last byte of the response. Handler time counts.
@@ -114,6 +122,11 @@ namespace HM
       // the responses the handlers build.
       typedef std::function<HttpResponse(int status, const AnsiString &message)> ErrorResponder;
 
+      // Whether a request, by method and target, may be as large as
+      // max_request_bytes_large. Asked after the head is parsed, before the
+      // body is read; never for the head itself.
+      typedef std::function<bool(const AnsiString &method, const AnsiString &target)> LargeRequestFilter;
+
       HttpServer(const AnsiString &name, const HttpLimits &limits, Handler handler,
                  AcceptFilter accept_filter, ErrorResponder error_responder);
       ~HttpServer();
@@ -124,6 +137,9 @@ namespace HM
       bool Listen(const String &bind_address, int port, std::shared_ptr<boost::asio::ssl::context> tls);
 
       void Start();
+
+      // Set before Listen; connections copy it as they are made.
+      void SetLargeRequestFilter(LargeRequestFilter filter);
 
       // Closes the listeners and every connection, then joins the workers. A
       // handler that is running at the time is waited for.
@@ -158,6 +174,7 @@ namespace HM
       Handler handler_;
       AcceptFilter accept_filter_;
       ErrorResponder error_responder_;
+      LargeRequestFilter large_request_filter_;
 
       boost::asio::io_context io_;
       std::unique_ptr<boost::asio::executor_work_guard<boost::asio::io_context::executor_type>> work_;

--- a/hmailserver/source/Server/Common/Util/RestApiServer.cpp
+++ b/hmailserver/source/Server/Common/Util/RestApiServer.cpp
@@ -39,6 +39,7 @@
 #include "../Cache/CacheContainer.h"
 #include "../Sieve/SieveStorage.h"
 #include "../Sieve/SieveScript.h"
+#include "GUIDCreator.h"
 #include <iterator>
 #include <set>
 #include "../BO/MessageRecipients.h"
@@ -125,6 +126,11 @@ namespace HM
       // The ceilings HttpServer enforces for this listener. Every one is
       // absolute - see HttpServer.cpp for why an idle timeout is not enough.
       const size_t MaxRequestSize = 64 * 1024;
+
+      // The two routes that carry attachments: sixteen megabytes on the
+      // wire, and five minutes for them to arrive.
+      const size_t MaxLargeRequestSize = 16 * 1024 * 1024;
+      const unsigned LargeRequestSeconds = 300;
       const unsigned RequestSeconds = 30;
       const unsigned ConnectionSeconds = 300;
       const unsigned MaxConnections = 64;
@@ -640,6 +646,8 @@ namespace HM
 
       HttpLimits limits;
       limits.max_request_bytes = MaxRequestSize;
+      limits.max_request_bytes_large = MaxLargeRequestSize;
+      limits.request_seconds_large = LargeRequestSeconds;
       limits.request_seconds = RequestSeconds;
       limits.connection_seconds = ConnectionSeconds;
       limits.max_connections = MaxConnections;
@@ -676,6 +684,8 @@ namespace HM
             body.Format("{\"error\":\"%hs\"}", JsonEscape_(message).c_str());
             return BuildResponse_(status, body);
          }));
+
+      server->SetLargeRequestFilter(&RestApiServer::IsLargeRequest_);
 
       if (!server->Listen(bind_address, port, use_tls_ ? tls_context_owner : std::shared_ptr<boost::asio::ssl::context>()))
       {
@@ -6084,6 +6094,11 @@ namespace HM
       if (!references.IsEmpty())
          messageData.SetFieldValue(_T("References"), references);
 
+      AnsiString attachmentError;
+      int attachmentStatus = AddAttachmentsFromJson_(messageData, requestBody, attachmentError);
+      if (attachmentStatus != 0)
+         return BuildResponse_(attachmentStatus, attachmentError);
+
       if (!messageData.Write(fileName))
          return BuildResponse_(500, "{\"error\":\"the message could not be written\"}");
 
@@ -6613,6 +6628,11 @@ namespace HM
       messageData.SetSentTime(Time::GetCurrentMimeDate());
       messageData.GenerateMessageID();
 
+      AnsiString attachmentError;
+      int attachmentStatus = AddAttachmentsFromJson_(messageData, requestBody, attachmentError);
+      if (attachmentStatus != 0)
+         return BuildResponse_(attachmentStatus, attachmentError);
+
       if (!messageData.Write(fileName))
          return BuildResponse_(500, "{\"error\":\"the draft could not be written\"}");
 
@@ -6656,6 +6676,183 @@ namespace HM
       AnsiString json;
       json.Format("{\"id\":%I64d,\"folder_id\":%I64d}", draft->GetID(), drafts->GetID());
       return BuildResponse_(201, json);
+   }
+
+   namespace
+   {
+      // What one message may carry from the portal. The request cap for the
+      // two routes that take attachments is sixteen megabytes on the wire;
+      // base64 adds a third, so twelve megabytes of files is what fits.
+      const int MaxAttachmentsPerMessage = 20;
+      const __int64 MaxAttachmentBytesPerMessage = 12 * 1024 * 1024;
+
+      // The text of the n-th object in the "attachments" array of a JSON
+      // body, by brace matching - or empty when there is none.
+      AnsiString JsonArrayObject(const AnsiString &json, const AnsiString &key, int index)
+      {
+         AnsiString needle = "\"" + key + "\"";
+         int keyPosition = json.Find(needle);
+         if (keyPosition < 0)
+            return "";
+
+         int bracket = json.Find("[", keyPosition + needle.GetLength());
+         if (bracket < 0)
+            return "";
+
+         int depth = 0;
+         bool inString = false;
+         int objectStart = -1;
+         int found = 0;
+         for (int i = bracket + 1; i < json.GetLength(); i++)
+         {
+            char c = json[i];
+
+            if (inString)
+            {
+               if (c == '\\')
+               {
+                  i++;
+                  continue;
+               }
+
+               if (c == '\"')
+                  inString = false;
+
+               continue;
+            }
+
+            if (c == '\"')
+            {
+               inString = true;
+               continue;
+            }
+
+            if (c == '{')
+            {
+               if (depth == 0)
+                  objectStart = i;
+               depth++;
+            }
+            else if (c == '}')
+            {
+               depth--;
+               if (depth == 0)
+               {
+                  if (found == index)
+                     return json.Mid(objectStart, i - objectStart + 1);
+                  found++;
+               }
+            }
+            else if (c == ']' && depth == 0)
+            {
+               break;
+            }
+         }
+
+         return "";
+      }
+
+      // A file name for the temporary file the MIME library reads: the name
+      // the sender gave, minus anything a path or a header could not carry.
+      String SafeAttachmentName(const String &name)
+      {
+         String safe;
+         for (int i = 0; i < name.GetLength(); i++)
+         {
+            wchar_t c = name.c_str()[i];
+            bool bad = c < 0x20 || c == '\\' || c == '/' || c == ':' || c == '*' || c == '?' || c == '\"' || c == '<' || c == '>' || c == '|';
+            safe += bad ? L'_' : c;
+         }
+         safe.TrimLeft();
+         safe.TrimRight();
+         if (safe.IsEmpty() || safe == _T(".") || safe == _T(".."))
+            safe = _T("attachment");
+         if (safe.GetLength() > 200)
+            safe = safe.Mid(0, 200);
+         return safe;
+      }
+   }
+
+   // The attachments a body names - name, type, data (base64) - added to the
+   // message the way COM's Attachments.Add adds a file: each is written under
+   // its own name in a directory of its own in the temp folder, read from
+   // there, and the directory removed. Returns 0, or the status to answer.
+   int
+   RestApiServer::AddAttachmentsFromJson_(MessageData &messageData, const AnsiString &requestBody, AnsiString &error)
+   {
+      if (requestBody.Find("\"attachments\"") < 0)
+         return 0;
+
+      __int64 totalBytes = 0;
+
+      for (int index = 0; index < MaxAttachmentsPerMessage + 1; index++)
+      {
+         AnsiString object = JsonArrayObject(requestBody, "attachments", index);
+         if (object.IsEmpty())
+            break;
+
+         if (index >= MaxAttachmentsPerMessage)
+         {
+            error.Format("{\"error\":\"at most %d attachments\"}", MaxAttachmentsPerMessage);
+            return 400;
+         }
+
+         String name = SafeAttachmentName(JsonUtf8Value_(object, "name"));
+         String type = JsonUtf8Value_(object, "type");
+         AnsiString encoded = GetJsonStringValue_(object, "data");
+
+         AnsiString bytes = Base64::Decode(encoded.c_str(), encoded.GetLength());
+         totalBytes += bytes.GetLength();
+         if (totalBytes > MaxAttachmentBytesPerMessage)
+         {
+            error = "{\"error\":\"the attachments are larger than twelve megabytes together\"}";
+            return 413;
+         }
+
+         type.TrimLeft();
+         type.TrimRight();
+         if (type.IsEmpty() || type.Find(_T("/")) < 0 || type.Find(_T("\r")) >= 0 || type.Find(_T("\n")) >= 0 || type.GetLength() > 100)
+            type = _T("application/octet-stream");
+
+         String directory = IniFileSettings::Instance()->GetTempDirectory() + _T("\\") + GUIDCreator::GetGUID();
+         if (!FileUtilities::CreateDirectory(directory))
+         {
+            error = "{\"error\":\"the attachment could not be written\"}";
+            return 500;
+         }
+
+         String path = directory + _T("\\") + name;
+         bool added = FileUtilities::WriteToFile(path, bytes) && messageData.GetAttachments()->Add(path, type);
+
+         FileUtilities::DeleteDirectory(directory, true);
+
+         if (!added)
+         {
+            error = "{\"error\":\"the attachment could not be added\"}";
+            return 500;
+         }
+
+         std::shared_ptr<Attachments> attachments = messageData.GetAttachments();
+         std::shared_ptr<Attachment> last = attachments->GetItem((unsigned int) attachments->GetCount() - 1);
+         if (last)
+            last->SetFileName(name);
+      }
+
+      return 0;
+   }
+
+   bool
+   RestApiServer::IsLargeRequest_(const AnsiString &method, const AnsiString &target)
+   {
+      if (method != "POST")
+         return false;
+
+      AnsiString path = target;
+      int query = path.Find("?");
+      if (query >= 0)
+         path = path.Mid(0, query);
+
+      return path == "/api/v1/me/messages" || path == "/api/v1/me/drafts";
    }
 
    namespace
@@ -6759,6 +6956,7 @@ namespace HM
          "<label for=\"compose-cc\">Cc</label><input id=\"compose-cc\" type=\"text\">\n"
          "<label for=\"compose-subject\">Subject</label><input id=\"compose-subject\" type=\"text\" maxlength=\"500\">\n"
          "<label for=\"compose-text\">Message</label><textarea id=\"compose-text\"></textarea>\n"
+         "<label for=\"compose-files\">Files</label><input id=\"compose-files\" type=\"file\" multiple><div id=\"compose-files-note\" class=\"held-detail\"></div>\n"
          "<button type=\"submit\">Send</button><button id=\"compose-save\" type=\"button\" class=\"secondary\">Save draft</button>\n"
          "<div id=\"compose-status\" class=\"status\" aria-live=\"polite\"></div>\n"
          "</form>\n"
@@ -7111,9 +7309,13 @@ namespace HM
          "    event.preventDefault();\n"
          "    say('compose-status', '', true);\n"
          "    var body = composeBody();\n"
-         "    call('POST', '/api/v1/me/messages', body).then(function (result) {\n"
+         "    readFiles().then(function (files) {\n"
+         "    if (files.length) { body.attachments = files; }\n"
+         "    return call('POST', '/api/v1/me/messages', body); }, function (why) { say('compose-status', why, false); return null; }).then(function (result) {\n"
+         "      if (!result) { return; }\n"
          "      if (result.status === 201) {\n"
          "        el('compose-to').value = ''; el('compose-cc').value = ''; el('compose-subject').value = ''; el('compose-text').value = '';\n"
+         "        el('compose-files').value = ''; el('compose-files-note').textContent = '';\n"
          "        say('compose-status', 'Sent.', true);\n"
          "        replyTo = null;\n"
          "        if (draftId) { var gone = draftId; draftId = 0; call('DELETE', '/api/v1/me/messages/' + gone + '?permanent=1').then(function () { loadFolders(); }); return; }\n"
@@ -7315,6 +7517,26 @@ namespace HM
          "    else if (event.key === 'Enter' && cursor >= 0) { openMessage(listRows[cursor].id); event.preventDefault(); }\n"
          "    else if (event.key === 'x' && cursor >= 0) { var r = listRows[cursor]; r.box.checked = !r.box.checked; selected[r.id] = r.box.checked; renderBulk(); event.preventDefault(); }\n"
          "  });\n"
+         "  // Files: read in the browser and sent as base64 in the same call,\n"
+         "  // twelve megabytes together at most.\n"
+         "  var readFiles = function () {\n"
+         "    var files = Array.prototype.slice.call(el('compose-files').files || []);\n"
+         "    var total = files.reduce(function (n, f) { return n + f.size; }, 0);\n"
+         "    if (files.length > 20) { return Promise.reject('At most 20 files.'); }\n"
+         "    if (total > 12 * 1024 * 1024) { return Promise.reject('The files are larger than 12 MB together.'); }\n"
+         "    return Promise.all(files.map(function (file) {\n"
+         "      return new Promise(function (resolve, reject) {\n"
+         "        var reader = new FileReader();\n"
+         "        reader.onload = function () { resolve({ name: file.name, type: file.type || 'application/octet-stream', data: String(reader.result).split(',')[1] || '' }); };\n"
+         "        reader.onerror = function () { reject('Could not read ' + file.name); };\n"
+         "        reader.readAsDataURL(file);\n"
+         "      });\n"
+         "    }));\n"
+         "  };\n"
+         "  el('compose-files').addEventListener('change', function () {\n"
+         "    var files = Array.prototype.slice.call(el('compose-files').files || []);\n"
+         "    el('compose-files-note').textContent = files.length ? files.map(function (f) { return f.name + ' (' + format(f.size) + ')'; }).join(', ') : '';\n"
+         "  });\n"
          "  // A session from an earlier visit is still good until it has been idle\n"
          "  // too long: try it first, and only ask for the password when it is not.\n"
          "  load(true);\n"
@@ -7378,7 +7600,7 @@ namespace HM
          "\"/api/v1/me/settings\":{\"get\":{\"summary\":\"The signed-in account's own settings\",\"responses\":{\"200\":{\"description\":\"name (first, last), forwarding (enabled, address, keep_original), signature (enabled, text, html)\"}}},\"put\":{\"summary\":\"Change the signed-in account's own settings\",\"description\":\"Each of name, forwarding and signature the body names is applied whole; one it does not name is left as it is. A forwarding that is enabled needs an e-mail address, and not the account's own.\",\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"object\"},\"forwarding\":{\"type\":\"object\"},\"signature\":{\"type\":\"object\"}}}}}},\"responses\":{\"200\":{\"description\":\"The settings as saved\"},\"400\":{\"description\":\"Nothing named, a name or signature too long, or a forwarding address refused\"}}}},"
          "\"/api/v1/me/filters\":{\"get\":{\"summary\":\"The signed-in account's active Sieve script\",\"responses\":{\"200\":{\"description\":\"active (the script, empty when none), name (the active script's name when ManageSieve set one)\"}}},\"put\":{\"summary\":\"Set the signed-in account's active Sieve script\",\"description\":\"Body: script. Checked as ManageSieve's PUTSCRIPT checks it, with the same wording in error; an empty script removes the filter. The script runs on every message that arrives from then on.\",\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"type\":\"object\",\"required\":[\"script\"],\"properties\":{\"script\":{\"type\":\"string\"}}}}}},\"responses\":{\"200\":{\"description\":\"active\"},\"400\":{\"description\":\"script missing, over 256 KB, or not parsing (the reason is in error)\"}}}},"
          "\"/api/v1/me/search\":{\"get\":{\"summary\":\"Search every folder of the signed-in account\",\"description\":\"Query parameters: q (required) and limit (1-200, default 50). The same match as q on a folder listing, over every folder the account may read, newest first; at most 2000 messages are looked at per request (scanned, complete), and more says whether hits beyond limit were cut. Each hit names its folder_id and folder path.\",\"responses\":{\"200\":{\"description\":\"query, scanned, complete, more, messages\"},\"400\":{\"description\":\"q missing\"}}}},"
-         "\"/api/v1/me/messages\":{\"post\":{\"summary\":\"Send a message as the signed-in account\",\"description\":\"Body: to, cc, bcc (address lists, comma or semicolon separated, display names allowed), subject, text; optionally in_reply_to and references (written as the headers of those names, so the recipient's client threads the reply) and answered_id (the id of the message this answers, which gets \\Answered). Every address is put through the checks RCPT TO makes for an authenticated sender, and a refused one is named in error. The message is queued through the same delivery pipeline as SMTP submission, and a copy marked read is kept in the folder designated \\\\Sent when the account has one and its quota allows. Text only; the request has to fit the listener's request limit.\",\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"type\":\"object\",\"properties\":{\"to\":{\"type\":\"string\"},\"cc\":{\"type\":\"string\"},\"bcc\":{\"type\":\"string\"},\"subject\":{\"type\":\"string\"},\"text\":{\"type\":\"string\"}}}}}},\"responses\":{\"201\":{\"description\":\"queued, recipients, sent_id (0 when no copy was kept)\"},\"400\":{\"description\":\"No recipient, or an address refused (named in error)\"},\"413\":{\"description\":\"Larger than the server allows\"}}}},"
+         "\"/api/v1/me/messages\":{\"post\":{\"summary\":\"Send a message as the signed-in account\",\"description\":\"Body: to, cc, bcc (address lists, comma or semicolon separated, display names allowed), subject, text; optionally in_reply_to and references (written as the headers of those names, so the recipient's client threads the reply) and answered_id (the id of the message this answers, which gets \\Answered). Every address is put through the checks RCPT TO makes for an authenticated sender, and a refused one is named in error. The message is queued through the same delivery pipeline as SMTP submission, and a copy marked read is kept in the folder designated \\\\Sent when the account has one and its quota allows. attachments is an array of {name, type, data} with data as base64 - at most 20, twelve megabytes together; this route and the drafts route take a request of up to sixteen megabytes.\",\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"type\":\"object\",\"properties\":{\"to\":{\"type\":\"string\"},\"cc\":{\"type\":\"string\"},\"bcc\":{\"type\":\"string\"},\"subject\":{\"type\":\"string\"},\"text\":{\"type\":\"string\"}}}}}},\"responses\":{\"201\":{\"description\":\"queued, recipients, sent_id (0 when no copy was kept)\"},\"400\":{\"description\":\"No recipient, or an address refused (named in error)\"},\"413\":{\"description\":\"Larger than the server allows\"}}}},"
          "\"/api/v1/me/messages/{id}\":{\"get\":{\"summary\":\"One message, read\",\"description\":\"The listing's fields plus folder_id, to, cc, text, html and attachments (index, name, size). A message over one megabyte is described with truncated true and no body. Another account's message, or one in a folder the ACL keeps from this account, is 404.\",\"responses\":{\"200\":{\"description\":\"The message\"},\"404\":{\"description\":\"Not this account's message\"}}},\"delete\":{\"summary\":\"Delete one message\",\"description\":\"Moved to the folder designated \\Trash when the account has one and the message is not in it already; final otherwise, or with ?permanent=1. The rights EXPUNGE asks for.\",\"responses\":{\"200\":{\"description\":\"deleted true, or deleted false with moved_to and the new id\"},\"403\":{\"description\":\"The folder does not allow it\"},\"404\":{\"description\":\"Not this account's message\"}}}},"
          "\"/api/v1/me/messages/{id}/flags\":{\"put\":{\"summary\":\"Change one message's flags\",\"description\":\"Body: any of seen, flagged, answered, draft, deleted as booleans; only the flags named change. The rights STORE asks for - seen, deleted and the rest are three permissions. Every IMAP session on the folder is told.\",\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"type\":\"object\",\"properties\":{\"seen\":{\"type\":\"boolean\"},\"flagged\":{\"type\":\"boolean\"},\"answered\":{\"type\":\"boolean\"},\"draft\":{\"type\":\"boolean\"},\"deleted\":{\"type\":\"boolean\"}}}}}},\"responses\":{\"200\":{\"description\":\"id, folder_id, flags\"},\"400\":{\"description\":\"No flag named\"},\"403\":{\"description\":\"The folder does not allow it\"},\"404\":{\"description\":\"Not this account's message\"}}}},"
          "\"/api/v1/me/messages/{id}/move\":{\"post\":{\"summary\":\"Move one message to another of the account's folders\",\"description\":\"Body: folder_id. As MOVE does: a copy with a new UID in the destination, then the original expunged, every session on either folder told. Another account's folder is 404.\",\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"type\":\"object\",\"required\":[\"folder_id\"],\"properties\":{\"folder_id\":{\"type\":\"integer\"}}}}}},\"responses\":{\"200\":{\"description\":\"id (the new one), folder_id\"},\"400\":{\"description\":\"folder_id missing, or the same folder\"},\"403\":{\"description\":\"A folder does not allow it\"},\"404\":{\"description\":\"Not this account's message or folder\"}}}},"

--- a/hmailserver/source/Server/Common/Util/RestApiServer.h
+++ b/hmailserver/source/Server/Common/Util/RestApiServer.h
@@ -72,6 +72,7 @@ namespace HM
    class IMAPFolder;
    class IMAPFolders;
    class Message;
+   class MessageData;
 
    class RestApiServer
    {
@@ -312,6 +313,8 @@ namespace HM
       static HttpResponse HandleMeDraftSave_(const Caller &caller, const AnsiString &requestBody);
       static AnsiString ThreadFieldsJson_(const String &fileName);
       static String FromHeader_(std::shared_ptr<const Account> account);
+      static int AddAttachmentsFromJson_(MessageData &messageData, const AnsiString &requestBody, AnsiString &error);
+      static bool IsLargeRequest_(const AnsiString &method, const AnsiString &target);
       static bool ReadJsonHex4_(const AnsiString &json, int at, unsigned int &value);
       static void AppendUtf8_(AnsiString &out, unsigned int codePoint);
       static void CollectReadableFolders_(std::shared_ptr<const Account> account, std::shared_ptr<IMAPFolders> folders, const String &parentPath,

--- a/hmailserver/test/RegressionTests/API/RestApiSelfService.cs
+++ b/hmailserver/test/RegressionTests/API/RestApiSelfService.cs
@@ -1565,6 +1565,78 @@ namespace RegressionTests.API
          imap.Disconnect();
       }
 
+      [Test]
+      [Description("Files named in a submission go out as attachments under their names and types, and the Sent copy serves them back")]
+      public void AttachmentsGoOutWithTheMessage()
+      {
+         string other = OtherAccount();
+         byte[] numbers = Pattern(1000);
+
+         var imap = new ImapClientSimulator();
+         Assert.IsTrue(imap.ConnectAndLogon(Address, UserPassword));
+         Assert.IsTrue(imap.CreateFolder("Sent"));
+         imap.Disconnect();
+
+         string body =
+            "{\"to\":\"" + other + "\",\"subject\":\"With files\",\"text\":\"See attached.\",\"attachments\":[" +
+            "{\"name\":\"numbers.bin\",\"type\":\"application/octet-stream\",\"data\":\"" + Convert.ToBase64String(numbers) + "\"}," +
+            "{\"name\":\"note.txt\",\"type\":\"text/plain\",\"data\":\"" + Convert.ToBase64String(Encoding.ASCII.GetBytes("hello")) + "\"}" +
+            "]}";
+
+         (int status, string body) sent = Http("POST", "/api/v1/me/messages", UserHeader(UserPassword), body);
+         Assert.AreEqual(201, sent.status, "Body: " + sent.body);
+         long sentId = long.Parse(Between(sent.body, "\"sent_id\":", "}"));
+
+         Pop3ClientSimulator.AssertMessageCount(other, UserPassword, 1);
+         string received = Pop3ClientSimulator.AssertGetFirstMessageText(other, UserPassword);
+         StringAssert.Contains("name=\"numbers.bin\"", received);
+         StringAssert.Contains("filename=\"numbers.bin\"", received);
+         StringAssert.Contains("Content-Type: text/plain", received);
+         StringAssert.Contains("name=\"note.txt\"", received);
+         StringAssert.Contains(Convert.ToBase64String(Encoding.ASCII.GetBytes("hello")), received);
+         StringAssert.Contains("See attached.", received);
+
+         (int status, string body) copy = Http("GET", "/api/v1/me/messages/" + sentId, UserHeader(UserPassword));
+         Assert.AreEqual(200, copy.status, "Body: " + copy.body);
+         StringAssert.Contains("{\"index\":0,\"name\":\"numbers.bin\",\"size\":1000}", copy.body);
+         StringAssert.Contains("{\"index\":1,\"name\":\"note.txt\",\"size\":5}", copy.body);
+
+         Response file = Raw("GET", "/api/v1/me/messages/" + sentId + "/attachments/0", UserHeader(UserPassword), null);
+         Assert.AreEqual(200, file.Status, file.Body);
+         Assert.AreEqual(numbers, file.BodyBytes);
+
+         string tooMany = "{\"to\":\"" + other + "\",\"text\":\"x\",\"attachments\":[";
+         for (int i = 0; i < 21; i++)
+            tooMany += (i > 0 ? "," : "") + "{\"name\":\"f" + i + ".txt\",\"type\":\"text/plain\",\"data\":\"aGk=\"}";
+         tooMany += "]}";
+         (int status, string body) refused = Http("POST", "/api/v1/me/messages", UserHeader(UserPassword), tooMany);
+         Assert.AreEqual(400, refused.status, "Body: " + refused.body);
+         Pop3ClientSimulator.AssertMessageCount(other, UserPassword, 0);
+      }
+
+      [Test]
+      [Description("A large body is accepted where a message is sent or a draft kept, and refused everywhere else")]
+      public void LargeBodiesAreAllowedOnlyWhereTheyBelong()
+      {
+         string big = "{\"to\":\"x@example.com\",\"text\":\"" + new string('a', 200 * 1024) + "\"}";
+
+         (int status, string body) send = Http("POST", "/api/v1/me/messages", UserHeader("not-the-password"), big);
+         Assert.AreEqual(401, send.status, "The body was read and the credentials refused, not the size. Body: " + send.body);
+
+         (int status, string body) draft = Http("POST", "/api/v1/me/drafts", UserHeader("not-the-password"), big);
+         Assert.AreEqual(401, draft.status, "Body: " + draft.body);
+
+         // The two above are sent for real, body and all, because they are meant
+         // to be read. These two are refused on the declared length before the
+         // body is read, so they are asked for the way a client asks for
+         // something that might be refused - see RefusedBySize.
+         (int status, string body) elsewhere = RefusedBySize("POST", "/api/v1/me/vacation", UserHeader(UserPassword), big.Length);
+         Assert.AreEqual(413, elsewhere.status, "Body: " + elsewhere.body);
+
+         (int status, string body) admin = RefusedBySize("POST", "/api/v1/status", AdminHeader(), big.Length);
+         Assert.AreEqual(413, admin.status, "Body: " + admin.body);
+      }
+
       // ------------------------------------------------------------ helpers ---
 
       private string SignIn()
@@ -1615,6 +1687,60 @@ namespace RegressionTests.API
       {
          Response response = Raw(method, path, authorization, requestBody);
          return (response.Status, response.Body);
+      }
+
+      /// <summary>
+      /// Asks for a body the server will refuse on its declared length, the way
+      /// RFC 7231 section 5.1.1 says to ask for one: Expect: 100-continue, with
+      /// the body withheld until the server says to send it. It never does - it
+      /// answers 413 off the Content-Length - and because nothing was in flight
+      /// the answer can be read.
+      ///
+      /// Sending the body first and then reading is not a reliable way to see a
+      /// refusal, and that is the server behaving correctly rather than a race
+      /// worth fixing: it refuses before reading the body, and closing a socket
+      /// whose receive buffer still holds an unread request resets the
+      /// connection, which discards the response with it. That surfaces here as
+      /// a connection abort instead of a status.
+      /// </summary>
+      private static (int status, string body) RefusedBySize(string method, string path, string authorization, int declaredLength)
+      {
+         using (var client = new TcpClient())
+         {
+            client.Connect("127.0.0.1", RestPort);
+
+            using (NetworkStream stream = client.GetStream())
+            using (var memory = new MemoryStream())
+            {
+               var head = new StringBuilder();
+               head.Append(method + " " + path + " HTTP/1.1\r\n");
+               head.Append("Host: 127.0.0.1\r\n");
+               if (authorization != null)
+                  head.Append("Authorization: " + authorization + "\r\n");
+               head.Append("Content-Type: application/json\r\n");
+               head.Append("Content-Length: " + declaredLength + "\r\n");
+               head.Append("Expect: 100-continue\r\n");
+               head.Append("Connection: close\r\n\r\n");
+
+               byte[] bytes = Encoding.ASCII.GetBytes(head.ToString());
+               stream.Write(bytes, 0, bytes.Length);
+
+               byte[] buffer = new byte[8192];
+               int read;
+               while ((read = stream.Read(buffer, 0, buffer.Length)) > 0)
+                  memory.Write(buffer, 0, read);
+
+               string raw = Encoding.UTF8.GetString(memory.ToArray());
+               int separator = raw.IndexOf("\r\n\r\n", StringComparison.Ordinal);
+               string first = raw.Split(new[] { "\r\n" }, StringSplitOptions.None)[0];
+               string[] parts = first.Split(' ');
+               int status = 0;
+               if (parts.Length >= 2)
+                  int.TryParse(parts[1], out status);
+
+               return (status, separator >= 0 ? raw.Substring(separator + 4) : "");
+            }
+         }
       }
 
       private static Response Raw(string method, string path, string authorization, string requestBody, string extraHeaders = null)


### PR DESCRIPTION
The fourth slice of Phase 5: attachments on send.

**Foundation.** `HttpLimits` gains `max_request_bytes_large` and `request_seconds_large`; `HttpServer::SetLargeRequestFilter` grants the second cap per request by method and target, after the head has passed the first cap on its own (the head is never granted more). The REST listener grants 16 MB / 300 s to `POST /api/v1/me/messages` and `POST /api/v1/me/drafts` only.

**Attachments.** `attachments: [{name, type, data}]` (base64; ≤ 20, ≤ 12 MB together) on a send or a draft; each written under a safe name in a temp directory of its own and added through `Attachments::Add(path, type)` (new overload; COM's call unchanged), the directory removed afterwards.

**Page.** A file input, read in the browser.

**Tests.** Two added to `API/RestApiSelfService.cs`: attachments received over POP3 and served back from the Sent copy, the count limit refused; a 200 KB body accepted on the two routes (401 on bad credentials, not 413) and 413 elsewhere.

**Verification.** Release build warning-free; the RestApiSelfService fixture is 36 of 36 and the full suite 2124 tests, 2116 passed, 0 failed, 8 skipped (the usual explicit skips).

Roadmap: Phase 5 paragraph updated, Phase 3's "text only" note qualified; README updated.
