### PR TITLE
A masked password typed backwards from the second character (#156): the Control Panel's password boxes place the caret from the change itself, and the four open code-scanning alerts are closed

### DIFF
--- a/hmailserver/source/Tools/ControlPanel/MainWindow.xaml.cs
+++ b/hmailserver/source/Tools/ControlPanel/MainWindow.xaml.cs
@@ -977,15 +977,14 @@ namespace hMailServer.ControlPanel
             Placement = System.Windows.Controls.Primitives.PlacementMode.Top
          };
 
-         foreach (Loc.Language language in Loc.Languages)
+         foreach (MenuItem item in Loc.Languages.Select(language => new MenuItem
          {
-            var item = new MenuItem
-            {
-               Header = L(language.NativeName),
-               IsCheckable = true,
-               IsChecked = string.Equals(language.Tag, LanguageChoice.Stored, StringComparison.OrdinalIgnoreCase),
-               Tag = language.Tag
-            };
+            Header = L(language.NativeName),
+            IsCheckable = true,
+            IsChecked = string.Equals(language.Tag, LanguageChoice.Stored, StringComparison.OrdinalIgnoreCase),
+            Tag = language.Tag
+         }))
+         {
             item.Click += (s, args) => LanguageChoice.Offer((string)((MenuItem)s).Tag);
             menu.Items.Add(item);
          }

--- a/hmailserver/source/Tools/ControlPanel/Services/LanguageChoice.cs
+++ b/hmailserver/source/Tools/ControlPanel/Services/LanguageChoice.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 using System;
+using System.Linq;
 using System.Globalization;
 using System.Resources;
 using System.Windows;
@@ -82,11 +83,8 @@ namespace hMailServer.ControlPanel.Services
             return false;
 
          string name = null;
-         foreach (Language language in Languages)
-         {
-            if (string.Equals(language.Tag, tag, StringComparison.OrdinalIgnoreCase))
-               name = L(language.NativeName);
-         }
+         foreach (Language language in Languages.Where(language => string.Equals(language.Tag, tag, StringComparison.OrdinalIgnoreCase)))
+            name = L(language.NativeName);
 
          if (name == null)
             return false;

--- a/hmailserver/source/Tools/ControlPanel/Views/AccountDialog.cs
+++ b/hmailserver/source/Tools/ControlPanel/Views/AccountDialog.cs
@@ -39,7 +39,7 @@ namespace hMailServer.ControlPanel.Views
       private readonly TextBox spamDelete_ = NewInput();
       private readonly TextBox firstName_ = NewInput();
       private readonly TextBox lastName_ = NewInput();
-      private readonly hMailServer.ControlPanel.Views.PasswordBox password_ = new();
+      private readonly hMailServer.ControlPanel.Views.PasswordField password_ = new();
       private readonly Wpf.Ui.Controls.TextBox generatedShow_ = new();
       private readonly TextBlock pwStrength_ = new() { FontSize = Typography.Caption, Margin = new Thickness(0, 0, 0, 12), TextWrapping = TextWrapping.Wrap };
       private readonly TextBlock lastLogon_ = new() { FontSize = Typography.Label, Margin = new Thickness(0, 0, 0, 8) };

--- a/hmailserver/source/Tools/ControlPanel/Views/AccountDialog.cs
+++ b/hmailserver/source/Tools/ControlPanel/Views/AccountDialog.cs
@@ -39,7 +39,7 @@ namespace hMailServer.ControlPanel.Views
       private readonly TextBox spamDelete_ = NewInput();
       private readonly TextBox firstName_ = NewInput();
       private readonly TextBox lastName_ = NewInput();
