### PR TITLE
The release checklist says what the 6.3.1 cut proved, and the pre-flight refuses to pass while WSL is running

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -20,11 +20,21 @@ already cost a release cycle or nearly shipped a defect.
    test that passes on both builds proves nothing — one of the 6.2.15 abort
    tests did exactly that until it was strengthened with session-count
    assertions.
-4. **Pre-flight the bench**: `build\preflight-tests.ps1` (add `-Clean` to
-   remove a stale ERROR log). Never skip this after an aborted run — an
-   aborted run leaves a deliberate scanner error in the ERROR log and the
-   next run fails 100% of tests in fixture setup, and it also leaves the
-   TLS fixtures' twelve extra ports behind, which the pre-flight checks.
+4. **Pre-flight the bench**: first `wsl -l --running`, and `wsl --shutdown` if
+   anything is up. With mirrored networking a Linux server or test run left
+   behind inside WSL holds the suite's ports invisibly - the Windows TCP table
+   shows nothing - and the pre-flight probes only the TLS fixtures' twelve, so
+   it passes. An orphaned Linux bench cost the first 6.3.1 assertion gate 24
+   errors this way; the Linux bench is the VM now, not WSL, for this reason.
+   Then `build\preflight-tests.ps1 -Clean` and restart the service, every time:
+   a *completed* suite leaves `PreferredHashAlgorithm=4` in the ini (a fixture
+   restores the default by writing it rather than removing the key), so the
+   next pre-flight fails until it is cleaned, and an aborted run leaves a
+   deliberate scanner error in the ERROR log that fails 100% of the next
+   run's tests in fixture setup, and the TLS fixtures' twelve extra ports
+   behind, which the pre-flight checks. Gate on its exit code rather than
+   reading its output: a chain that started the suite after a failed
+   pre-flight did exactly that once.
 5. **Check the roadmap against itself**: `build\check-roadmap.ps1`. It
    reconciles every tick box in `Roadmap.md` against the per-section counts
    and the contents table, because three hand-edited restatements of the same
@@ -56,8 +66,12 @@ already cost a release cycle or nearly shipped a defect.
      parses the PKGBUILD as a shell script and never runs CMake.
    * `hmailserver/source/Tools/ImportTool.Tests/packages.lock.json` - the entry
      for the project's own version. Regenerate it (`dotnet restore
-     --force-evaluate` on that project) rather than editing it by hand; a stale
-     lock file fails two *required* checks, `Build .NET tools` and `submit-nuget`.
+     --force-evaluate` on that project) rather than editing it by hand.
+     **Nothing enforces this one.** Measured on 10 September 2026: `dotnet
+     restore --locked-mode` with a stale project-reference version exits 0,
+     because locked mode validates the package graph and not project
+     references - so a stale entry ships a lock file that lies about the tree,
+     and this step is the only thing that catches it.
 
    `hmailserver/source/Server/CMakeLists.txt` is **not** on the list, and this
    is the one line of this step worth reading twice: it used to be, and a stamp
@@ -329,8 +343,15 @@ replaces the installer asset, and cosign has to sign the bytes that ship.
   its resource group and its subscription cannot be changed afterwards, so choose
   them as permanent.
 * Repository secrets `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`,
-  `AZURE_CLIENT_SECRET`, for an app registration holding the *Certificate
-  Profile Signer* role on that profile.
+  `AZURE_CLIENT_SECRET`, for an app registration holding the *Artifact Signing
+  Certificate Profile Signer* role on that profile. The roles were renamed with
+  the service and the old names do not resolve. Two more things the portal
+  does not say: creating the identity validation needs the *Artifact Signing
+  Identity Verifier* role on the account - Owner is not enough, because it is
+  a data action, and without it the portal simply offers nothing to create -
+  and the validation itself has no ARM resource type, so it is portal-only,
+  while the certificate profile *is* scriptable (`certificateProfiles`,
+  api-version 2025-10-13).
 * Repository variables `ARTIFACT_SIGNING_ENDPOINT`, `ARTIFACT_SIGNING_ACCOUNT`,
   `ARTIFACT_SIGNING_PROFILE`. The endpoint is a full URI, not a bare host:
   `https://neu.codesigning.azure.net`, which is the action's own documented

--- a/build/preflight-tests.ps1
+++ b/build/preflight-tests.ps1
@@ -164,6 +164,24 @@ foreach ($port in 25000, 25001, 25002, 25003, 11000, 11001, 11002, 11003, 14300,
 Report ($reserved.Count -eq 0) 'The SSL fixtures'' twelve ports are bindable' `
     ("{0} of them are not: {1}. Nothing needs to be LISTENING on them - if the service is stopped and they still cannot be bound, something is holding the reservation invisibly. On this bench that is WSL: run ``wsl --shutdown`` (stopping the Linux server is not enough - the reservation belongs to the VM) and check again. See hmailserver/docs/RegressionEnvironment.md." -f $reserved.Count, ($reserved -join ', '))
 
+# 8b. WSL is down. With networkingMode=mirrored the Windows host and every WSL
+#     distribution share one port space, and a Linux server or test run left
+#     behind inside WSL - a killed agent's bench, typically - holds whatever
+#     ports it bound, on Windows too, showing in no Windows TCP table. The
+#     probe above covers twelve ports; the suite allocates hundreds from 20000
+#     up, the same allocator the Linux suite uses, so the collision is exact
+#     and invisible. 24 errors in the first 6.3.1 assertion gate, 11 September
+#     2026. The remedy is the whole VM, not the process: the reservation
+#     outlives the process that made it (RegressionEnvironment.md).
+$wslRunning = @()
+try {
+    $wslRunning = @((& wsl.exe -l --running --quiet 2>$null) | ForEach-Object { ($_ -replace "`0", '').Trim() } | Where-Object { $_ })
+} catch {
+    $wslRunning = @()
+}
+Report ($wslRunning.Count -eq 0) 'WSL is not running' `
+    ("Running: {0}. Run ``wsl --shutdown`` before the suite - a Linux process inside WSL holds the suite's ports on this host invisibly under mirrored networking, and the Linux bench belongs on the VM (192.168.11.154), not in WSL." -f ($wslRunning -join ', '))
+
 # 9. Interference sources that have broken runs before (warn only).
 $vpn = Get-NetAdapter -ErrorAction SilentlyContinue | Where-Object { $_.InterfaceDescription -match 'Proton|WireGuard' -and $_.Status -eq 'Up' }
 if ($vpn) { Write-Host ("  WARN  VPN adapter up: {0} - has broken address selection in tests before." -f ($vpn.Name -join ', ')) -ForegroundColor Yellow }


### PR DESCRIPTION
Docs and bench tooling only. RELEASE.md: shut WSL down before the bench and why, clean the pre-flight every time and gate on its exit code, the lock-file stamp is enforced by nothing (measured), and the Azure Artifact Signing roles by their real names with the Identity Verifier role that creating the validation needs. build/preflight-tests.ps1: a check that fails while any WSL distribution is running, because an orphaned Linux bench cost the first 6.3.1 assertion gate 24 errors with the pre-flight green. Verified: the script parses and the check passes with WSL down.