### PR TITLE
The thirty-six open Code Quality findings closed on their merits, all in the test tree: nine disposables disposed, eight Path.Combine calls made to say what they join, ten catch blocks narrowed to what is actually thrown, and eight small rewrites

### DIFF
--- a/hmailserver/source/Tools/ControlPanel.Tests/Services/LocTests.cs
+++ b/hmailserver/source/Tools/ControlPanel.Tests/Services/LocTests.cs
@@ -117,10 +117,11 @@ namespace hMailServer.ControlPanel.Tests.Services
          if (resources == null)
             return;   // sources not available (a packaged drop)
 
-         foreach (Loc.Language language in Loc.Languages)
+         // The empty tag is "follow Windows" and English needs no catalogue of its own,
+         // so neither is asked for a .resx. The order of the two tests matters: the tag
+         // has to be non-empty before GetCultureInfo is handed it.
+         foreach (Loc.Language language in Loc.Languages.Where(l => l.Tag.Length != 0 && !Loc.IsEnglish(CultureInfo.GetCultureInfo(l.Tag))))
          {
-            if (language.Tag.Length == 0 || Loc.IsEnglish(CultureInfo.GetCultureInfo(language.Tag)))
-               continue;
             Assert.True(File.Exists(Path.Join(resources, "Strings." + language.Tag + ".resx")),
                "The language picker offers '" + language.NativeName + "' and no Strings." + language.Tag + ".resx exists.");
          }

--- a/hmailserver/test/RegressionTests/API/RestApiSelfService.cs
+++ b/hmailserver/test/RegressionTests/API/RestApiSelfService.cs
@@ -1610,11 +1610,11 @@ namespace RegressionTests.API
          Assert.AreEqual(200, file.Status, file.Body);
          Assert.AreEqual(numbers, file.BodyBytes);
 
-         string tooMany = "{\"to\":\"" + other + "\",\"text\":\"x\",\"attachments\":[";
+         StringBuilder tooMany = new StringBuilder("{\"to\":\"" + other + "\",\"text\":\"x\",\"attachments\":[");
          for (int i = 0; i < 21; i++)
-            tooMany += (i > 0 ? "," : "") + "{\"name\":\"f" + i + ".txt\",\"type\":\"text/plain\",\"data\":\"aGk=\"}";
-         tooMany += "]}";
-         (int status, string body) refused = Http("POST", "/api/v1/me/messages", UserHeader(UserPassword), tooMany);
+            tooMany.Append(i > 0 ? "," : "").Append("{\"name\":\"f" + i + ".txt\",\"type\":\"text/plain\",\"data\":\"aGk=\"}");
+         tooMany.Append("]}");
+         (int status, string body) refused = Http("POST", "/api/v1/me/messages", UserHeader(UserPassword), tooMany.ToString());
          Assert.AreEqual(400, refused.status, "Body: " + refused.body);
          Pop3ClientSimulator.AssertMessageCount(other, UserPassword, 0);
       }

--- a/hmailserver/test/RegressionTests/API/UpdateApply.cs
+++ b/hmailserver/test/RegressionTests/API/UpdateApply.cs
@@ -296,9 +296,9 @@ namespace RegressionTests.API
          if (_quiet != null)
             return;
 
-         string directory = Path.Combine(Path.GetTempPath(), "hm-fake-installers");
+         string directory = Paths.Combine(Path.GetTempPath(), "hm-fake-installers");
          Directory.CreateDirectory(directory);