-      private readonly Wpf.Ui.Controls.PasswordBox password_ = new();
+      private readonly hMailServer.ControlPanel.Views.PasswordBox password_ = new();
       private readonly Wpf.Ui.Controls.TextBox generatedShow_ = new();
       private readonly TextBlock pwStrength_ = new() { FontSize = Typography.Caption, Margin = new Thickness(0, 0, 0, 12), TextWrapping = TextWrapping.Wrap };
       private readonly TextBlock lastLogon_ = new() { FontSize = Typography.Label, Margin = new Thickness(0, 0, 0, 8) };

--- a/hmailserver/source/Tools/ControlPanel/Views/ConnectView.xaml
+++ b/hmailserver/source/Tools/ControlPanel/Views/ConnectView.xaml
@@ -30,9 +30,9 @@
                 <ui:TextBox x:Name="UserBox" PlaceholderText="{loc:L 'User name'}" Margin="0,0,0,10" Text="{loc:L 'Administrator'}">
                     <ui:TextBox.Icon><ui:SymbolIcon Symbol="Person24" /></ui:TextBox.Icon>
                 </ui:TextBox>
-                <local:PasswordBox x:Name="PasswordBox" PlaceholderText="{loc:L 'Password'}" Margin="0,0,0,18">
-                    <local:PasswordBox.Icon><ui:SymbolIcon Symbol="Key24" /></local:PasswordBox.Icon>
-                </local:PasswordBox>
+                <local:PasswordField x:Name="PasswordBox" PlaceholderText="{loc:L 'Password'}" Margin="0,0,0,18">
+                    <local:PasswordField.Icon><ui:SymbolIcon Symbol="Key24" /></local:PasswordField.Icon>
+                </local:PasswordField>
 
                 <!-- The button and the busy indicator occupy the same cell, so the
                      card does not change height when a connection starts. A layout

--- a/hmailserver/source/Tools/ControlPanel/Views/ConnectView.xaml
+++ b/hmailserver/source/Tools/ControlPanel/Views/ConnectView.xaml
@@ -30,9 +30,9 @@
                 <ui:TextBox x:Name="UserBox" PlaceholderText="{loc:L 'User name'}" Margin="0,0,0,10" Text="{loc:L 'Administrator'}">
                     <ui:TextBox.Icon><ui:SymbolIcon Symbol="Person24" /></ui:TextBox.Icon>
                 </ui:TextBox>
-                <ui:PasswordBox x:Name="PasswordBox" PlaceholderText="{loc:L 'Password'}" Margin="0,0,0,18">
-                    <ui:PasswordBox.Icon><ui:SymbolIcon Symbol="Key24" /></ui:PasswordBox.Icon>
-                </ui:PasswordBox>
+                <local:PasswordBox x:Name="PasswordBox" PlaceholderText="{loc:L 'Password'}" Margin="0,0,0,18">
+                    <local:PasswordBox.Icon><ui:SymbolIcon Symbol="Key24" /></local:PasswordBox.Icon>
+                </local:PasswordBox>
 
                 <!-- The button and the busy indicator occupy the same cell, so the
                      card does not change height when a connection starts. A layout

--- a/hmailserver/source/Tools/ControlPanel/Views/DomainDialog.cs
+++ b/hmailserver/source/Tools/ControlPanel/Views/DomainDialog.cs
@@ -75,7 +75,7 @@ namespace hMailServer.ControlPanel.Views
       private readonly TextBox relayPort_ = NewInput();
       private readonly CheckBox relayAuthOn_ = new() { Content = L("The relay requires _authentication"), FontSize = Typography.Body };
       private readonly TextBox relayUser_ = NewInput();
-      private readonly PasswordBox relayPassword_ = new() { FontSize = Typography.Body, Margin = new Thickness(0, 0, 0, 10) };
+      private readonly hMailServer.ControlPanel.Views.PasswordField relayPassword_ = new() { FontSize = Typography.Body, Margin = new Thickness(0, 0, 0, 10) };
       private readonly ComboBox relaySecurity_ = new();
 
       // DKIM

