### PR TITLE
Add Star History section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,15 @@
 
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/14187/badge)](https://www.bestpractices.dev/projects/14187)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/Progressiverobot/hmailserver/badge)](https://scorecard.dev/viewer/?uri=github.com/Progressiverobot/hmailserver)
+## Star History
 
+<a href="https://www.star-history.com/?repos=progressiverobot%2Fhmailserver&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=progressiverobot/hmailserver&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=progressiverobot/hmailserver&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=progressiverobot/hmailserver&type=date&legend=top-left" />
+ </picture>
+</a>
 hMailServer is a free, open source email server for Microsoft Windows, implementing SMTP, IMAP and POP3. Since 8 September 2026 the server itself also builds, runs and packages on Linux, for x86-64 and AArch64 - see [Linux and AArch64](#linux-and-aarch64) below for exactly how far that goes.
 
 This repository is a maintained fork of the original project, which is no longer developed upstream. It has been brought up to date with a current toolchain, current cryptography, and the transport-security and authentication standards expected of a mail server in 2026 — while remaining a drop-in upgrade for existing hMailServer installations. It is maintained by Christopher Holloway / [Progressive Robot Ltd](https://www.progressiverobot.com).

--- a/README.md
+++ b/README.md
@@ -3,15 +3,7 @@
 
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/14187/badge)](https://www.bestpractices.dev/projects/14187)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/Progressiverobot/hmailserver/badge)](https://scorecard.dev/viewer/?uri=github.com/Progressiverobot/hmailserver)
-## Star History
 
-<a href="https://www.star-history.com/?repos=progressiverobot%2Fhmailserver&type=date&legend=top-left">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=progressiverobot/hmailserver&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=progressiverobot/hmailserver&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=progressiverobot/hmailserver&type=date&legend=top-left" />
- </picture>
-</a>
 hMailServer is a free, open source email server for Microsoft Windows, implementing SMTP, IMAP and POP3. Since 8 September 2026 the server itself also builds, runs and packages on Linux, for x86-64 and AArch64 - see [Linux and AArch64](#linux-and-aarch64) below for exactly how far that goes.
 
 This repository is a maintained fork of the original project, which is no longer developed upstream. It has been brought up to date with a current toolchain, current cryptography, and the transport-security and authentication standards expected of a mail server in 2026 — while remaining a drop-in upgrade for existing hMailServer installations. It is maintained by Christopher Holloway / [Progressive Robot Ltd](https://www.progressiverobot.com).
@@ -823,3 +815,14 @@ Contributing
 ============
 
 See [CONTRIBUTING.md](.github/CONTRIBUTING.md).
+
+Star History
+============
+
+<a href="https://www.star-history.com/?repos=progressiverobot%2Fhmailserver&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=progressiverobot/hmailserver&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=progressiverobot/hmailserver&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=progressiverobot/hmailserver&type=date&legend=top-left" />
+ </picture>
+</a>


### PR DESCRIPTION
Added Star History section with visual representation.

## Summary

<!-- What does this PR change and why? -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring / internal
- [ ] Documentation
- [ ] Build / installer

## Checklist

- [ ] Builds warning-free (`/WX`) with `build/build.ps1`
- [ ] Regression suite passes with no failures (`build/run-tests.ps1`; run
      `build/preflight-tests.ps1` first, or a stale bench will fail tests that
      have nothing to do with your change)
- [ ] New behavior covered by regression tests
- [ ] SQL uses parameterised queries only
- [ ] DB schema changes include scripts for MySQL, MS SQL and PostgreSQL in `source/DBScripts/`
- [ ] New settings exposed via COM API or `hMailServer.INI` pattern as appropriate