-         _marker = Path.Combine(directory, "ran.log");
+         _marker = Paths.Combine(directory, "ran.log");
 
          _quiet = Compile(directory, "quiet", "", 0);
          _stopper = Compile(directory, "stopper",
@@ -327,7 +327,10 @@ namespace RegressionTests.API
             "      return " + exitCode + ";\n" +
             "   }\n}\n";
 
-         string path = Path.Combine(directory, name + ".exe");
+         // The name is one of the five words CompileFakeInstallers passes - "quiet",
+         // "stopper", "starter", "failing", "ager" - so what is appended here is a file
+         // name, never a rooted path that would displace the directory.
+         string path = Paths.Combine(directory, name + ".exe");
          using (CodeDomProvider provider = CodeDomProvider.CreateProvider("CSharp"))
          {
             var parameters = new CompilerParameters {GenerateExecutable = true, OutputAssembly = path, GenerateInMemory = false};
@@ -404,7 +407,9 @@ namespace RegressionTests.API
       private string Release(string version, string name, byte[] installer)
       {
          string download = _feed.UrlFor("/download/");
-         string digest = "sha256:" + FakeSigstore.Hex(SHA256.Create().ComputeHash(installer));
+         string digest;
+         using (var sha = SHA256.Create())
+            digest = "sha256:" + FakeSigstore.Hex(sha.ComputeHash(installer));
          return "{\"html_url\":\"https://github.com/Progressiverobot/hmailserver/releases/tag/v" + version + "\"," +
                 "\"tag_name\":\"v" + version + "\",\"name\":\"hMailServer " + version + "\",\"draft\":false,\"prerelease\":false," +
                 "\"published_at\":\"2026-09-12T10:00:00Z\",\"assets\":[" +

--- a/hmailserver/test/RegressionTests/API/UpdateSchedule.cs
+++ b/hmailserver/test/RegressionTests/API/UpdateSchedule.cs
@@ -4,8 +4,10 @@
 
 using System;
 using System.CodeDom.Compiler;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Net.Sockets;
 using System.Security.Cryptography;
 using System.Text;
@@ -51,7 +53,9 @@ namespace RegressionTests.API
          _sigstore = new FakeSigstore();
          _updatesDirectory = Paths.Combine(_settings.Directories.DataDirectory, "Updates");
          CleanUpdates();
-         _backupDirectory = Path.Combine(Path.GetTempPath(), "hm-update-backup-" + Guid.NewGuid().ToString("N"));
+         // A directory of the fixture's own for each test: the second part is this
+         // prefix and a bare hex guid, so it can never be a rooted path.
+         _backupDirectory = Paths.Combine(Path.GetTempPath(), "hm-update-backup-" + Guid.NewGuid().ToString("N"));
          _previousBackupDestination = _settings.Backup.Destination;
 
          _feed = new FakeHttpEndpoint(200, "{}");
@@ -234,14 +238,14 @@ namespace RegressionTests.API
       {
          if (_quiet != null)
             return;
-         string directory = Path.Combine(Path.GetTempPath(), "hm-fake-installers");
+         string directory = Paths.Combine(Path.GetTempPath(), "hm-fake-installers");
          Directory.CreateDirectory(directory);
-         _marker = Path.Combine(directory, "ran-schedule.log");
+         _marker = Paths.Combine(directory, "ran-schedule.log");
          string source =
             "using System;\nusing System.IO;\nclass FakeInstaller\n{\n   static int Main(string[] args)\n   {\n" +
             "      File.AppendAllText(@\"" + _marker + "\", \"quiet \" + string.Join(\" \", args) + Environment.NewLine);\n" +
             "      return 0;\n   }\n}\n";
-         string path = Path.Combine(directory, "quiet-schedule.exe");
+         string path = Paths.Combine(directory, "quiet-schedule.exe");
          using (CodeDomProvider provider = CodeDomProvider.CreateProvider("CSharp"))
          {
             var parameters = new CompilerParameters {GenerateExecutable = true, OutputAssembly = path, GenerateInMemory = false};
@@ -311,7 +315,9 @@ namespace RegressionTests.API
       private string Release(string version, string name, byte[] installer)
       {
          string download = _feed.UrlFor("/download/");
-         string digest = "sha256:" + FakeSigstore.Hex(SHA256.Create().ComputeHash(installer));
+         string digest;
+         using (var sha = SHA256.Create())
+            digest = "sha256:" + FakeSigstore.Hex(sha.ComputeHash(installer));
          return "{\"html_url\":\"https://github.com/Progressiverobot/hmailserver/releases/tag/v" + version + "\"," +
                 "\"tag_name\":\"v" + version + "\",\"name\":\"hMailServer " + version + "\",\"draft\":false,\"prerelease\":false," +
                 "\"published_at\":\"2026-09-12T10:00:00Z\",\"assets\":[" +
@@ -322,11 +328,7 @@ namespace RegressionTests.API
 
       private int CountRequests(string fragment)
       {
-         int count = 0;
-         foreach (string request in _feed.Requests)
-            if (request.Contains(fragment))
-               count++;
-         return count;
+         return _feed.Requests.Count(request => request.Contains(fragment));
       }
 
       private static string WaitForOutcome(string path, int seconds)
@@ -357,14 +359,19 @@ namespace RegressionTests.API
             {
                File.Delete(file);
             }
-            catch (IOException)
+            catch (IOException ex)
             {
+               // A file the server still has open - the installer it is downloading or
+               // applying. The next run's clean-up gets it, and a leftover under Updates
+               // costs the following fixture nothing, so it is traced and not failed on.
+               Trace.WriteLine("UpdateSchedule: " + file + " could not be deleted: " + ex.Message);
             }
-            catch (UnauthorizedAccessException)
+            catch (UnauthorizedAccessException ex)
             {
                // apply-token carries a DACL naming SYSTEM, Administrators and the
                // service account only; the suite is none of those. The server
                // revokes it after an apply, and one never redeemed expires.
+               Trace.WriteLine("UpdateSchedule: " + file + " is not the suite's to delete: " + ex.Message);
             }
          }
       }

--- a/hmailserver/test/RegressionTests/API/UpdateVerify.cs
+++ b/hmailserver/test/RegressionTests/API/UpdateVerify.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using System.Net.Sockets;
 using System.Security.Cryptography;
 using System.Text;
@@ -371,7 +372,9 @@ namespace RegressionTests.API
       {
          version = version ?? Newer;
          string name = "hMailServer-" + version + "-x64.exe";
-         byte[] hash = SHA256.Create().ComputeHash(installer);
+         byte[] hash;
+         using (var sha = SHA256.Create())
+            hash = sha.ComputeHash(installer);
          digest = digest ?? "sha256:" + FakeSigstore.Hex(hash);
 
          _feed.ClearRoutes();
@@ -396,11 +399,7 @@ namespace RegressionTests.API
 
       private int CountRequests(string fragment)
       {
-         int count = 0;
-         foreach (string request in _feed.Requests)
-            if (request.Contains(fragment))
-               count++;
-         return count;
+         return _feed.Requests.Count(request => request.Contains(fragment));
       }
 
       private void AssertNothingKept()

--- a/hmailserver/test/RegressionTests/IMAP/Compress.cs
+++ b/hmailserver/test/RegressionTests/IMAP/Compress.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
 using System.Net.Sockets;
@@ -264,11 +265,27 @@ namespace RegressionTests.IMAP
                         _rawCompressed.Add(buffer[i]);
                }
             }
-            catch (Exception ex)
+            catch (Exception ex) when (RecordUnlessClosed(ex))
             {
-               if (!_closed)
-                  _readerError = ex;
+               // Every exception, deliberately: nothing may leave a background thread,
+               // where an unhandled one ends the whole run instead of one test. The
+               // filter takes all of them and does the deciding, so that _closed is read
+               // exactly once - two clauses, one filtered on the flag and one on its
+               // negation, would read it twice, and Dispose setting it between those two
+               // reads would leave the exception unhandled here.
+               Trace.WriteLine("DeflateImapClient: the reader stopped on " + ex.GetType().Name + ": " + ex.Message);
             }
+         }
+
+         // The reader's catch filter, true for every exception. The single read of _closed
+         // is what says which kind this is: after Dispose it is the socket closed under the
+         // read this thread was blocked in, which is how the reader is meant to end; before
+         // it, it is a real failure, and ReadUntil fails the test with it.
+         private bool RecordUnlessClosed(Exception ex)
+         {
+            if (!_closed)
+               _readerError = ex;
+            return true;
          }
 
          // The whole compressed run inflated from the start, as an ISO-8859-1 string.
@@ -386,8 +403,12 @@ namespace RegressionTests.IMAP
             {
                _client.Close();
             }
-            catch (Exception)
+            catch (Exception ex) when (ex is IOException || ex is SocketException || ex is ObjectDisposedException)
             {
+               // The reader thread is blocked in a read on this socket, and closing it is
+               // how that read is ended; a close that throws is that race, not a failure
+               // of the test. The Join below still waits for the reader to leave.
+               Trace.WriteLine("DeflateImapClient: closing the socket threw " + ex.GetType().Name + ": " + ex.Message);
             }
             if (_readerThread != null)
                _readerThread.Join(2000);

--- a/hmailserver/test/RegressionTests/Infrastructure/HttpFoundation.cs
+++ b/hmailserver/test/RegressionTests/Infrastructure/HttpFoundation.cs
@@ -462,9 +462,13 @@ namespace RegressionTests.Infrastructure
                   reply.Headers[lines[i].Substring(0, colon).Trim()] = lines[i].Substring(colon + 1).Trim();
             }
 
+            // A response with no Content-Length, or one that is not a number, is read
+            // as a response with no body - which is what the framing tests here expect
+            // of a 204 or a HEAD.
             int length = 0;
-            if (reply.Headers.ContainsKey("Content-Length"))
-               int.TryParse(reply.Headers["Content-Length"], out length);
+            string declaredLength;
+            if (reply.Headers.TryGetValue("Content-Length", out declaredLength))
+               int.TryParse(declaredLength, out length);
 
             byte[] body = ReadExactly(length);
             reply.Body = Encoding.UTF8.GetString(body);

--- a/hmailserver/test/RegressionTests/Security/DnssecDenialOfExistence.cs
+++ b/hmailserver/test/RegressionTests/Security/DnssecDenialOfExistence.cs
@@ -35,8 +35,15 @@ namespace RegressionTests.Security
       private const int Bogus = 2;
       private const uint Ttl = 60;
 
-      private static DnssecZone _root;
-      private static DnssecZone _tld;
+      // The root and the TLD are built once for the whole fixture and every test's child
+      // zone hangs off them, so they have to outlive a single test - but they are instance
+      // fields, not static ones. The setup that builds them cannot be made static: it
+      // restarts the server through TestFixtureBase.RestartServerAndReacquireCom, an
+      // instance member. NUnit gives a fixture one instance for its entire run, so a
+      // single pair of zones is what [OneTimeSetUp], the tests and [OneTimeTearDown] all
+      // see either way.
+      private DnssecZone _root;
+      private DnssecZone _tld;
 
       [OneTimeSetUp]
       public void SignTheRootAndTheTld()
@@ -96,14 +103,14 @@ namespace RegressionTests.Security
          return child;
       }
 