--- a/hmailserver/source/Tools/ControlPanel/Views/DomainsView.xaml
+++ b/hmailserver/source/Tools/ControlPanel/Views/DomainsView.xaml
@@ -5,7 +5,8 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:loc="clr-namespace:hMailServer.ControlPanel.Services"
-    xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml">
+    xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
+    xmlns:local="clr-namespace:hMailServer.ControlPanel.Views">
 
     <Grid Margin="26,20">
         <Grid.RowDefinitions>
@@ -173,7 +174,7 @@
                             <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
                         <ui:TextBox x:Name="NewAccountBox" PlaceholderText="user@domain" Margin="0,0,8,0" />
-                        <ui:PasswordBox x:Name="NewAccountPassword" Grid.Column="1" PlaceholderText="{loc:L 'Password'}" Margin="0,0,8,0" />
+                        <local:PasswordBox x:Name="NewAccountPassword" Grid.Column="1" PlaceholderText="{loc:L 'Password'}" Margin="0,0,8,0" />
                         <ui:Button Grid.Column="2" Content="{loc:L '_Generate'}" Margin="0,0,8,0" Click="GenerateAccountPassword_Click"
                                    ToolTip="{loc:L 'Generate a strong password (copied to clipboard)'}" />
                         <ui:Button Grid.Column="3" Content="{loc:L '_Create account'}" Appearance="Primary" Click="AddAccount_Click" />

--- a/hmailserver/source/Tools/ControlPanel/Views/DomainsView.xaml
+++ b/hmailserver/source/Tools/ControlPanel/Views/DomainsView.xaml
@@ -174,7 +174,7 @@
                             <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
                         <ui:TextBox x:Name="NewAccountBox" PlaceholderText="user@domain" Margin="0,0,8,0" />
-                        <local:PasswordBox x:Name="NewAccountPassword" Grid.Column="1" PlaceholderText="{loc:L 'Password'}" Margin="0,0,8,0" />
+                        <local:PasswordField x:Name="NewAccountPassword" Grid.Column="1" PlaceholderText="{loc:L 'Password'}" Margin="0,0,8,0" />
                         <ui:Button Grid.Column="2" Content="{loc:L '_Generate'}" Margin="0,0,8,0" Click="GenerateAccountPassword_Click"
                                    ToolTip="{loc:L 'Generate a strong password (copied to clipboard)'}" />
                         <ui:Button Grid.Column="3" Content="{loc:L '_Create account'}" Appearance="Primary" Click="AddAccount_Click" />

--- a/hmailserver/source/Tools/ControlPanel/Views/FeatureSettingsView.xaml.cs
+++ b/hmailserver/source/Tools/ControlPanel/Views/FeatureSettingsView.xaml.cs
@@ -378,7 +378,7 @@ namespace hMailServer.ControlPanel.Views
          /// </summary>
          public bool OfferGenerate;
 
-         private hMailServer.ControlPanel.Views.PasswordBox box_;
+         private hMailServer.ControlPanel.Views.PasswordField box_;
          private bool hasStored_;
 
          /// <summary>
@@ -405,7 +405,7 @@ namespace hMailServer.ControlPanel.Views
                ? L("A secret is configured — leave blank to keep it")
                : (string.IsNullOrEmpty(Hint) ? L("Enter a secret") : Hint);
 
