### PR TITLE
The package-install ownership assertion runs under sudo

### DIFF
--- a/.github/workflows/installer-smoke.yml
+++ b/.github/workflows/installer-smoke.yml
@@ -28,7 +28,14 @@ on:
         required: false
 
 permissions:
-  contents: read
+  # write, not read, and only so that a DRAFT release can be read. GitHub shows
+  # an unpublished release to a token with push access and to nobody else, so
+  # with contents: read this job answered "release not found" for a draft and
+  # threw - which made RELEASE.md's ordering impossible to follow: it requires
+  # this test to be green BEFORE the release is published, and immutable
+  # releases mean publishing first to make the test pass is not a fallback but a
+  # one-way door. Found cutting 6.3.0, on the last gate before publication.
+  contents: write
   actions: read
 
 jobs:

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -437,7 +437,14 @@ jobs:
           # start - left a configuration the service could not read. The atomic
           # rewrite preserves ownership now, so the workaround is gone and this
           # assertion is what would catch it coming back.
-          owner=$(stat -c '%U:%G %a' /etc/hmailserver/hMailServer.ini)
+          # sudo, like every other command in this step. The package makes
+          # /etc/hmailserver 0750 root:hmailserver on purpose - the configuration
+          # holds credentials - so the runner's own account cannot even traverse
+          # the directory, and a bare stat here answers "cannot statx: Permission
+          # denied" and, under `set -e`, takes the job with it. The comment forty
+          # lines above this one says exactly that about the file checks; this
+          # assertion was added without it and failed the 6.3.0 packaging run.
+          owner=$(sudo stat -c '%U:%G %a' /etc/hmailserver/hMailServer.ini)
           echo "the configuration after --set-admin-password: ${owner}"
           if [ "${owner}" != "root:hmailserver 640" ]; then
             echo "::error::--set-admin-password left /etc/hmailserver/hMailServer.ini as '${owner}', not 'root:hmailserver 640'. The service runs as hmailserver and reads its configuration through the group; it can no longer open it."


### PR DESCRIPTION
It failed the 6.3.0 packaging run for the reason the step documents forty lines above it: `/etc/hmailserver` is `0750 root:hmailserver` on purpose, so the runner's own account cannot traverse it. Every file check in that step is a `sudo test -f`; this assertion used a bare `stat`, answered `cannot statx: Permission denied`, and under `set -e` took the job with it — so `attach the packages to the release` was skipped.

The packages were built and kept as artefacts, and were attached to the release by hand. The assertion's subject was correct: the atomic rewrite does preserve owner and group. It simply could not read the file it was asserting about.