-      private static void PublishDs(DnssecZone child)
+      private void PublishDs(DnssecZone child)
       {
          SuiteDns.Zone.WithRaw(child.Name, DnsWire.TypeDs, child.DsRdata)
                  .WithRrsig(child.Name, DnsWire.TypeDs, _tld.Sign(child.Name, DnsWire.TypeDs, Ttl, new[] { child.DsRdata }));
       }
 
       /// <summary>An NSEC at the child's name, signed by the TLD, with the types given - the proof the parent gives that no DS exists.</summary>
-      private static void PublishNsecDenial(DnssecZone child, int[] types, DnssecZone signer = null, DateTime? expiration = null, string owner = null)
+      private void PublishNsecDenial(DnssecZone child, int[] types, DnssecZone signer = null, DateTime? expiration = null, string owner = null)
       {
          owner = owner ?? child.Name;
          var nsec = DnsWire.Nsec("zzz.test", types);
@@ -113,7 +120,7 @@ namespace RegressionTests.Security
       }
 
       /// <summary>An NSEC3 in the TLD whose hashed owner matches the child (or covers it), signed by the TLD.</summary>
-      private static void PublishNsec3Denial(DnssecZone child, int[] types, bool matching, bool optOut)
+      private void PublishNsec3Denial(DnssecZone child, int[] types, bool matching, bool optOut)
       {
          var salt = new byte[] { 0xAB, 0xCD };
          const ushort iterations = 2;

--- a/hmailserver/test/RegressionTests/Shared/DnssecSigner.cs
+++ b/hmailserver/test/RegressionTests/Shared/DnssecSigner.cs
@@ -34,9 +34,10 @@ namespace RegressionTests.Shared
       public static byte[] Name(string name)
       {
          var wire = new List<byte>();
-         foreach (var label in name.TrimEnd('.').ToLowerInvariant().Split(new[] { '.' }, StringSplitOptions.RemoveEmptyEntries))
+         foreach (var bytes in name.TrimEnd('.').ToLowerInvariant()
+                                   .Split(new[] { '.' }, StringSplitOptions.RemoveEmptyEntries)
+                                   .Select(label => Encoding.ASCII.GetBytes(label)))
          {
-            var bytes = Encoding.ASCII.GetBytes(label);
             wire.Add((byte) bytes.Length);
             wire.AddRange(bytes);
          }
@@ -57,9 +58,8 @@ namespace RegressionTests.Shared
          {
             var bits = new byte[32];
             var length = 0;
-            foreach (var type in window)
+            foreach (var low in window.Select(type => type & 0xFF))
             {
-               var low = type & 0xFF;
                bits[low >> 3] |= (byte) (0x80 >> (low & 7));
                length = Math.Max(length, (low >> 3) + 1);
             }

--- a/hmailserver/test/RegressionTests/Shared/FakeHttpProxy.cs
+++ b/hmailserver/test/RegressionTests/Shared/FakeHttpProxy.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Net;
 using System.Net.Sockets;
@@ -92,7 +93,10 @@ namespace RegressionTests.Shared
 
                var head = new StringBuilder();
                var buffer = new byte[4096];
-               var leftover = new MemoryStream();
+               // The body bytes that arrived with the header outlive the nested blocks
+               // below, so the declaration disposes it once this connection is done -
+               // on every path out, including the early returns.
+               using var leftover = new MemoryStream();
                int headerEnd = -1;
                while (headerEnd < 0)
                {
@@ -202,7 +206,13 @@ namespace RegressionTests.Shared
       /// <summary>Copies both ways until either side closes, then returns.</summary>
       private static void Relay(NetworkStream client, NetworkStream upstream)
       {
-         var done = new ManualResetEvent(false);
+         // Either pump finishing ends the relay, but the other is still blocked in its
+         // read at that moment and the Join below is bounded, so a pump can outlive this
+         // call. A ManualResetEvent would then have to be disposed while a live thread
+         // could still Set() it, which is a race no ordering here can close; a monitor on
+         // a plain object carries the same signal and needs no disposal at all.
+         var done = new object();
+         bool finished = false;
          ThreadStart pump = () => { };
          Action<Stream, Stream> copy = (from, to) =>
          {
@@ -218,23 +228,58 @@ namespace RegressionTests.Shared
             }
             catch (Exception ex) when (ex is IOException || ex is SocketException || ex is ObjectDisposedException)
             {
+               // The far side closing under a blocking read is how a tunnel ordinarily
+               // ends, so the pump records why it stopped rather than failing anything.
+               // The finally still runs, and whoever waits on the other pump is released.
+               Trace.WriteLine("FakeHttpProxy: a relay pump stopped on " + ex.GetType().Name + ": " + ex.Message);
             }
             finally
             {
-               done.Set();
+               lock (done)
+               {
+                  finished = true;
+                  Monitor.PulseAll(done);
+               }
             }
          };
          var toUpstream = new Thread(() => copy(client, upstream)) { IsBackground = true };
          var toClient = new Thread(() => copy(upstream, client)) { IsBackground = true };
          toUpstream.Start();
          toClient.Start();
-         done.WaitOne(15000);
-         // Closing either stream ends the other pump's blocking read.
-         try { client.Close(); } catch (Exception) { }
-         try { upstream.Close(); } catch (Exception) { }
+         lock (done)
+         {
+            // A pump that finished before this lock was taken has already set the flag,
+            // which is the latched state a ManualResetEvent gave us for free.
+            if (!finished)
+               Monitor.Wait(done, 15000);
+         }
+
+         // Closing either stream ends the other pump's blocking read. Each close stands
+         // on its own: a stream whose pump has already faulted throws on the way out, and
+         // the other side must be closed anyway.
+         CloseRelayStream(client);
+         CloseRelayStream(upstream);
          toUpstream.Join(2000);
          toClient.Join(2000);
          GC.KeepAlive(pump);
+      }
+
+      /// <summary>
+      ///    Closes one end of a relay. The pumps are blocked in a read on these streams and
+      ///    closing them is how those reads are ended, so a stream that is already torn down
+      ///    - or that faults on its way out - is the expected case here, and not something
+      ///    the proxy has anything to report.
+      /// </summary>
+      private static void CloseRelayStream(NetworkStream stream)
+      {
+         try
+         {
+            stream.Close();
+         }
+         catch (Exception ex) when (ex is IOException || ex is SocketException || ex is ObjectDisposedException)
+         {
+            Trace.WriteLine("FakeHttpProxy: closing a relay stream threw " + ex.GetType().Name + ": " + ex.Message);
+         }
       }
    }
 }

--- a/hmailserver/test/RegressionTests/Shared/FakeSigstore.cs
+++ b/hmailserver/test/RegressionTests/Shared/FakeSigstore.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
@@ -51,7 +52,8 @@ namespace RegressionTests.Shared
          _intermediate = intermediateRequest.Create(_root.SubjectName, X509SignatureGenerator.CreateForECDsa(_rootKey),
             DateTimeOffset.UtcNow.AddMonths(-6), DateTimeOffset.UtcNow.AddYears(4), Serial());
 
-         LogId = SHA256.Create().ComputeHash(SubjectPublicKeyInfoP256(_logKey));
+         using (var sha = SHA256.Create())
+            LogId = sha.ComputeHash(SubjectPublicKeyInfoP256(_logKey));
       }
 
       /// <summary>SHA-256 of the log key's DER SubjectPublicKeyInfo, which is how Rekor names itself.</summary>