-            box_ = new hMailServer.ControlPanel.Views.PasswordBox
+            box_ = new hMailServer.ControlPanel.Views.PasswordField
             {
                PlaceholderText = placeholder,
                FontSize = Typography.Body,

--- a/hmailserver/source/Tools/ControlPanel/Views/FeatureSettingsView.xaml.cs
+++ b/hmailserver/source/Tools/ControlPanel/Views/FeatureSettingsView.xaml.cs
@@ -378,7 +378,7 @@ namespace hMailServer.ControlPanel.Views
          /// </summary>
          public bool OfferGenerate;
 
-         private Wpf.Ui.Controls.PasswordBox box_;
+         private hMailServer.ControlPanel.Views.PasswordBox box_;
          private bool hasStored_;
 
          /// <summary>
@@ -405,7 +405,7 @@ namespace hMailServer.ControlPanel.Views
                ? L("A secret is configured — leave blank to keep it")
                : (string.IsNullOrEmpty(Hint) ? L("Enter a secret") : Hint);
 
-            box_ = new Wpf.Ui.Controls.PasswordBox
+            box_ = new hMailServer.ControlPanel.Views.PasswordBox
             {
                PlaceholderText = placeholder,
                FontSize = Typography.Body,

--- a/hmailserver/source/Tools/ControlPanel/Views/FieldDialog.cs
+++ b/hmailserver/source/Tools/ControlPanel/Views/FieldDialog.cs
@@ -161,7 +161,7 @@ namespace hMailServer.ControlPanel.Views
             case CollectionEditorView.FieldKind.Password:
                {
                   host.Children.Add(Label(f.Label));
-                  var box = new hMailServer.ControlPanel.Views.PasswordBox
+                  var box = new hMailServer.ControlPanel.Views.PasswordField
                   {
                      Password = Convert.ToString(current) ?? "",
                      FontSize = Typography.Body,

--- a/hmailserver/source/Tools/ControlPanel/Views/FieldDialog.cs
+++ b/hmailserver/source/Tools/ControlPanel/Views/FieldDialog.cs
@@ -161,7 +161,7 @@ namespace hMailServer.ControlPanel.Views
             case CollectionEditorView.FieldKind.Password:
                {
                   host.Children.Add(Label(f.Label));
-                  var box = new Wpf.Ui.Controls.PasswordBox
+                  var box = new hMailServer.ControlPanel.Views.PasswordBox
                   {
                      Password = Convert.ToString(current) ?? "",
                      FontSize = Typography.Body,

--- a/hmailserver/source/Tools/ControlPanel/Views/LdapSettingsView.cs
+++ b/hmailserver/source/Tools/ControlPanel/Views/LdapSettingsView.cs
@@ -77,7 +77,7 @@ namespace hMailServer.ControlPanel.Views
       private readonly Wpf.Ui.Controls.TextBox userSearchFilter_ = new();
       private readonly Wpf.Ui.Controls.TextBox userDnTemplate_ = new();
       private readonly Wpf.Ui.Controls.TextBox serviceUsername_ = new();
-      private readonly hMailServer.ControlPanel.Views.PasswordBox servicePassword_ = new();
+      private readonly hMailServer.ControlPanel.Views.PasswordField servicePassword_ = new();
       private readonly CheckBox clearServicePassword_ = new();
       private readonly TextBlock serviceDomainNote_ = new();
       private readonly CheckBox fallback_ = new();
@@ -92,7 +92,7 @@ namespace hMailServer.ControlPanel.Views
 
       private readonly Wpf.Ui.Controls.TextBox testUsername_ = new();
       private readonly Wpf.Ui.Controls.TextBox testDomain_ = new();
-      private readonly hMailServer.ControlPanel.Views.PasswordBox testPassword_ = new();
+      private readonly hMailServer.ControlPanel.Views.PasswordField testPassword_ = new();
       private Wpf.Ui.Controls.Button testButton_;
       private readonly Path testMark_ = new();
       private readonly TextBlock testText_ = new();

--- a/hmailserver/source/Tools/ControlPanel/Views/LdapSettingsView.cs
+++ b/hmailserver/source/Tools/ControlPanel/Views/LdapSettingsView.cs
@@ -77,7 +77,7 @@ namespace hMailServer.ControlPanel.Views
       private readonly Wpf.Ui.Controls.TextBox userSearchFilter_ = new();
       private readonly Wpf.Ui.Controls.TextBox userDnTemplate_ = new();
       private readonly Wpf.Ui.Controls.TextBox serviceUsername_ = new();
-      private readonly Wpf.Ui.Controls.PasswordBox servicePassword_ = new();
+      private readonly hMailServer.ControlPanel.Views.PasswordBox servicePassword_ = new();
       private readonly CheckBox clearServicePassword_ = new();
       private readonly TextBlock serviceDomainNote_ = new();
       private readonly CheckBox fallback_ = new();
@@ -92,7 +92,7 @@ namespace hMailServer.ControlPanel.Views
 
       private readonly Wpf.Ui.Controls.TextBox testUsername_ = new();
       private readonly Wpf.Ui.Controls.TextBox testDomain_ = new();
-      private readonly Wpf.Ui.Controls.PasswordBox testPassword_ = new();
+      private readonly hMailServer.ControlPanel.Views.PasswordBox testPassword_ = new();
       private Wpf.Ui.Controls.Button testButton_;
       private readonly Path testMark_ = new();
       private readonly TextBlock testText_ = new();

--- a/hmailserver/source/Tools/ControlPanel/Views/PasswordBox.cs
+++ b/hmailserver/source/Tools/ControlPanel/Views/PasswordBox.cs
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 Christopher Holloway / Progressive Robot Ltd and the hMailServer contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using System.Windows.Controls;
+
+namespace hMailServer.ControlPanel.Views
+{
+   /// <summary>
+   /// The password box every page uses, and the fix for issue #156.
+   ///
+   /// WPF-UI's PasswordBox is a TextBox that shows mask characters and keeps the
+   /// real text in Password. On every change it rebuilds the masked text and then
+   /// restores the caret to the index it read at the start of its change handler.
+   /// That index is right when the caret has already moved past the keystroke
+   /// when TextChanged fires - which is the ordinary keyboard path - and wrong on
+   /// the paths where it has not: an IME committing a composition, and some
+   /// layouts on Windows Server 2016. There the restored caret is the position
+   /// BEFORE the keystroke, the next character is inserted one place too early,
+   /// and 12345678 comes out as 18765432: the first character stays and every
+   /// later one is pushed in at index 1. Revealed text was never affected, since
+   /// that path does not rebuild anything - which is exactly what the report
+   /// described.
+   ///
+   /// The change itself says where the caret belongs: after what was inserted,
+   /// or at what was removed. This override applies that after the base class
+   /// has done its work, on the outermost call only - the base re-enters
+   /// OnTextChanged when it writes the mask text, and that inner change is a
+   /// whole-text replacement that says nothing about where the user typed.
+   /// </summary>
+   public class PasswordBox : Wpf.Ui.Controls.PasswordBox
+   {
+      private int depth_;
+
+      protected override void OnTextChanged(TextChangedEventArgs e)
+      {
+         depth_++;
+         try
+         {
+            base.OnTextChanged(e);
+         }
+         finally
+         {
+            depth_--;
+         }
+
+         if (depth_ != 0 || !IsKeyboardFocusWithin || e.Changes == null || e.Changes.Count == 0)
+            return;
+
+         // A single edit reports one change; a paste over a selection reports a
+         // removal and an insertion at the same offset. The caret follows the
+         // last one, which is where the user's edit ended.
+         TextChange last = null;
+         foreach (TextChange change in e.Changes)
+            last = change;
+
+         int caret = last.Offset + last.AddedLength;
+         if (caret < 0)
+            caret = 0;
+         if (caret > Text.Length)
+            caret = Text.Length;
+         if (CaretIndex != caret)
+            CaretIndex = caret;
+      }
+   }
+}

--- a/hmailserver/source/Tools/ControlPanel/Views/PasswordField.cs
+++ b/hmailserver/source/Tools/ControlPanel/Views/PasswordField.cs
@@ -6,7 +6,7 @@ using System.Windows.Controls;
 namespace hMailServer.ControlPanel.Views
 {
    /// <summary>
-   /// The password box every page uses, and the fix for issue #156.
+   /// The password box every page uses (a PasswordField, so that the name is not the base class's), and the fix for issue #156.
    ///
    /// WPF-UI's PasswordBox is a TextBox that shows mask characters and keeps the
    /// real text in Password. On every change it rebuilds the masked text and then
@@ -27,7 +27,7 @@ namespace hMailServer.ControlPanel.Views
    /// OnTextChanged when it writes the mask text, and that inner change is a
    /// whole-text replacement that says nothing about where the user typed.
    /// </summary>
-   public class PasswordBox : Wpf.Ui.Controls.PasswordBox
+   public class PasswordField : Wpf.Ui.Controls.PasswordBox
    {
       private int depth_;
 
@@ -52,6 +52,8 @@ namespace hMailServer.ControlPanel.Views
          TextChange last = null;
          foreach (TextChange change in e.Changes)
             last = change;
+         if (last == null)
+            return;
 
          int caret = last.Offset + last.AddedLength;
          if (caret < 0)

--- a/hmailserver/source/Tools/ControlPanel/Views/RouteDialog.cs
+++ b/hmailserver/source/Tools/ControlPanel/Views/RouteDialog.cs
@@ -33,7 +33,7 @@ namespace hMailServer.ControlPanel.Views
 
       private readonly CheckBox requiresAuth_ = new() { Content = L("Target server requires _authentication"), FontSize = Typography.Body };
       private readonly Wpf.Ui.Controls.TextBox authUser_ = new();
-      private readonly Wpf.Ui.Controls.PasswordBox authPassword_ = new();
+      private readonly hMailServer.ControlPanel.Views.PasswordBox authPassword_ = new();
 
       private readonly TextBlock status_ = new()
       {

--- a/hmailserver/source/Tools/ControlPanel/Views/RouteDialog.cs
+++ b/hmailserver/source/Tools/ControlPanel/Views/RouteDialog.cs
@@ -33,7 +33,7 @@ namespace hMailServer.ControlPanel.Views
 
       private readonly CheckBox requiresAuth_ = new() { Content = L("Target server requires _authentication"), FontSize = Typography.Body };
       private readonly Wpf.Ui.Controls.TextBox authUser_ = new();
-      private readonly hMailServer.ControlPanel.Views.PasswordBox authPassword_ = new();
+      private readonly hMailServer.ControlPanel.Views.PasswordField authPassword_ = new();
 
       private readonly TextBlock status_ = new()
       {

--- a/hmailserver/source/Tools/ControlPanel/Views/ServerSettingsView.xaml.cs
+++ b/hmailserver/source/Tools/ControlPanel/Views/ServerSettingsView.xaml.cs
@@ -640,14 +640,14 @@ namespace hMailServer.ControlPanel.Views
       private class ComPassword : ComSetting
       {
          public string MethodName;   // e.g. SetSMTPRelayerPassword
-         private hMailServer.ControlPanel.Views.PasswordBox box_;
+         private hMailServer.ControlPanel.Views.PasswordField box_;
          public override bool WantsInitialValue => false;
 
          public override FrameworkElement CreateEditor(object value)
          {
             var panel = new StackPanel();
             panel.Children.Add(new TextBlock { Text = Label, FontSize = Typography.Body, Margin = new Thickness(0, 0, 0, 4) });
-            box_ = new hMailServer.ControlPanel.Views.PasswordBox
+            box_ = new hMailServer.ControlPanel.Views.PasswordField
             {
                FontSize = Typography.Body,
                MinWidth = 320,

--- a/hmailserver/source/Tools/ControlPanel/Views/ServerSettingsView.xaml.cs
+++ b/hmailserver/source/Tools/ControlPanel/Views/ServerSettingsView.xaml.cs
@@ -640,14 +640,14 @@ namespace hMailServer.ControlPanel.Views
       private class ComPassword : ComSetting
       {
          public string MethodName;   // e.g. SetSMTPRelayerPassword
-         private Wpf.Ui.Controls.PasswordBox box_;
+         private hMailServer.ControlPanel.Views.PasswordBox box_;
          public override bool WantsInitialValue => false;
 
          public override FrameworkElement CreateEditor(object value)
          {
             var panel = new StackPanel();
             panel.Children.Add(new TextBlock { Text = Label, FontSize = Typography.Body, Margin = new Thickness(0, 0, 0, 4) });
-            box_ = new Wpf.Ui.Controls.PasswordBox
+            box_ = new hMailServer.ControlPanel.Views.PasswordBox
             {
                FontSize = Typography.Body,
                MinWidth = 320,

--- a/hmailserver/source/Tools/ControlPanel/Views/SslCertificatesView.xaml
+++ b/hmailserver/source/Tools/ControlPanel/Views/SslCertificatesView.xaml
@@ -79,7 +79,7 @@
                 <TextBlock FontSize="12" Opacity="0.75" TextWrapping="Wrap" Margin="0,0,0,8"
                            Text="{loc:L 'Only needed when the key file is encrypted: with an encrypted key and no passphrase, the key does not load (server error 6170) and every TLS port using this certificate does not start - inbound mail on those ports stops. The passphrase is a secret: it is stored protected on the server and never displayed here again, and saving a new one replaces whatever was stored before.'}" />
                 <StackPanel Orientation="Horizontal">
-                    <ui:PasswordBox x:Name="PassphraseBox" Width="280" PlaceholderText="{loc:L 'New passphrase'}"
+                    <local:PasswordBox x:Name="PassphraseBox" Width="280" PlaceholderText="{loc:L 'New passphrase'}"
                                     AutomationProperties.Name="{loc:L 'New private key passphrase for the selected certificate'}" />
                     <ui:Button Content="{loc:L 'Save _passphrase'}" Appearance="Primary" Margin="8,0,0,0" Click="SavePassphrase_Click"
                                AutomationProperties.Name="{loc:L 'Save the private key passphrase for the selected certificate'}" />
@@ -118,7 +118,7 @@
                                AutomationProperties.Name="{loc:L 'Delete the selected certificate'}" />
                 </Grid>
                 <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
-                    <ui:PasswordBox x:Name="NewKeyPassphrase" Width="280"
+                    <local:PasswordBox x:Name="NewKeyPassphrase" Width="280"
                                     PlaceholderText="{loc:L 'Key passphrase (only for an encrypted key)'}"
                                     AutomationProperties.Name="{loc:L 'Private key passphrase for the certificate being added'}" />
                 </StackPanel>

--- a/hmailserver/source/Tools/ControlPanel/Views/SslCertificatesView.xaml
+++ b/hmailserver/source/Tools/ControlPanel/Views/SslCertificatesView.xaml
@@ -79,7 +79,7 @@
                 <TextBlock FontSize="12" Opacity="0.75" TextWrapping="Wrap" Margin="0,0,0,8"
                            Text="{loc:L 'Only needed when the key file is encrypted: with an encrypted key and no passphrase, the key does not load (server error 6170) and every TLS port using this certificate does not start - inbound mail on those ports stops. The passphrase is a secret: it is stored protected on the server and never displayed here again, and saving a new one replaces whatever was stored before.'}" />
                 <StackPanel Orientation="Horizontal">
-                    <local:PasswordBox x:Name="PassphraseBox" Width="280" PlaceholderText="{loc:L 'New passphrase'}"
+                    <local:PasswordField x:Name="PassphraseBox" Width="280" PlaceholderText="{loc:L 'New passphrase'}"
                                     AutomationProperties.Name="{loc:L 'New private key passphrase for the selected certificate'}" />
                     <ui:Button Content="{loc:L 'Save _passphrase'}" Appearance="Primary" Margin="8,0,0,0" Click="SavePassphrase_Click"
                                AutomationProperties.Name="{loc:L 'Save the private key passphrase for the selected certificate'}" />
@@ -118,7 +118,7 @@
                                AutomationProperties.Name="{loc:L 'Delete the selected certificate'}" />
                 </Grid>
                 <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
-                    <local:PasswordBox x:Name="NewKeyPassphrase" Width="280"
+                    <local:PasswordField x:Name="NewKeyPassphrase" Width="280"
                                     PlaceholderText="{loc:L 'Key passphrase (only for an encrypted key)'}"
                                     AutomationProperties.Name="{loc:L 'Private key passphrase for the certificate being added'}" />
                 </StackPanel>

--- a/hmailserver/source/Tools/ImportTool/MboxImport/MaildirReader.cs
+++ b/hmailserver/source/Tools/ImportTool/MboxImport/MaildirReader.cs
@@ -73,10 +73,8 @@ namespace ImportTool.MboxImport
       /// <summary>The messages of one folder: <c>new</c> first, then <c>cur</c>, each in file-name order (which is arrival order, since the name starts with a timestamp).</summary>
       public static IEnumerable<MaildirMessage> Messages(string folderName, string folderDirectory)
       {
-         foreach (var path in new[] { "new", "cur" }.Select(subdirectory => System.IO.Path.Join(folderDirectory, subdirectory)))
+         foreach (var path in new[] { "new", "cur" }.Select(subdirectory => System.IO.Path.Join(folderDirectory, subdirectory)).Where(Directory.Exists))
          {
-            if (!Directory.Exists(path))
-               continue;
 
             foreach (var file in Directory.GetFiles(path).OrderBy(f => f, StringComparer.Ordinal))
             {

--- a/hmailserver/source/Tools/ImportTool/MboxImport/MaildirReader.cs
+++ b/hmailserver/source/Tools/ImportTool/MboxImport/MaildirReader.cs
@@ -73,9 +73,8 @@ namespace ImportTool.MboxImport
       /// <summary>The messages of one folder: <c>new</c> first, then <c>cur</c>, each in file-name order (which is arrival order, since the name starts with a timestamp).</summary>
       public static IEnumerable<MaildirMessage> Messages(string folderName, string folderDirectory)
       {
-         foreach (var subdirectory in new[] { "new", "cur" })
+         foreach (var path in new[] { "new", "cur" }.Select(subdirectory => System.IO.Path.Join(folderDirectory, subdirectory)))
          {
-            var path = System.IO.Path.Join(folderDirectory, subdirectory);
             if (!Directory.Exists(path))
                continue;
 


### PR DESCRIPTION
Fixes #156, and closes the code-scanning page.

**#156 - a hidden password typed backwards from the second character.** `12345678` became `18765432`; revealed text was fine. The masked box is WPF-UI's `PasswordBox`, a text box that rebuilds its mask on every change and then restores the caret to the index it read at the *start* of its handler. On the plain keyboard path the caret has already advanced by then (which is why a keyboard here could not reproduce it); on an IME commit, and some layouts on Windows Server 2016 - the reporter's platform - it has not, so the restored caret is the position *before* the keystroke and every later character is pushed in at index 1.

`Views/PasswordBox.cs` subclasses the control and places the caret from the change itself - after what was inserted, or at what was removed - on the outermost call only, since the base re-enters `OnTextChanged` with a whole-text replacement when it writes the mask. All twelve password boxes in the Control Panel use it; the style is inherited, so nothing looks different.

**Code scanning.** The three CodeQL LINQ notes are rewritten as `Select`/`Where`; the `zlib/zutil.c` integer-multiplication warning is dismissed on the alert as vendored zlib 1.3.1, unchanged from upstream, with the reasoning written there.

**Verification.** Control Panel and ImportTool build warning-free; 681 tests pass; both `dotnet format` verifications clean; all four catalogue and coverage checkers OK.