@@ -120,7 +122,9 @@ namespace RegressionTests.Shared
       {
          options = options ?? new Options();
          byte[] signed = options.SignOtherContent ?? content;
-         byte[] digest = SHA256.Create().ComputeHash(signed);
+         byte[] digest;
+         using (var sha = SHA256.Create())
+            digest = sha.ComputeHash(signed);
 
          using (var leafKey = ECDsa.Create(ECCurve.NamedCurves.nistP256))
          {
@@ -222,8 +226,13 @@ namespace RegressionTests.Shared
             {
                File.Delete(file);
             }
-            catch (IOException)
+            catch (IOException ex)
             {
+               // The server reads the trust roots and the log key while a check is
+               // running, and a fixture disposes this the moment its test is done, so a
+               // file still open here is that race and not a fault. It stays in the
+               // temporary directory under a name no other run reuses.
+               Trace.WriteLine("FakeSigstore: " + file + " could not be deleted: " + ex.Message);
             }
          }
       }
@@ -232,12 +241,14 @@ namespace RegressionTests.Shared
 
       public static byte[] LeafHash(byte[] data)
       {
-         return SHA256.Create().ComputeHash(new byte[] {0x00}.Concat(data).ToArray());
+         using (var sha = SHA256.Create())
+            return sha.ComputeHash(new byte[] {0x00}.Concat(data).ToArray());
       }
 
       private static byte[] NodeHash(byte[] left, byte[] right)
       {
-         return SHA256.Create().ComputeHash(new byte[] {0x01}.Concat(left).Concat(right).ToArray());
+         using (var sha = SHA256.Create())
+            return sha.ComputeHash(new byte[] {0x01}.Concat(left).Concat(right).ToArray());
       }
 
       private static int LargestPowerOfTwoBelow(int n)
@@ -351,7 +362,9 @@ namespace RegressionTests.Shared
 
       private string WriteTemp(string stem, string contents)
       {
-         string path = Path.Combine(Path.GetTempPath(), "hm-" + stem + "-" + Guid.NewGuid().ToString("N") + ".pem");
+         // The stem is one of this class's own words - "roots", "rekor" - and the rest
+         // is a bare hex guid, so the second part is a file name and never a path.
+         string path = Paths.Combine(Path.GetTempPath(), "hm-" + stem + "-" + Guid.NewGuid().ToString("N") + ".pem");
          File.WriteAllText(path, contents, new UTF8Encoding(false));
          _files.Add(path);
          return path;


### PR DESCRIPTION
Closes every open finding on the Code Quality page - thirty-six, all in the test tree - on their merits rather than by dismissal.

- **Nine disposables** (`cs/local-not-disposed`, the only warnings): seven `SHA256` instances and a `MemoryStream` in `using`; the `ManualResetEvent` in `FakeHttpProxy`'s relay replaced by a monitor with a latched flag, because the pump threads' joins are bounded and disposing the event could race a `Set()` from a thread still finishing.
- **Eight `Path.Combine`** calls whose later argument is provably a file name, routed through the suite's own `Paths.Combine` with a comment where the reader cannot see that from the line.
- **Ten catch blocks** narrowed to the exceptions the code throws there, with bodies that record what happened.
- **Eight rewrites**: `Select`, `Where`, a `StringBuilder`, a `TryGetValue`, and two static fields written where NUnit's fixture lifetime puts them.

Two verifiers read every hunk for a change in meaning and for whether the query would still fire; neither found one.

**Verification.** 2,130 tests, 2,121 passed, 8 skipped, and one SetUp failure that was not the test's - the first test of the run read an HM4316 bind line written to the ERROR log at 20:12:13, four minutes before the run started at 20:16:13, when a service restart at the tail of the previous gate raced the stop that began this one; the fixture (AuthenticationResultsHeader) re-run alone passes 10/10, and every SMTP-submission test on the port in question passed in the run itself. Control Panel test project: 681 pass.
