### PR TITLE
Code Quality back to zero findings: the Linux shims say what they mean, and the analyser can read it

### DIFF
--- a/build/portal-script-test.js
+++ b/build/portal-script-test.js
@@ -376,7 +376,7 @@ function answer(method, path) {
    }
    if (/\/flags$/.test(path)) { return json(200, { flags: { seen: true, flagged: false, draft: false } }); }
    if (path.startsWith('/api/v1/me/changes')) {
-      if (changesMissing) { return json(changesMissing === 403 ? 403 : 404, { error: 'Not found.' }); }
+      if (changesMissing) { return json(404, { error: 'Not found.' }); }
       changeStep += 1;
       if (changeStep === 1) { return json(200, { token: 't1', folders: [{ id: 1, count: 3, unseen: 2 }, { id: 2, count: 1, unseen: 0 }, { id: 3, count: 0, unseen: 0 }] }); }
       if (changeStep === 2) { arrived = true; return json(200, { token: 't2', changed: true, folders: [{ id: 1, count: 4, unseen: 3 }, { id: 2, count: 1, unseen: 0 }, { id: 3, count: 0, unseen: 0 }] }); }

--- a/build/portal-script-test.js
+++ b/build/portal-script-test.js
@@ -216,7 +216,6 @@ if (!document.body) { throw new Error('the page has no <body>'); }
 
 /* -------------------------------------------------- window, location, timers */
 
-const fired = [];
 const window = new Element('#window');
 const historyStack = [''];
 let historyAt = 0;

--- a/hmailserver/test/LinuxRegressionTests/Shims/ComCollections.cs
+++ b/hmailserver/test/LinuxRegressionTests/Shims/ComCollections.cs
@@ -82,11 +82,8 @@ namespace hMailServer
 
       public Domain get_ItemByName(string name)
       {
-         foreach (var element in All())
-            if (string.Equals(ServerApi.StringOf(element, "name"), name, StringComparison.OrdinalIgnoreCase))
-               return From(element);
-
-         throw new System.Runtime.InteropServices.COMException("Item not found. " + name);
+         return All().Where(element => string.Equals(ServerApi.StringOf(element, "name"), name, StringComparison.OrdinalIgnoreCase)).Select(element => From(element)).FirstOrDefault()
+            ?? throw new System.Runtime.InteropServices.COMException("Item not found. " + name);
       }
 
       public Domain Add()
@@ -168,11 +165,8 @@ namespace hMailServer
 
       public Account get_ItemByAddress(string address)
       {
-         foreach (var element in All())
-            if (string.Equals(ServerApi.StringOf(element, "address"), address, StringComparison.OrdinalIgnoreCase))
-               return From(element);
-
-         throw new System.Runtime.InteropServices.COMException("Item not found. " + address);
+         return All().Where(element => string.Equals(ServerApi.StringOf(element, "address"), address, StringComparison.OrdinalIgnoreCase)).Select(element => From(element)).FirstOrDefault()
+            ?? throw new System.Runtime.InteropServices.COMException("Item not found. " + address);
       }
 
       public Account Add()
@@ -249,11 +243,8 @@ namespace hMailServer
 
       public Alias get_ItemByName(string name)
       {
-         foreach (var element in All())
-            if (string.Equals(ServerApi.StringOf(element, "name"), name, StringComparison.OrdinalIgnoreCase))
-               return From(element);
-
-         throw new System.Runtime.InteropServices.COMException("Item not found. " + name);
+         return All().Where(element => string.Equals(ServerApi.StringOf(element, "name"), name, StringComparison.OrdinalIgnoreCase)).Select(element => From(element)).FirstOrDefault()
+            ?? throw new System.Runtime.InteropServices.COMException("Item not found. " + name);
       }
 
       public Alias Add()
@@ -309,11 +300,8 @@ namespace hMailServer
 
       public DistributionList get_ItemByAddress(string address)
       {
-         foreach (var element in All())
-            if (string.Equals(ServerApi.StringOf(element, "address"), address, StringComparison.OrdinalIgnoreCase))
-               return new DistributionList { Address = address, Active = true };
-
-         throw new System.Runtime.InteropServices.COMException("Item not found. " + address);
+         return All().Where(element => string.Equals(ServerApi.StringOf(element, "address"), address, StringComparison.OrdinalIgnoreCase)).Select(element => new DistributionList { Address = address, Active = true }).FirstOrDefault()
+            ?? throw new System.Runtime.InteropServices.COMException("Item not found. " + address);
       }
 
       public DistributionList Add()
@@ -475,11 +463,8 @@ namespace hMailServer
 
       public TCPIPPort get_ItemByDBID(long id)
       {
-         foreach (var element in All())
-            if (ServerApi.LongOf(element, "id") == id)
-               return From(element);
-
-         throw new System.Runtime.InteropServices.COMException("Item not found. " + id);
+         return All().Where(element => ServerApi.LongOf(element, "id") == id).Select(element => From(element)).FirstOrDefault()
+            ?? throw new System.Runtime.InteropServices.COMException("Item not found. " + id);
       }
 
       public TCPIPPort Add()
@@ -671,11 +656,7 @@ namespace hMailServer
 
       public SecurityRange get_ItemByName(string name)
       {
-         foreach (var element in All())
-            if (string.Equals(ServerApi.StringOf(element, "name"), name, StringComparison.OrdinalIgnoreCase))
-               return From(element);
-
-         return null;
+         return All().Where(element => string.Equals(ServerApi.StringOf(element, "name"), name, StringComparison.OrdinalIgnoreCase)).Select(element => From(element)).FirstOrDefault();
       }
 
       public SecurityRange Add()
@@ -834,11 +815,7 @@ namespace hMailServer
 
       public SSLCertificate get_ItemByName(string name)
       {
-         foreach (var element in All())
-            if (string.Equals(ServerApi.StringOf(element, "name"), name, StringComparison.OrdinalIgnoreCase))
-               return From(element);
-
-         return null;
+         return All().Where(element => string.Equals(ServerApi.StringOf(element, "name"), name, StringComparison.OrdinalIgnoreCase)).Select(element => From(element)).FirstOrDefault();
       }
 
       private static SSLCertificate From(JsonElement element)
@@ -873,12 +850,10 @@ namespace hMailServer
 
       public void Clear()
       {
-         foreach (var id in All().Select(element => ServerApi.LongOf(element, "id")))
+         // A certificate a listener is bound to cannot go; the Windows Clear has
+         // the same constraint and the fixtures clear the ports first.
+         foreach (var answer in All().Select(element => ServerApi.Delete("/api/v1/certificates/" + ServerApi.LongOf(element, "id"))))
          {
-            var answer = ServerApi.Delete("/api/v1/certificates/" + id);
-
-            // A certificate a listener is bound to cannot go; the Windows Clear has
-            // the same constraint and the fixtures clear the ports first.
             if (answer.Status != 200 && answer.Status != 404)
                throw new System.Runtime.InteropServices.COMException("Failed to delete object. " + answer.Error);
          }
@@ -970,11 +945,7 @@ namespace hMailServer
 
       public Route get_ItemByName(string domainName)
       {
-         foreach (var element in All())
-            if (string.Equals(ServerApi.StringOf(element, "domain_name"), domainName, StringComparison.OrdinalIgnoreCase))
-               return From(element);
-
-         return null;
+         return All().Where(element => string.Equals(ServerApi.StringOf(element, "domain_name"), domainName, StringComparison.OrdinalIgnoreCase)).Select(element => From(element)).FirstOrDefault();
       }
 
       public Route ItemByName(string domainName)
@@ -1026,11 +997,7 @@ namespace hMailServer
 
       public Rule get_ItemByName(string name)
       {
-         foreach (var element in All())
-            if (string.Equals(ServerApi.StringOf(element, "name"), name, StringComparison.Ordinal))
-               return Rule.From(element);
-
-         return null;
+         return All().Where(element => string.Equals(ServerApi.StringOf(element, "name"), name, StringComparison.Ordinal)).Select(element => Rule.From(element)).FirstOrDefault();
       }
 
       public Rule Add()
@@ -1043,11 +1010,7 @@ namespace hMailServer
 
       public Rule get_ItemByDBID(long id)
       {
-         foreach (var element in All())
-            if (ServerApi.LongOf(element, "id") == id)
-               return Rule.From(element);
-
-         return null;
+         return All().Where(element => ServerApi.LongOf(element, "id") == id).Select(element => Rule.From(element)).FirstOrDefault();
       }
 
       public void DeleteByDBID(long id)
@@ -1503,11 +1466,8 @@ namespace hMailServer
 
       public IMAPFolder get_ItemByName(string name)
       {
-         foreach (var folder in All())
-            if (string.Equals(ServerApi.StringOf(folder, "name"), name, StringComparison.OrdinalIgnoreCase))
-               return From(folder);
-
-         throw new System.Runtime.InteropServices.COMException("Item not found. " + name);
+         return All().Where(folder => string.Equals(ServerApi.StringOf(folder, "name"), name, StringComparison.OrdinalIgnoreCase)).Select(folder => From(folder)).FirstOrDefault()
+            ?? throw new System.Runtime.InteropServices.COMException("Item not found. " + name);
       }
 
       private IMAPFolder From(JsonElement element)

--- a/hmailserver/test/LinuxRegressionTests/Shims/ComCollections.cs
+++ b/hmailserver/test/LinuxRegressionTests/Shims/ComCollections.cs
@@ -854,7 +854,8 @@ namespace hMailServer
          // the same constraint and the fixtures clear the ports first.
          foreach (var answer in All().Select(element => ServerApi.Delete("/api/v1/certificates/" + ServerApi.LongOf(element, "id"))))
          {
-            if (answer.Status != 200 && answer.Status != 404)
+            var gone = answer.Status == 200 || answer.Status == 404;
+            if (!gone)
                throw new System.Runtime.InteropServices.COMException("Failed to delete object. " + answer.Error);
          }
       }

--- a/hmailserver/test/LinuxRegressionTests/Shims/ComCollections.cs
+++ b/hmailserver/test/LinuxRegressionTests/Shims/ComCollections.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Text;
 using System.Text.Json;
+using System.Linq;
 using RegressionTests.Shared;
 
 // The collections the Windows suite reaches through COM - the server's domains and
@@ -31,6 +32,14 @@ namespace hMailServer
          if (!_unsupported.Contains(property))
             _unsupported.Add(property);
       }
+
+      /// <summary>
+      ///    A setter with no route: remembered with the value it was handed, so
+      ///    that the skip Save() raises says what the test wanted, not only which
+      ///    field it wanted it in.
+      /// </summary>
+      protected void Unsupported(string property, object value)
+         => Unsupported(property + "=" + (value == null ? "null" : value.ToString()));
 
       protected void SkipIfAnythingUnsupported(string route)
       {
@@ -103,11 +112,8 @@ namespace hMailServer
 
       public void Clear()
       {
-         foreach (var element in All())
-         {
-            var name = ServerApi.StringOf(element, "name");
+         foreach (var name in All().Select(element => ServerApi.StringOf(element, "name")))
             ServerApi.Delete("/api/v1/domains/" + name).Expect(200, "DELETE /api/v1/domains/" + name);
-         }
       }
    }
 
@@ -253,7 +259,7 @@ namespace hMailServer
       public Alias Add()
       {
          if (!ServerApi.HasAliasWriteRoutes)
-            NotOnThisServer.Ignore(NotOnThisServer.NoAliasCreate);
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoAliasCreate);
 
          return new Alias { DomainName = _domain, Active = true, Unsaved = true };
       }
@@ -312,8 +318,7 @@ namespace hMailServer
 
       public DistributionList Add()
       {
-         NotOnThisServer.Ignore(NotOnThisServer.NoListObject);
-         return null;
+         throw NotOnThisServer.Skipped(NotOnThisServer.NoListObject);
       }
 
       public void DeleteByDBID(long id)
@@ -342,21 +347,18 @@ namespace hMailServer
       {
          get
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoDomainAliases);
-            return 0;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoDomainAliases);
          }
       }
 
       public DomainAlias Add()
       {
-         NotOnThisServer.Ignore(NotOnThisServer.NoDomainAliases);
-         return null;
+         throw NotOnThisServer.Skipped(NotOnThisServer.NoDomainAliases);
       }
 
       public DomainAlias get_ItemByName(string name)
       {
-         NotOnThisServer.Ignore(NotOnThisServer.NoDomainAliases);
-         return null;
+         throw NotOnThisServer.Skipped(NotOnThisServer.NoDomainAliases);
       }
 
       public void DeleteByDBID(long id)
@@ -483,7 +485,7 @@ namespace hMailServer
       public TCPIPPort Add()
       {
          if (!ServerApi.HasRoute("/api/v1/ports", "post"))
-            NotOnThisServer.Ignore(NotOnThisServer.NoPortCreate);
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoPortCreate);
 
          return new TCPIPPort { Unsaved = true };
       }
@@ -679,7 +681,7 @@ namespace hMailServer
       public SecurityRange Add()
       {
          if (!ServerApi.HasRoute("/api/v1/ipranges", "post"))
-            NotOnThisServer.Ignore(NotOnThisServer.NoIpRangeCreate);
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoIpRangeCreate);
 
          return new SecurityRange();
       }
@@ -854,7 +856,7 @@ namespace hMailServer
       public SSLCertificate Add()
       {
          if (!ServerApi.HasRoute("/api/v1/certificates", "post"))
-            NotOnThisServer.Ignore(NotOnThisServer.NoCertificateCreate);
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoCertificateCreate);
 
          return new SSLCertificate();
       }
@@ -871,9 +873,8 @@ namespace hMailServer
 
       public void Clear()
       {
-         foreach (var element in All())
+         foreach (var id in All().Select(element => ServerApi.LongOf(element, "id")))
          {
-            var id = ServerApi.LongOf(element, "id");
             var answer = ServerApi.Delete("/api/v1/certificates/" + id);
 
             // A certificate a listener is bound to cannot go; the Windows Clear has
@@ -984,7 +985,7 @@ namespace hMailServer
       public Route Add()
       {
          if (!ServerApi.HasRouteWriteRoutes)
-            NotOnThisServer.Ignore(NotOnThisServer.NoRouteCreate);
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoRouteCreate);
 
          return new Route();
       }
@@ -1035,7 +1036,7 @@ namespace hMailServer
       public Rule Add()
       {
          if (!ServerApi.HasRoute("/api/v1/rules", "post"))
-            NotOnThisServer.Ignore(NotOnThisServer.NoRuleCreate);
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoRuleCreate);
 
          return new Rule();
       }
@@ -1061,11 +1062,8 @@ namespace hMailServer
 
       public void Clear()
       {
-         foreach (var element in All())
-         {
-            var id = ServerApi.LongOf(element, "id");
+         foreach (var id in All().Select(element => ServerApi.LongOf(element, "id")))
             ServerApi.Delete("/api/v1/rules/" + id).Expect(200, "DELETE /api/v1/rules/" + id);
-         }
       }
 
       public void Refresh()

--- a/hmailserver/test/LinuxRegressionTests/Shims/ComExtras.cs
+++ b/hmailserver/test/LinuxRegressionTests/Shims/ComExtras.cs
@@ -15,16 +15,14 @@ namespace hMailServer
    {
       public BlockedAttachment Add()
       {
-         NotOnThisServer.Ignore(NotOnThisServer.NoAntiVirusSettings);
-         return null;
+         throw NotOnThisServer.Skipped(NotOnThisServer.NoAntiVirusSettings);
       }
 
       public int Count
       {
          get
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoAntiVirusSettings);
-            return 0;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoAntiVirusSettings);
          }
       }
 
@@ -56,39 +54,31 @@ namespace hMailServer
    {
       public Rule Add()
       {
-         NotOnThisServer.Ignore(NotOnThisServer.NoAccountRules);
-         return null;
+         throw NotOnThisServer.Skipped(NotOnThisServer.NoAccountRules);
       }
 
       public int Count
       {
          get
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoAccountRules);
-            return 0;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoAccountRules);
          }
       }
 
       public Rule get_ItemByName(string name)
       {
-         NotOnThisServer.Ignore(NotOnThisServer.NoAccountRules);
-         return null;
+         throw NotOnThisServer.Skipped(NotOnThisServer.NoAccountRules);
       }
 
       [System.Runtime.CompilerServices.IndexerName("At")]
       public Rule this[int index]
       {
-         get
-         {
-            NotOnThisServer.Ignore(NotOnThisServer.NoAccountRules);
-            return null;
-         }
+         get { throw NotOnThisServer.Skipped(NotOnThisServer.NoAccountRules); }
       }
 
       public Rule get_Item(int index)
       {
-         NotOnThisServer.Ignore(NotOnThisServer.NoAccountRules);
-         return null;
+         throw NotOnThisServer.Skipped(NotOnThisServer.NoAccountRules);
       }
 
       public void DeleteByDBID(long id)
@@ -110,39 +100,31 @@ namespace hMailServer
    {
       public FetchAccount Add()
       {
-         NotOnThisServer.Ignore(NotOnThisServer.NoFetchAccounts);
-         return null;
+         throw NotOnThisServer.Skipped(NotOnThisServer.NoFetchAccounts);
       }
 
       public int Count
       {
          get
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoFetchAccounts);
-            return 0;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoFetchAccounts);
          }
       }
 
       [System.Runtime.CompilerServices.IndexerName("At")]
       public FetchAccount this[int index]
       {
-         get
-         {
-            NotOnThisServer.Ignore(NotOnThisServer.NoFetchAccounts);
-            return null;
-         }
+         get { throw NotOnThisServer.Skipped(NotOnThisServer.NoFetchAccounts); }
       }
 
       public FetchAccount get_Item(int index)
       {
-         NotOnThisServer.Ignore(NotOnThisServer.NoFetchAccounts);
-         return null;
+         throw NotOnThisServer.Skipped(NotOnThisServer.NoFetchAccounts);
       }
 
       public FetchAccount get_ItemByName(string name)
       {
-         NotOnThisServer.Ignore(NotOnThisServer.NoFetchAccounts);
-         return null;
+         throw NotOnThisServer.Skipped(NotOnThisServer.NoFetchAccounts);
       }
 
       public void DeleteByDBID(long id)
@@ -210,33 +192,26 @@ namespace hMailServer
    {
       public AppPassword Add()
       {
-         NotOnThisServer.Ignore(NotOnThisServer.NoAppPasswords);
-         return null;
+         throw NotOnThisServer.Skipped(NotOnThisServer.NoAppPasswords);
       }
 
       public int Count
       {
          get
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoAppPasswords);
-            return 0;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoAppPasswords);
          }
       }
 
       [System.Runtime.CompilerServices.IndexerName("At")]
       public AppPassword this[int index]
       {
-         get
-         {
-            NotOnThisServer.Ignore(NotOnThisServer.NoAppPasswords);
-            return null;
-         }
+         get { throw NotOnThisServer.Skipped(NotOnThisServer.NoAppPasswords); }
       }
 
       public AppPassword get_Item(int index)
       {
-         NotOnThisServer.Ignore(NotOnThisServer.NoAppPasswords);
-         return null;
+         throw NotOnThisServer.Skipped(NotOnThisServer.NoAppPasswords);
       }
 
       public void DeleteByDBID(long id)
@@ -264,8 +239,7 @@ namespace hMailServer
 
       public string Generate()
       {
-         NotOnThisServer.Ignore(NotOnThisServer.NoAppPasswords);
-         return null;
+         throw NotOnThisServer.Skipped(NotOnThisServer.NoAppPasswords);
       }
 
       public void SetPassword(string password)
@@ -297,31 +271,24 @@ namespace hMailServer
       {
          get
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoFolderAcl);
-            return 0;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoFolderAcl);
          }
       }
 
       public IMAPFolderPermission Add()
       {
-         NotOnThisServer.Ignore(NotOnThisServer.NoFolderAcl);
-         return null;
+         throw NotOnThisServer.Skipped(NotOnThisServer.NoFolderAcl);
       }
 
       [System.Runtime.CompilerServices.IndexerName("At")]
       public IMAPFolderPermission this[int index]
       {
-         get
-         {
-            NotOnThisServer.Ignore(NotOnThisServer.NoFolderAcl);
-            return null;
-         }
+         get { throw NotOnThisServer.Skipped(NotOnThisServer.NoFolderAcl); }
       }
 
       public IMAPFolderPermission get_Item(int index)
       {
-         NotOnThisServer.Ignore(NotOnThisServer.NoFolderAcl);
-         return null;
+         throw NotOnThisServer.Skipped(NotOnThisServer.NoFolderAcl);
       }
 
       public void DeleteByDBID(long id)
@@ -354,8 +321,7 @@ namespace hMailServer
 
       public bool get_Permission(eACLPermission permission)
       {
-         NotOnThisServer.Ignore(NotOnThisServer.NoFolderAcl);
-         return false;
+         throw NotOnThisServer.Skipped(NotOnThisServer.NoFolderAcl);
       }
    }
 }

--- a/hmailserver/test/LinuxRegressionTests/Shims/ComObjects.cs
+++ b/hmailserver/test/LinuxRegressionTests/Shims/ComObjects.cs
@@ -1313,7 +1313,7 @@ namespace hMailServer
       {
          get
          {
-            throw NotOnThisServer.Skipped(NotOnThisServer.NoMessageIndexing);
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoMessageIndexing + " (TotalIndexedCount)");
          }
       }
 
@@ -1321,7 +1321,7 @@ namespace hMailServer
       {
          get
          {
-            throw NotOnThisServer.Skipped(NotOnThisServer.NoMessageIndexing);
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoMessageIndexing + " (TotalMessageCount)");
          }
       }
    }
@@ -1604,7 +1604,7 @@ namespace hMailServer
       public DNSBlackList Add() { throw NotOnThisServer.Skipped("adds a DNSBlackList, which no REST route carries yet"); }
 
       [System.Runtime.CompilerServices.IndexerName("At")]
-      public DNSBlackList this[int index] => null;
+      public DNSBlackList this[int index] => throw NotOnThisServer.Skipped("indexes a DNSBlackList, which no REST route carries yet");
 
       public DNSBlackList get_Item(int index)
       {
@@ -1649,7 +1649,7 @@ namespace hMailServer
       public SURBLServer Add() { throw NotOnThisServer.Skipped("adds a SURBLServer, which no REST route carries yet"); }
 
       [System.Runtime.CompilerServices.IndexerName("At")]
-      public SURBLServer this[int index] => null;
+      public SURBLServer this[int index] => throw NotOnThisServer.Skipped("indexes a SURBLServer, which no REST route carries yet");
 
       public SURBLServer get_Item(int index)
       {
@@ -1694,7 +1694,7 @@ namespace hMailServer
       public BlockedSender Add() { throw NotOnThisServer.Skipped("adds a BlockedSender, which no REST route carries yet"); }
 
       [System.Runtime.CompilerServices.IndexerName("At")]
-      public BlockedSender this[int index] => null;
+      public BlockedSender this[int index] => throw NotOnThisServer.Skipped("indexes a BlockedSender, which no REST route carries yet");
 
       public BlockedSender get_Item(int index)
       {
@@ -1740,7 +1740,7 @@ namespace hMailServer
       public WhiteListAddress Add() { throw NotOnThisServer.Skipped("adds a WhiteListAddress, which no REST route carries yet"); }
 
       [System.Runtime.CompilerServices.IndexerName("At")]
-      public WhiteListAddress this[int index] => null;
+      public WhiteListAddress this[int index] => throw NotOnThisServer.Skipped("indexes a WhiteListAddress, which no REST route carries yet");
 
       public WhiteListAddress get_Item(int index)
       {
@@ -1785,7 +1785,7 @@ namespace hMailServer
       public GreyListingWhiteAddress Add() { throw NotOnThisServer.Skipped("adds a GreyListingWhiteAddress, which no REST route carries yet"); }
 
       [System.Runtime.CompilerServices.IndexerName("At")]
-      public GreyListingWhiteAddress this[int index] => null;
+      public GreyListingWhiteAddress this[int index] => throw NotOnThisServer.Skipped("indexes a GreyListingWhiteAddress, which no REST route carries yet");
 
       public GreyListingWhiteAddress get_Item(int index)
       {
@@ -1836,7 +1836,7 @@ namespace hMailServer
       }
 
       [System.Runtime.CompilerServices.IndexerName("At")]
-      public QuarantinedMessage this[int index] => null;
+      public QuarantinedMessage this[int index] => throw NotOnThisServer.Skipped("indexes a QuarantinedMessage, which no REST route carries yet");
 
       public QuarantinedMessage get_Item(int index)
       {
@@ -2310,7 +2310,7 @@ namespace hMailServer
       public DistributionListRecipient Add() { throw NotOnThisServer.Skipped("adds a DistributionListRecipient, which no REST route carries yet"); }
 
       [System.Runtime.CompilerServices.IndexerName("At")]
-      public DistributionListRecipient this[int index] => null;
+      public DistributionListRecipient this[int index] => throw NotOnThisServer.Skipped("indexes a DistributionListRecipient, which no REST route carries yet");
 
       public DistributionListRecipient get_Item(int index)
       {
@@ -2428,7 +2428,7 @@ namespace hMailServer
       public RouteAddress Add() { throw NotOnThisServer.Skipped("adds a RouteAddress, which no REST route carries yet"); }
 
       [System.Runtime.CompilerServices.IndexerName("At")]
-      public RouteAddress this[int index] => null;
+      public RouteAddress this[int index] => throw NotOnThisServer.Skipped("indexes a RouteAddress, which no REST route carries yet");
 
       public RouteAddress get_Item(int index)
       {
@@ -3191,7 +3191,7 @@ namespace hMailServer
       public MessageHeader Add() { throw NotOnThisServer.Skipped("adds a MessageHeader, which no REST route carries yet"); }
 
       [System.Runtime.CompilerServices.IndexerName("At")]
-      public MessageHeader this[int index] => null;
+      public MessageHeader this[int index] => throw NotOnThisServer.Skipped("indexes a MessageHeader, which no REST route carries yet");
 
       public MessageHeader get_Item(int index)
       {
@@ -3229,7 +3229,7 @@ namespace hMailServer
       public MessageRecipient Add() { throw NotOnThisServer.Skipped("adds a MessageRecipient, which no REST route carries yet"); }
 
       [System.Runtime.CompilerServices.IndexerName("At")]
-      public MessageRecipient this[int index] => null;
+      public MessageRecipient this[int index] => throw NotOnThisServer.Skipped("indexes a MessageRecipient, which no REST route carries yet");
 
       public MessageRecipient get_Item(int index)
       {
@@ -3256,7 +3256,7 @@ namespace hMailServer
       public int Count => 0;
 
       [System.Runtime.CompilerServices.IndexerName("At")]
-      public Attachment this[int index] => null;
+      public Attachment this[int index] => throw NotOnThisServer.Skipped("indexes a Attachment, which no REST route carries yet");
 
       public Attachment get_Item(int index)
       {

--- a/hmailserver/test/LinuxRegressionTests/Shims/ComObjects.cs
+++ b/hmailserver/test/LinuxRegressionTests/Shims/ComObjects.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Text.Json;
+using System.Linq;
 using RegressionTests.Shared;
 
 // The hMailServer namespace, as the fixtures compile against it. On Windows these
@@ -66,58 +67,39 @@ namespace hMailServer
 
       public bool Authenticate(string user, string password)
       {
-         NotOnThisServer.Ignore(NotOnThisServer.NoComAuthenticate);
-         return false;
+         throw NotOnThisServer.Skipped(NotOnThisServer.NoComAuthenticate);
       }
 
       public Database Database
       {
-         get
-         {
-            NotOnThisServer.Ignore(NotOnThisServer.NoDatabaseObject);
-            return null;
-         }
+         get { throw NotOnThisServer.Skipped(NotOnThisServer.NoDatabaseObject); }
       }
 
       public Diagnostics Diagnostics
       {
-         get
-         {
-            NotOnThisServer.Ignore(NotOnThisServer.NoDiagnostics);
-            return null;
-         }
+         get { throw NotOnThisServer.Skipped(NotOnThisServer.NoDiagnostics); }
       }
 
       public BackupManager BackupManager
       {
-         get
-         {
-            NotOnThisServer.Ignore(NotOnThisServer.NoBackupSettings);
-            return null;
-         }
+         get { throw NotOnThisServer.Skipped(NotOnThisServer.NoBackupSettings); }
       }
 
       public GlobalObjects GlobalObjects
       {
-         get
-         {
-            NotOnThisServer.Ignore(NotOnThisServer.NoScripting);
-            return null;
-         }
+         get { throw NotOnThisServer.Skipped(NotOnThisServer.NoScripting); }
       }
 
       public bool AuthenticateWithCode(string user, string password, string code)
       {
-         NotOnThisServer.Ignore(NotOnThisServer.NoAdministratorTotp);
-         return false;
+         throw NotOnThisServer.Skipped(NotOnThisServer.NoAdministratorTotp);
       }
 
       public bool AdministratorTOTPEnabled
       {
          get
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoAdministratorTotp);
-            return false;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoAdministratorTotp);
          }
       }
    }
@@ -131,10 +113,7 @@ namespace hMailServer
       {
       }
 
-      public object Add()
-      {
-         return null;
-      }
+      public object Add() { throw NotOnThisServer.Skipped("adds a object, which no REST route carries yet"); }
 
       public object get_ItemByName(string name)
       {
@@ -163,16 +142,14 @@ namespace hMailServer
 
       public string ExecuteSQLWithReturn(string sql)
       {
-         NotOnThisServer.Ignore(NotOnThisServer.NoDatabaseObject);
-         return null;
+         throw NotOnThisServer.Skipped(NotOnThisServer.NoDatabaseObject);
       }
 
       public int CurrentVersion
       {
          get
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoDatabaseObject);
-            return 0;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoDatabaseObject);
          }
       }
 
@@ -199,8 +176,7 @@ namespace hMailServer
       {
          get
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoBackupSettings);
-            return false;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoBackupSettings);
          }
       }
    }
@@ -212,15 +188,13 @@ namespace hMailServer
       {
          get
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoDiagnostics);
-            return false;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoDiagnostics);
          }
       }
 
       public object PerformTests()
       {
-         NotOnThisServer.Ignore(NotOnThisServer.NoDiagnostics);
-         return null;
+         throw NotOnThisServer.Skipped(NotOnThisServer.NoDiagnostics);
       }
 
       public void TriggerAssertion(int which = 0)
@@ -232,18 +206,13 @@ namespace hMailServer
       {
          get
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoDiagnostics);
-            return DateTime.MinValue;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoDiagnostics);
          }
       }
 
       public string DnssecChainStatus
       {
-         get
-         {
-            NotOnThisServer.Ignore(NotOnThisServer.NoDiagnostics);
-            return null;
-         }
+         get { throw NotOnThisServer.Skipped(NotOnThisServer.NoDiagnostics); }
       }
    }
 
@@ -259,8 +228,7 @@ namespace hMailServer
       {
          get
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoStatusThreadId);
-            return 0;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoStatusThreadId);
          }
       }
 
@@ -279,8 +247,7 @@ namespace hMailServer
             case eSessionType.eSTIMAP: name = "imap"; break;
             case eSessionType.eSTPOP3: name = "pop3"; break;
             default:
-               NotOnThisServer.Ignore(NotOnThisServer.NoClientSessionCount);
-               return 0;
+               throw NotOnThisServer.Skipped(NotOnThisServer.NoClientSessionCount);
          }
 
          var answer = ServerApi.Get("/api/v1/status").Expect(200, "GET /api/v1/status");
@@ -296,8 +263,7 @@ namespace hMailServer
       {
          get
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoServerStartTime);
-            return DateTime.MinValue;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoServerStartTime);
          }
       }
 
@@ -308,38 +274,27 @@ namespace hMailServer
 
       public string CheckForUpdate()
       {
-         NotOnThisServer.Ignore(NotOnThisServer.NoUpdateObject);
-         return null;
+         throw NotOnThisServer.Skipped(NotOnThisServer.NoUpdateObject);
       }
 
       public string DownloadUpdate()
       {
-         NotOnThisServer.Ignore(NotOnThisServer.NoUpdateObject);
-         return null;
+         throw NotOnThisServer.Skipped(NotOnThisServer.NoUpdateObject);
       }
 
       public string UpdateState
       {
-         get
-         {
-            NotOnThisServer.Ignore(NotOnThisServer.NoUpdateObject);
-            return null;
-         }
+         get { throw NotOnThisServer.Skipped(NotOnThisServer.NoUpdateObject); }
       }
 
       public string UpdateLastError
       {
-         get
-         {
-            NotOnThisServer.Ignore(NotOnThisServer.NoUpdateObject);
-            return null;
-         }
+         get { throw NotOnThisServer.Skipped(NotOnThisServer.NoUpdateObject); }
       }
 
       public string InstallUpdate()
       {
-         NotOnThisServer.Ignore(NotOnThisServer.NoUpdateObject);
-         return null;
+         throw NotOnThisServer.Skipped(NotOnThisServer.NoUpdateObject);
       }
 
       public eServerState State
@@ -371,7 +326,8 @@ namespace hMailServer
          var answer = ServerApi.Get(group).Expect(200, "GET " + group);
          JsonElement value;
          if (!answer.Json.HasValue || !answer.Json.Value.TryGetProperty(key, out value))
-            NotOnThisServer.Ignore(NotOnThisServer.NoSettingsWrite + " (" + key + " is not in " + group + ")");
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoSettingsWrite + " (" + key + " is not in " + group + ")");
+
          return answer.Json.Value.GetProperty(key);
       }
 
@@ -830,8 +786,7 @@ namespace hMailServer
 
       public string GetIniSetting(string name)
       {
-         NotOnThisServer.Ignore(NotOnThisServer.NoIniSettings);
-         return null;
+         throw NotOnThisServer.Skipped(NotOnThisServer.NoIniSettings);
       }
 
       public void SetIniSetting(string name, string value)
@@ -846,30 +801,21 @@ namespace hMailServer
 
       public string IniSettingNames
       {
-         get
-         {
-            NotOnThisServer.Ignore(NotOnThisServer.NoIniSettings);
-            return null;
-         }
+         get { throw NotOnThisServer.Skipped(NotOnThisServer.NoIniSettings); }
       }
 
       public int CrashSimulationMode
       {
          get
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoCrashSimulation);
-            return 0;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoCrashSimulation);
          }
-         set { NotOnThisServer.Ignore(NotOnThisServer.NoCrashSimulation); }
+         set { NotOnThisServer.Ignore(NotOnThisServer.NoCrashSimulation, value); }
       }
 
       public string PublicFolderDiskName
       {
-         get
-         {
-            NotOnThisServer.Ignore(NotOnThisServer.NoServerDirectories);
-            return null;
-         }
+         get { throw NotOnThisServer.Skipped(NotOnThisServer.NoServerDirectories); }
       }
 
       public void DisableAdministratorTOTP()
@@ -879,36 +825,28 @@ namespace hMailServer
 
       public string EnrolAdministratorTOTP()
       {
-         NotOnThisServer.Ignore(NotOnThisServer.NoAdministratorTotp);
-         return null;
+         throw NotOnThisServer.Skipped(NotOnThisServer.NoAdministratorTotp);
       }
 
       public string TestLdapDirectory(string a = null, string b = null)
       {
-         NotOnThisServer.Ignore(NotOnThisServer.NoDirectorySync);
-         return null;
+         throw NotOnThisServer.Skipped(NotOnThisServer.NoDirectorySync);
       }
 
       public string PreviewDirectorySync(string a = null, string b = null, string c = null)
       {
-         NotOnThisServer.Ignore(NotOnThisServer.NoDirectorySync);
-         return null;
+         throw NotOnThisServer.Skipped(NotOnThisServer.NoDirectorySync);
       }
 
       public string ApplyDirectorySync(string a = null, string b = null, string c = null)
       {
-         NotOnThisServer.Ignore(NotOnThisServer.NoDirectorySync);
-         return null;
+         throw NotOnThisServer.Skipped(NotOnThisServer.NoDirectorySync);
       }
 
       public string UserInterfaceLanguage
       {
-         get
-         {
-            NotOnThisServer.Ignore(NotOnThisServer.NoUserInterfaceLanguage);
-            return null;
-         }
-         set { NotOnThisServer.Ignore(NotOnThisServer.NoUserInterfaceLanguage); }
+         get { throw NotOnThisServer.Skipped(NotOnThisServer.NoUserInterfaceLanguage); }
+         set { NotOnThisServer.Ignore(NotOnThisServer.NoUserInterfaceLanguage, value); }
       }
    }
 
@@ -1021,38 +959,31 @@ namespace hMailServer
       {
          get
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoLiveLog);
-            return false;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoLiveLog);
          }
       }
 
       public string LiveLog
       {
-         get
-         {
-            NotOnThisServer.Ignore(NotOnThisServer.NoLiveLog);
-            return null;
-         }
+         get { throw NotOnThisServer.Skipped(NotOnThisServer.NoLiveLog); }
       }
 
       public bool MaskPasswordsInLog
       {
          get
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoSettingsKey("mask_passwords_in_log", "logging"));
-            return false;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoSettingsKey("mask_passwords_in_log", "logging"));
          }
-         set { NotOnThisServer.Ignore(NotOnThisServer.NoSettingsKey("mask_passwords_in_log", "logging")); }
+         set { NotOnThisServer.Ignore(NotOnThisServer.NoSettingsKey("mask_passwords_in_log", "logging"), value); }
       }
 
       public eLogDevice Device
       {
          get
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoLogDeviceWrite);
-            return eLogDevice.hLogDeviceFile;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoLogDeviceWrite);
          }
-         set { NotOnThisServer.Ignore(NotOnThisServer.NoLogDeviceWrite); }
+         set { NotOnThisServer.Ignore(NotOnThisServer.NoLogDeviceWrite, value); }
       }
    }
 
@@ -1068,38 +999,22 @@ namespace hMailServer
 
       public string ProgramDirectory
       {
-         get
-         {
-            NotOnThisServer.Ignore(NotOnThisServer.NoServerDirectories);
-            return null;
-         }
+         get { throw NotOnThisServer.Skipped(NotOnThisServer.NoServerDirectories); }
       }
 
       public string DataDirectory
       {
-         get
-         {
-            NotOnThisServer.Ignore(NotOnThisServer.NoServerDirectories);
-            return null;
-         }
+         get { throw NotOnThisServer.Skipped(NotOnThisServer.NoServerDirectories); }
       }
 
       public string EventDirectory
       {
-         get
-         {
-            NotOnThisServer.Ignore(NotOnThisServer.NoServerDirectories);
-            return null;
-         }
+         get { throw NotOnThisServer.Skipped(NotOnThisServer.NoServerDirectories); }
       }
 
       public string TempDirectory
       {
-         get
-         {
-            NotOnThisServer.Ignore(NotOnThisServer.NoServerDirectories);
-            return null;
-         }
+         get { throw NotOnThisServer.Skipped(NotOnThisServer.NoServerDirectories); }
       }
    }
 
@@ -1110,39 +1025,26 @@ namespace hMailServer
       {
          get
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoScripting);
-            return false;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoScripting);
          }
-         set { NotOnThisServer.Ignore(NotOnThisServer.NoScripting); }
+         set { NotOnThisServer.Ignore(NotOnThisServer.NoScripting, value); }
       }
 
       public string Language
       {
-         get
-         {
-            NotOnThisServer.Ignore(NotOnThisServer.NoScripting);
-            return null;
-         }
-         set { NotOnThisServer.Ignore(NotOnThisServer.NoScripting); }
+         get { throw NotOnThisServer.Skipped(NotOnThisServer.NoScripting); }
+         set { NotOnThisServer.Ignore(NotOnThisServer.NoScripting, value); }
       }
 
       public string CurrentScriptFile
       {
-         get
-         {
-            NotOnThisServer.Ignore(NotOnThisServer.NoScripting);
-            return null;
-         }
+         get { throw NotOnThisServer.Skipped(NotOnThisServer.NoScripting); }
       }
 
       public object FileSystemObject
       {
-         get
-         {
-            NotOnThisServer.Ignore(NotOnThisServer.NoScripting);
-            return null;
-         }
-         set { NotOnThisServer.Ignore(NotOnThisServer.NoScripting); }
+         get { throw NotOnThisServer.Skipped(NotOnThisServer.NoScripting); }
+         set { NotOnThisServer.Ignore(NotOnThisServer.NoScripting, value); }
       }
 
       public void Reload()
@@ -1152,8 +1054,7 @@ namespace hMailServer
 
       public string CheckSyntax()
       {
-         NotOnThisServer.Ignore(NotOnThisServer.NoScripting);
-         return null;
+         throw NotOnThisServer.Skipped(NotOnThisServer.NoScripting);
       }
    }
 
@@ -1161,22 +1062,19 @@ namespace hMailServer
    {
       public IMAPFolder Add(string name)
       {
-         NotOnThisServer.Ignore(NotOnThisServer.NoPublicFolderWrite);
-         return null;
+         throw NotOnThisServer.Skipped(NotOnThisServer.NoPublicFolderWrite);
       }
 
       public IMAPFolder get_ItemByName(string name)
       {
-         NotOnThisServer.Ignore(NotOnThisServer.NoPublicFolderWrite);
-         return null;
+         throw NotOnThisServer.Skipped(NotOnThisServer.NoPublicFolderWrite);
       }
 
       public int Count
       {
          get
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoPublicFolderWrite);
-            return 0;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoPublicFolderWrite);
          }
       }
 
@@ -1190,61 +1088,49 @@ namespace hMailServer
    {
       public string Destination
       {
-         get
-         {
-            NotOnThisServer.Ignore(NotOnThisServer.NoBackupSettings);
-            return null;
-         }
-         set { NotOnThisServer.Ignore(NotOnThisServer.NoBackupSettings); }
+         get { throw NotOnThisServer.Skipped(NotOnThisServer.NoBackupSettings); }
+         set { NotOnThisServer.Ignore(NotOnThisServer.NoBackupSettings, value); }
       }
 
       public string LogFile
       {
-         get
-         {
-            NotOnThisServer.Ignore(NotOnThisServer.NoBackupSettings);
-            return null;
-         }
+         get { throw NotOnThisServer.Skipped(NotOnThisServer.NoBackupSettings); }
       }
 
       public bool BackupMessages
       {
          get
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoBackupSettings);
-            return false;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoBackupSettings);
          }
-         set { NotOnThisServer.Ignore(NotOnThisServer.NoBackupSettings); }
+         set { NotOnThisServer.Ignore(NotOnThisServer.NoBackupSettings, value); }
       }
 
       public bool BackupSettings
       {
          get
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoBackupSettings);
-            return false;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoBackupSettings);
          }
-         set { NotOnThisServer.Ignore(NotOnThisServer.NoBackupSettings); }
+         set { NotOnThisServer.Ignore(NotOnThisServer.NoBackupSettings, value); }
       }
 
       public bool BackupDomains
       {
          get
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoBackupSettings);
-            return false;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoBackupSettings);
          }
-         set { NotOnThisServer.Ignore(NotOnThisServer.NoBackupSettings); }
+         set { NotOnThisServer.Ignore(NotOnThisServer.NoBackupSettings, value); }
       }
 
       public bool CompressDestinationFiles
       {
          get
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoBackupSettings);
-            return false;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoBackupSettings);
          }
-         set { NotOnThisServer.Ignore(NotOnThisServer.NoBackupSettings); }
+         set { NotOnThisServer.Ignore(NotOnThisServer.NoBackupSettings, value); }
       }
    }
 
@@ -1254,18 +1140,16 @@ namespace hMailServer
       {
          get
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoCacheControl);
-            return false;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoCacheControl);
          }
-         set { NotOnThisServer.Ignore(NotOnThisServer.NoCacheControl); }
+         set { NotOnThisServer.Ignore(NotOnThisServer.NoCacheControl, value); }
       }
 
       public int DomainCacheSizeKb
       {
          get
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoCacheControl);
-            return 0;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoCacheControl);
          }
       }
 
@@ -1273,18 +1157,16 @@ namespace hMailServer
       {
          get
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoCacheControl);
-            return 0;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoCacheControl);
          }
-         set { NotOnThisServer.Ignore(NotOnThisServer.NoCacheControl); }
+         set { NotOnThisServer.Ignore(NotOnThisServer.NoCacheControl, value); }
       }
 
       public int AccountCacheSizeKb
       {
          get
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoCacheControl);
-            return 0;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoCacheControl);
          }
       }
 
@@ -1292,10 +1174,9 @@ namespace hMailServer
       {
          get
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoCacheControl);
-            return 0;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoCacheControl);
          }
-         set { NotOnThisServer.Ignore(NotOnThisServer.NoCacheControl); }
+         set { NotOnThisServer.Ignore(NotOnThisServer.NoCacheControl, value); }
       }
 
       public void Clear()
@@ -1310,10 +1191,9 @@ namespace hMailServer
       {
          get
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoAntiVirusSettings);
-            return false;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoAntiVirusSettings);
          }
-         set { NotOnThisServer.Ignore(NotOnThisServer.NoAntiVirusSettings); }
+         set { NotOnThisServer.Ignore(NotOnThisServer.NoAntiVirusSettings, value); }
       }
 
       public BlockedAttachments BlockedAttachments { get; } = new BlockedAttachments();
@@ -1322,46 +1202,41 @@ namespace hMailServer
       {
          get
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoAntiVirusSettings);
-            return eAntivirusAction.hDeleteEmail;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoAntiVirusSettings);
          }
-         set { NotOnThisServer.Ignore(NotOnThisServer.NoAntiVirusSettings); }
+         set { NotOnThisServer.Ignore(NotOnThisServer.NoAntiVirusSettings, value); }
       }
 
       public int ScannerFailurePolicy
       {
          get
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoAntiVirusSettings);
-            return 0;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoAntiVirusSettings);
          }
-         set { NotOnThisServer.Ignore(NotOnThisServer.NoAntiVirusSettings); }
+         set { NotOnThisServer.Ignore(NotOnThisServer.NoAntiVirusSettings, value); }
       }
 
       public bool CustomScannerEnabled
       {
          get
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoAntiVirusSettings);
-            return false;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoAntiVirusSettings);
          }
-         set { NotOnThisServer.Ignore(NotOnThisServer.NoAntiVirusSettings); }
+         set { NotOnThisServer.Ignore(NotOnThisServer.NoAntiVirusSettings, value); }
       }
 
       public string TestClamAVScanner(string host = null, int port = 0)
       {
-         NotOnThisServer.Ignore(NotOnThisServer.NoAntiVirusSettings);
-         return null;
+         throw NotOnThisServer.Skipped(NotOnThisServer.NoAntiVirusSettings);
       }
 
       public bool ClamAVEnabled
       {
          get
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoAntiVirusSettings);
-            return false;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoAntiVirusSettings);
          }
-         set { NotOnThisServer.Ignore(NotOnThisServer.NoAntiVirusSettings); }
+         set { NotOnThisServer.Ignore(NotOnThisServer.NoAntiVirusSettings, value); }
       }
    }
 
@@ -1371,8 +1246,7 @@ namespace hMailServer
       {
          get
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoGroups);
-            return 0;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoGroups);
          }
       }
 
@@ -1380,21 +1254,18 @@ namespace hMailServer
       {
          get
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoGroups);
-            return 0;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoGroups);
          }
       }
 
       public Group Add()
       {
-         NotOnThisServer.Ignore(NotOnThisServer.NoGroups);
-         return null;
+         throw NotOnThisServer.Skipped(NotOnThisServer.NoGroups);
       }
 
       public Group get_ItemByName(string name)
       {
-         NotOnThisServer.Ignore(NotOnThisServer.NoGroups);
-         return null;
+         throw NotOnThisServer.Skipped(NotOnThisServer.NoGroups);
       }
 
       public void DeleteByDBID(long id)
@@ -1407,8 +1278,7 @@ namespace hMailServer
    {
       public ServerMessage get_ItemByName(string name)
       {
-         NotOnThisServer.Ignore(NotOnThisServer.NoServerMessages);
-         return null;
+         throw NotOnThisServer.Skipped(NotOnThisServer.NoServerMessages);
       }
    }
 
@@ -1429,10 +1299,9 @@ namespace hMailServer
       {
          get
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoMessageIndexing);
-            return false;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoMessageIndexing);
          }
-         set { NotOnThisServer.Ignore(NotOnThisServer.NoMessageIndexing); }
+         set { NotOnThisServer.Ignore(NotOnThisServer.NoMessageIndexing, value); }
       }
 
       public void Index()
@@ -1444,8 +1313,7 @@ namespace hMailServer
       {
          get
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoMessageIndexing);
-            return 0;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoMessageIndexing);
          }
       }
 
@@ -1453,8 +1321,7 @@ namespace hMailServer
       {
          get
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoMessageIndexing);
-            return 0;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoMessageIndexing);
          }
       }
    }
@@ -1463,16 +1330,14 @@ namespace hMailServer
    {
       public object Add()
       {
-         NotOnThisServer.Ignore(NotOnThisServer.NoIncomingRelays);
-         return null;
+         throw NotOnThisServer.Skipped(NotOnThisServer.NoIncomingRelays);
       }
 
       public int Count
       {
          get
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoIncomingRelays);
-            return 0;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoIncomingRelays);
          }
       }
    }
@@ -1692,68 +1557,42 @@ namespace hMailServer
 
       public string TestSpamAssassinConnection(string host, int port, bool useSpamAssassinUser = false)
       {
-         NotOnThisServer.Ignore(NotOnThisServer.NoSpamAssassinProbe);
-         return null;
+         throw NotOnThisServer.Skipped(NotOnThisServer.NoSpamAssassinProbe);
       }
 
       public string DKIMVerify(string rawMessage)
       {
-         NotOnThisServer.Ignore(NotOnThisServer.NoDkimVerifyCall);
-         return null;
+         throw NotOnThisServer.Skipped(NotOnThisServer.NoDkimVerifyCall);
       }
 
       public DNSBlackLists DNSBlackLists
       {
-         get
-         {
-            NotOnThisServer.Ignore(NotOnThisServer.NoBlacklistCollections);
-            return null;
-         }
+         get { throw NotOnThisServer.Skipped(NotOnThisServer.NoBlacklistCollections); }
       }
 
       public SURBLServers SURBLServers
       {
-         get
-         {
-            NotOnThisServer.Ignore(NotOnThisServer.NoBlacklistCollections);
-            return null;
-         }
+         get { throw NotOnThisServer.Skipped(NotOnThisServer.NoBlacklistCollections); }
       }
 
       public BlockedSenders BlockedSenders
       {
-         get
-         {
-            NotOnThisServer.Ignore(NotOnThisServer.NoBlacklistCollections);
-            return null;
-         }
+         get { throw NotOnThisServer.Skipped(NotOnThisServer.NoBlacklistCollections); }
       }
 
       public WhiteListAddresses WhiteListAddresses
       {
-         get
-         {
-            NotOnThisServer.Ignore(NotOnThisServer.NoBlacklistCollections);
-            return null;
-         }
+         get { throw NotOnThisServer.Skipped(NotOnThisServer.NoBlacklistCollections); }
       }
 
       public GreyListingWhiteAddresses GreyListingWhiteAddresses
       {
-         get
-         {
-            NotOnThisServer.Ignore(NotOnThisServer.NoBlacklistCollections);
-            return null;
-         }
+         get { throw NotOnThisServer.Skipped(NotOnThisServer.NoBlacklistCollections); }
       }
 
       public Quarantine Quarantine
       {
-         get
-         {
-            NotOnThisServer.Ignore(NotOnThisServer.NoQuarantineObject);
-            return null;
-         }
+         get { throw NotOnThisServer.Skipped(NotOnThisServer.NoQuarantineObject); }
       }
    }
 
@@ -1762,10 +1601,7 @@ namespace hMailServer
    // only so that a fixture naming their types compiles.
    public class DNSBlackLists
    {
-      public DNSBlackList Add()
-      {
-         return null;
-      }
+      public DNSBlackList Add() { throw NotOnThisServer.Skipped("adds a DNSBlackList, which no REST route carries yet"); }
 
       [System.Runtime.CompilerServices.IndexerName("At")]
       public DNSBlackList this[int index] => null;
@@ -1810,10 +1646,7 @@ namespace hMailServer
 
    public class SURBLServers
    {
-      public SURBLServer Add()
-      {
-         return null;
-      }
+      public SURBLServer Add() { throw NotOnThisServer.Skipped("adds a SURBLServer, which no REST route carries yet"); }
 
       [System.Runtime.CompilerServices.IndexerName("At")]
       public SURBLServer this[int index] => null;
@@ -1858,10 +1691,7 @@ namespace hMailServer
 
    public class BlockedSenders
    {
-      public BlockedSender Add()
-      {
-         return null;
-      }
+      public BlockedSender Add() { throw NotOnThisServer.Skipped("adds a BlockedSender, which no REST route carries yet"); }
 
       [System.Runtime.CompilerServices.IndexerName("At")]
       public BlockedSender this[int index] => null;
@@ -1907,10 +1737,7 @@ namespace hMailServer
 
    public class WhiteListAddresses
    {
-      public WhiteListAddress Add()
-      {
-         return null;
-      }
+      public WhiteListAddress Add() { throw NotOnThisServer.Skipped("adds a WhiteListAddress, which no REST route carries yet"); }
 
       [System.Runtime.CompilerServices.IndexerName("At")]
       public WhiteListAddress this[int index] => null;
@@ -1955,10 +1782,7 @@ namespace hMailServer
 
    public class GreyListingWhiteAddresses
    {
-      public GreyListingWhiteAddress Add()
-      {
-         return null;
-      }
+      public GreyListingWhiteAddress Add() { throw NotOnThisServer.Skipped("adds a GreyListingWhiteAddress, which no REST route carries yet"); }
 
       [System.Runtime.CompilerServices.IndexerName("At")]
       public GreyListingWhiteAddress this[int index] => null;
@@ -2084,32 +1908,27 @@ namespace hMailServer
 
       public string EvaluateSieveScript(string script, string rawMessage)
       {
-         NotOnThisServer.Ignore(NotOnThisServer.NoSieveEvaluate);
-         return null;
+         throw NotOnThisServer.Skipped(NotOnThisServer.NoSieveEvaluate);
       }
 
       public string GetMailServer(string address)
       {
-         NotOnThisServer.Ignore(NotOnThisServer.NoMailServerLookup);
-         return null;
+         throw NotOnThisServer.Skipped(NotOnThisServer.NoMailServerLookup);
       }
 
       public string MD5(string text)
       {
-         NotOnThisServer.Ignore(NotOnThisServer.NoUtilityCall);
-         return null;
+         throw NotOnThisServer.Skipped(NotOnThisServer.NoUtilityCall);
       }
 
       public string BlowfishEncrypt(string text)
       {
-         NotOnThisServer.Ignore(NotOnThisServer.NoUtilityCall);
-         return null;
+         throw NotOnThisServer.Skipped(NotOnThisServer.NoUtilityCall);
       }
 
       public string BlowfishDecrypt(string text)
       {
-         NotOnThisServer.Ignore(NotOnThisServer.NoUtilityCall);
-         return null;
+         throw NotOnThisServer.Skipped(NotOnThisServer.NoUtilityCall);
       }
 
       public void ImportMessageFromFile(string file, long accountId)
@@ -2124,44 +1943,37 @@ namespace hMailServer
 
       public string RunTestSuite(string name = null)
       {
-         NotOnThisServer.Ignore(NotOnThisServer.NoUtilityCall);
-         return null;
+         throw NotOnThisServer.Skipped(NotOnThisServer.NoUtilityCall);
       }
 
       public string SendDmarcReports(string date = null)
       {
-         NotOnThisServer.Ignore(NotOnThisServer.NoUtilityCall);
-         return null;
+         throw NotOnThisServer.Skipped(NotOnThisServer.NoUtilityCall);
       }
 
       public string SendTlsRptReports(string date = null)
       {
-         NotOnThisServer.Ignore(NotOnThisServer.NoUtilityCall);
-         return null;
+         throw NotOnThisServer.Skipped(NotOnThisServer.NoUtilityCall);
       }
 
       public string SearchArchive(string query, string from = null, string to = null)
       {
-         NotOnThisServer.Ignore(NotOnThisServer.NoUtilityCall);
-         return null;
+         throw NotOnThisServer.Skipped(NotOnThisServer.NoUtilityCall);
       }
 
       public string ResolveMXRecords(string domain)
       {
-         NotOnThisServer.Ignore(NotOnThisServer.NoUtilityCall);
-         return null;
+         throw NotOnThisServer.Skipped(NotOnThisServer.NoUtilityCall);
       }
 
       public string RunMessageRetention()
       {
-         NotOnThisServer.Ignore(NotOnThisServer.NoUtilityCall);
-         return null;
+         throw NotOnThisServer.Skipped(NotOnThisServer.NoUtilityCall);
       }
 
       public string PerformMaintenance(eMaintenanceOperation operation)
       {
-         NotOnThisServer.Ignore(NotOnThisServer.NoUtilityCall);
-         return null;
+         throw NotOnThisServer.Skipped(NotOnThisServer.NoUtilityCall);
       }
 
       public void SampleMetricsNow()
@@ -2171,14 +1983,12 @@ namespace hMailServer
 
       public string IsStrongPassword(string password)
       {
-         NotOnThisServer.Ignore(NotOnThisServer.NoUtilityCall);
-         return null;
+         throw NotOnThisServer.Skipped(NotOnThisServer.NoUtilityCall);
       }
 
       public string IsValidEmailAddress(string address)
       {
-         NotOnThisServer.Ignore(NotOnThisServer.NoUtilityCall);
-         return null;
+         throw NotOnThisServer.Skipped(NotOnThisServer.NoUtilityCall);
       }
    }
 
@@ -2225,8 +2035,7 @@ namespace hMailServer
       {
          get
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoDomainIds);
-            return 0;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoDomainIds);
          }
       }
 
@@ -2236,75 +2045,75 @@ namespace hMailServer
       public DomainAliases DomainAliases { get; } = new DomainAliases();
 
       // What the COM object saves and PUT /api/v1/domains/{domain} does not take.
-      public bool DKIMSignEnabled { get { Unsupported("DKIMSignEnabled"); return false; } set { Unsupported("DKIMSignEnabled"); } }
-      public string DKIMSelector { get { Unsupported("DKIMSelector"); return null; } set { Unsupported("DKIMSelector"); } }
-      public string DKIMPrivateKeyFile { get { Unsupported("DKIMPrivateKeyFile"); return null; } set { Unsupported("DKIMPrivateKeyFile"); } }
-      public string DKIMSecondarySelector { get { Unsupported("DKIMSecondarySelector"); return null; } set { Unsupported("DKIMSecondarySelector"); } }
-      public string DKIMSecondaryPrivateKeyFile { get { Unsupported("DKIMSecondaryPrivateKeyFile"); return null; } set { Unsupported("DKIMSecondaryPrivateKeyFile"); } }
-      public int SignatureMethod { get { Unsupported("SignatureMethod"); return 0; } set { Unsupported("SignatureMethod"); } }
-      public bool SignatureEnabled { get { Unsupported("SignatureEnabled"); return false; } set { Unsupported("SignatureEnabled"); } }
-      public string SignaturePlainText { get { Unsupported("SignaturePlainText"); return null; } set { Unsupported("SignaturePlainText"); } }
-      public string SignatureHTML { get { Unsupported("SignatureHTML"); return null; } set { Unsupported("SignatureHTML"); } }
-      public bool AddSignaturesToLocalMail { get { Unsupported("AddSignaturesToLocalMail"); return false; } set { Unsupported("AddSignaturesToLocalMail"); } }
-      public int MaxMessageSize { get { Unsupported("MaxMessageSize"); return 0; } set { Unsupported("MaxMessageSize"); } }
-      public int MaxAccountSize { get { Unsupported("MaxAccountSize"); return 0; } set { Unsupported("MaxAccountSize"); } }
-      public int MaxNumberOfAccounts { get { Unsupported("MaxNumberOfAccounts"); return 0; } set { Unsupported("MaxNumberOfAccounts"); } }
-      public int MaxNumberOfAliases { get { Unsupported("MaxNumberOfAliases"); return 0; } set { Unsupported("MaxNumberOfAliases"); } }
-      public int MaxNumberOfDistributionLists { get { Unsupported("MaxNumberOfDistributionLists"); return 0; } set { Unsupported("MaxNumberOfDistributionLists"); } }
-      public int MessageRetentionDays { get { Unsupported("MessageRetentionDays"); return 0; } set { Unsupported("MessageRetentionDays"); } }
-      public string RelayHost { get { Unsupported("RelayHost"); return null; } set { Unsupported("RelayHost"); } }
-      public int RelayPort { get { Unsupported("RelayPort"); return 0; } set { Unsupported("RelayPort"); } }
-      public bool VacationMessageIsOn { get { Unsupported("VacationMessageIsOn"); return false; } set { Unsupported("VacationMessageIsOn"); } }
-      public string ADDomainName { get { Unsupported("ADDomainName"); return null; } set { Unsupported("ADDomainName"); } }
+      public bool DKIMSignEnabled { get { Unsupported("DKIMSignEnabled"); return false; } set { Unsupported("DKIMSignEnabled", value); } }
+      public string DKIMSelector { get { Unsupported("DKIMSelector"); return null; } set { Unsupported("DKIMSelector", value); } }
+      public string DKIMPrivateKeyFile { get { Unsupported("DKIMPrivateKeyFile"); return null; } set { Unsupported("DKIMPrivateKeyFile", value); } }
+      public string DKIMSecondarySelector { get { Unsupported("DKIMSecondarySelector"); return null; } set { Unsupported("DKIMSecondarySelector", value); } }
+      public string DKIMSecondaryPrivateKeyFile { get { Unsupported("DKIMSecondaryPrivateKeyFile"); return null; } set { Unsupported("DKIMSecondaryPrivateKeyFile", value); } }
+      public int SignatureMethod { get { Unsupported("SignatureMethod"); return 0; } set { Unsupported("SignatureMethod", value); } }
+      public bool SignatureEnabled { get { Unsupported("SignatureEnabled"); return false; } set { Unsupported("SignatureEnabled", value); } }
+      public string SignaturePlainText { get { Unsupported("SignaturePlainText"); return null; } set { Unsupported("SignaturePlainText", value); } }
+      public string SignatureHTML { get { Unsupported("SignatureHTML"); return null; } set { Unsupported("SignatureHTML", value); } }
+      public bool AddSignaturesToLocalMail { get { Unsupported("AddSignaturesToLocalMail"); return false; } set { Unsupported("AddSignaturesToLocalMail", value); } }
+      public int MaxMessageSize { get { Unsupported("MaxMessageSize"); return 0; } set { Unsupported("MaxMessageSize", value); } }
+      public int MaxAccountSize { get { Unsupported("MaxAccountSize"); return 0; } set { Unsupported("MaxAccountSize", value); } }
+      public int MaxNumberOfAccounts { get { Unsupported("MaxNumberOfAccounts"); return 0; } set { Unsupported("MaxNumberOfAccounts", value); } }
+      public int MaxNumberOfAliases { get { Unsupported("MaxNumberOfAliases"); return 0; } set { Unsupported("MaxNumberOfAliases", value); } }
+      public int MaxNumberOfDistributionLists { get { Unsupported("MaxNumberOfDistributionLists"); return 0; } set { Unsupported("MaxNumberOfDistributionLists", value); } }
+      public int MessageRetentionDays { get { Unsupported("MessageRetentionDays"); return 0; } set { Unsupported("MessageRetentionDays", value); } }
+      public string RelayHost { get { Unsupported("RelayHost"); return null; } set { Unsupported("RelayHost", value); } }
+      public int RelayPort { get { Unsupported("RelayPort"); return 0; } set { Unsupported("RelayPort", value); } }
+      public bool VacationMessageIsOn { get { Unsupported("VacationMessageIsOn"); return false; } set { Unsupported("VacationMessageIsOn", value); } }
+      public string ADDomainName { get { Unsupported("ADDomainName"); return null; } set { Unsupported("ADDomainName", value); } }
       public eDKIMAlgorithm DKIMSigningAlgorithm
       {
          get { Unsupported("DKIMSigningAlgorithm"); return eDKIMAlgorithm.eSHA256; }
-         set { Unsupported("DKIMSigningAlgorithm"); }
+         set { Unsupported("DKIMSigningAlgorithm", value); }
       }
       public bool AntiSpamEnableGreylisting
       {
          get { Unsupported("AntiSpamEnableGreylisting"); return false; }
-         set { Unsupported("AntiSpamEnableGreylisting"); }
+         set { Unsupported("AntiSpamEnableGreylisting", value); }
       }
       public bool MaxNumberOfAccountsEnabled
       {
          get { Unsupported("MaxNumberOfAccountsEnabled"); return false; }
-         set { Unsupported("MaxNumberOfAccountsEnabled"); }
+         set { Unsupported("MaxNumberOfAccountsEnabled", value); }
       }
       public bool MaxNumberOfAliasesEnabled
       {
          get { Unsupported("MaxNumberOfAliasesEnabled"); return false; }
-         set { Unsupported("MaxNumberOfAliasesEnabled"); }
+         set { Unsupported("MaxNumberOfAliasesEnabled", value); }
       }
       public bool MaxNumberOfDistributionListsEnabled
       {
          get { Unsupported("MaxNumberOfDistributionListsEnabled"); return false; }
-         set { Unsupported("MaxNumberOfDistributionListsEnabled"); }
+         set { Unsupported("MaxNumberOfDistributionListsEnabled", value); }
       }
       public bool MaxMessageSizeEnabled
       {
          get { Unsupported("MaxMessageSizeEnabled"); return false; }
-         set { Unsupported("MaxMessageSizeEnabled"); }
+         set { Unsupported("MaxMessageSizeEnabled", value); }
       }
       public bool MaxAccountSizeEnabled
       {
          get { Unsupported("MaxAccountSizeEnabled"); return false; }
-         set { Unsupported("MaxAccountSizeEnabled"); }
+         set { Unsupported("MaxAccountSizeEnabled", value); }
       }
       public bool RelayRequiresAuthentication
       {
          get { Unsupported("RelayRequiresAuthentication"); return false; }
-         set { Unsupported("RelayRequiresAuthentication"); }
+         set { Unsupported("RelayRequiresAuthentication", value); }
       }
       public string VacationSubject
       {
          get { Unsupported("VacationSubject"); return null; }
-         set { Unsupported("VacationSubject"); }
+         set { Unsupported("VacationSubject", value); }
       }
       public string VacationMessage
       {
          get { Unsupported("VacationMessage"); return null; }
-         set { Unsupported("VacationMessage"); }
+         set { Unsupported("VacationMessage", value); }
       }
 
       public void DKIMPromoteSecondary()
@@ -2312,9 +2121,9 @@ namespace hMailServer
          Unsupported("DKIMPromoteSecondary");
          SkipIfAnythingUnsupported("PUT /api/v1/domains/{domain}");
       }
-      public bool EnableLimitations { get { Unsupported("EnableLimitations"); return false; } set { Unsupported("EnableLimitations"); } }
-      public bool PlusAddressingEnabled { get { Unsupported("PlusAddressingEnabled"); return false; } set { Unsupported("PlusAddressingEnabled"); } }
-      public string PlusAddressingCharacter { get { Unsupported("PlusAddressingCharacter"); return null; } set { Unsupported("PlusAddressingCharacter"); } }
+      public bool EnableLimitations { get { Unsupported("EnableLimitations"); return false; } set { Unsupported("EnableLimitations", value); } }
+      public bool PlusAddressingEnabled { get { Unsupported("PlusAddressingEnabled"); return false; } set { Unsupported("PlusAddressingEnabled", value); } }
+      public string PlusAddressingCharacter { get { Unsupported("PlusAddressingCharacter"); return null; } set { Unsupported("PlusAddressingCharacter", value); } }
 
       public void Save()
       {
@@ -2376,8 +2185,7 @@ namespace hMailServer
       {
          get
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoAliasIds);
-            return 0;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoAliasIds);
          }
       }
 
@@ -2415,8 +2223,7 @@ namespace hMailServer
       {
          get
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoListIds);
-            return 0;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoListIds);
          }
       }
 
@@ -2424,89 +2231,65 @@ namespace hMailServer
       {
          get
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoListObject);
-            return eDistributionListMode.eLMPublic;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoListObject);
          }
-         set { NotOnThisServer.Ignore(NotOnThisServer.NoListObject); }
+         set { NotOnThisServer.Ignore(NotOnThisServer.NoListObject, value); }
       }
 
       public string RequireSMTPAuth
       {
-         get
-         {
-            NotOnThisServer.Ignore(NotOnThisServer.NoListObject);
-            return null;
-         }
-         set { NotOnThisServer.Ignore(NotOnThisServer.NoListObject); }
+         get { throw NotOnThisServer.Skipped(NotOnThisServer.NoListObject); }
+         set { NotOnThisServer.Ignore(NotOnThisServer.NoListObject, value); }
       }
 
       public DistributionListRecipients Recipients
       {
-         get
-         {
-            NotOnThisServer.Ignore(NotOnThisServer.NoListObject);
-            return null;
-         }
+         get { throw NotOnThisServer.Skipped(NotOnThisServer.NoListObject); }
       }
 
       public string ModeratorAddress
       {
-         get
-         {
-            NotOnThisServer.Ignore(NotOnThisServer.NoListObject);
-            return null;
-         }
-         set { NotOnThisServer.Ignore(NotOnThisServer.NoListObject); }
+         get { throw NotOnThisServer.Skipped(NotOnThisServer.NoListObject); }
+         set { NotOnThisServer.Ignore(NotOnThisServer.NoListObject, value); }
       }
 
       public bool RequireSenderAddress
       {
          get
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoListObject);
-            return false;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoListObject);
          }
-         set { NotOnThisServer.Ignore(NotOnThisServer.NoListObject); }
+         set { NotOnThisServer.Ignore(NotOnThisServer.NoListObject, value); }
       }
 
       public bool ModerationEnabled
       {
          get
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoListObject);
-            return false;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoListObject);
          }
-         set { NotOnThisServer.Ignore(NotOnThisServer.NoListObject); }
+         set { NotOnThisServer.Ignore(NotOnThisServer.NoListObject, value); }
       }
 
       public bool AnnouncementsOnly
       {
          get
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoListObject);
-            return false;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoListObject);
          }
-         set { NotOnThisServer.Ignore(NotOnThisServer.NoListObject); }
+         set { NotOnThisServer.Ignore(NotOnThisServer.NoListObject, value); }
       }
 
       public string SenderAddress
       {
-         get
-         {
-            NotOnThisServer.Ignore(NotOnThisServer.NoListObject);
-            return null;
-         }
-         set { NotOnThisServer.Ignore(NotOnThisServer.NoListObject); }
+         get { throw NotOnThisServer.Skipped(NotOnThisServer.NoListObject); }
+         set { NotOnThisServer.Ignore(NotOnThisServer.NoListObject, value); }
       }
 
       public string Name
       {
-         get
-         {
-            NotOnThisServer.Ignore(NotOnThisServer.NoListObject);
-            return null;
-         }
-         set { NotOnThisServer.Ignore(NotOnThisServer.NoListObject); }
+         get { throw NotOnThisServer.Skipped(NotOnThisServer.NoListObject); }
+         set { NotOnThisServer.Ignore(NotOnThisServer.NoListObject, value); }
       }
 
       public void Save()
@@ -2524,10 +2307,7 @@ namespace hMailServer
    {
       public int Count => 0;
 
-      public DistributionListRecipient Add()
-      {
-         return null;
-      }
+      public DistributionListRecipient Add() { throw NotOnThisServer.Skipped("adds a DistributionListRecipient, which no REST route carries yet"); }
 
       [System.Runtime.CompilerServices.IndexerName("At")]
       public DistributionListRecipient this[int index] => null;
@@ -2637,11 +2417,7 @@ namespace hMailServer
 
       public RouteAddresses Addresses
       {
-         get
-         {
-            NotOnThisServer.Ignore(NotOnThisServer.NoRouteAddresses);
-            return null;
-         }
+         get { throw NotOnThisServer.Skipped(NotOnThisServer.NoRouteAddresses); }
       }
    }
 
@@ -2649,10 +2425,7 @@ namespace hMailServer
    {
       public int Count => 0;
 
-      public RouteAddress Add()
-      {
-         return null;
-      }
+      public RouteAddress Add() { throw NotOnThisServer.Skipped("adds a RouteAddress, which no REST route carries yet"); }
 
       [System.Runtime.CompilerServices.IndexerName("At")]
       public RouteAddress this[int index] => null;
@@ -2844,8 +2617,7 @@ namespace hMailServer
       {
          get
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoAccountIds);
-            return 0;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoAccountIds);
          }
       }
 
@@ -2865,54 +2637,42 @@ namespace hMailServer
       {
          get
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoAccountTotp);
-            return false;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoAccountTotp);
          }
-         set { NotOnThisServer.Ignore(NotOnThisServer.NoAccountTotp); }
+         set { NotOnThisServer.Ignore(NotOnThisServer.NoAccountTotp, value); }
       }
 
       public string EnrolTOTP()
       {
-         NotOnThisServer.Ignore(NotOnThisServer.NoAccountTotp);
-         return null;
+         throw NotOnThisServer.Skipped(NotOnThisServer.NoAccountTotp);
       }
 
       public bool IsAD
       {
          get
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoDirectoryLink);
-            return false;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoDirectoryLink);
          }
-         set { NotOnThisServer.Ignore(NotOnThisServer.NoDirectoryLink); }
+         set { NotOnThisServer.Ignore(NotOnThisServer.NoDirectoryLink, value); }
       }
 
       public string ADUsername
       {
-         get
-         {
-            NotOnThisServer.Ignore(NotOnThisServer.NoDirectoryLink);
-            return null;
-         }
-         set { NotOnThisServer.Ignore(NotOnThisServer.NoDirectoryLink); }
+         get { throw NotOnThisServer.Skipped(NotOnThisServer.NoDirectoryLink); }
+         set { NotOnThisServer.Ignore(NotOnThisServer.NoDirectoryLink, value); }
       }
 
       public string ADDomain
       {
-         get
-         {
-            NotOnThisServer.Ignore(NotOnThisServer.NoDirectoryLink);
-            return null;
-         }
-         set { NotOnThisServer.Ignore(NotOnThisServer.NoDirectoryLink); }
+         get { throw NotOnThisServer.Skipped(NotOnThisServer.NoDirectoryLink); }
+         set { NotOnThisServer.Ignore(NotOnThisServer.NoDirectoryLink, value); }
       }
 
       public DateTime LastLogonTime
       {
          get
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoAccountLastLogon);
-            return DateTime.MinValue;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoAccountLastLogon);
          }
       }
 
@@ -2977,21 +2737,21 @@ namespace hMailServer
       public bool VacationMessageAbortSpamFlagged
       {
          get { Unsupported("VacationMessageAbortSpamFlagged"); return false; }
-         set { Unsupported("VacationMessageAbortSpamFlagged"); }
+         set { Unsupported("VacationMessageAbortSpamFlagged", value); }
       }
 
       public string VacationMessageBeginDate
       {
          get { Unsupported("VacationMessageBeginDate"); return null; }
-         set { Unsupported("VacationMessageBeginDate"); }
+         set { Unsupported("VacationMessageBeginDate", value); }
       }
 
-      public int MessageRetentionDays { get { Unsupported("MessageRetentionDays"); return 0; } set { Unsupported("MessageRetentionDays"); } }
-      public int SpamMarkThreshold { get { Unsupported("SpamMarkThreshold"); return 0; } set { Unsupported("SpamMarkThreshold"); } }
-      public int SpamDeleteThreshold { get { Unsupported("SpamDeleteThreshold"); return 0; } set { Unsupported("SpamDeleteThreshold"); } }
-      public bool PersonalSpamSettingsEnabled { get { Unsupported("PersonalSpamSettingsEnabled"); return false; } set { Unsupported("PersonalSpamSettingsEnabled"); } }
-      public bool AntiSpamEnabled { get { Unsupported("AntiSpamEnabled"); return false; } set { Unsupported("AntiSpamEnabled"); } }
-      public bool AntiVirusEnabled { get { Unsupported("AntiVirusEnabled"); return false; } set { Unsupported("AntiVirusEnabled"); } }
+      public int MessageRetentionDays { get { Unsupported("MessageRetentionDays"); return 0; } set { Unsupported("MessageRetentionDays", value); } }
+      public int SpamMarkThreshold { get { Unsupported("SpamMarkThreshold"); return 0; } set { Unsupported("SpamMarkThreshold", value); } }
+      public int SpamDeleteThreshold { get { Unsupported("SpamDeleteThreshold"); return 0; } set { Unsupported("SpamDeleteThreshold", value); } }
+      public bool PersonalSpamSettingsEnabled { get { Unsupported("PersonalSpamSettingsEnabled"); return false; } set { Unsupported("PersonalSpamSettingsEnabled", value); } }
+      public bool AntiSpamEnabled { get { Unsupported("AntiSpamEnabled"); return false; } set { Unsupported("AntiSpamEnabled", value); } }
+      public bool AntiVirusEnabled { get { Unsupported("AntiVirusEnabled"); return false; } set { Unsupported("AntiVirusEnabled", value); } }
 
       /// <summary>
       ///    PUT /api/v1/accounts/{address} for the fields it takes; a create goes
@@ -3206,11 +2966,10 @@ namespace hMailServer
             var folders = ServerApi.AsAccount(_account.Address, _account.Password, HttpMethod.Get, "/api/v1/me/folders")
                .Expect(200, "GET /api/v1/me/folders as " + _account.Address);
 
-            foreach (var folder in ServerApi.Array(folders, "folders"))
-            {
-               if (string.Equals(ServerApi.StringOf(folder, "name"), "INBOX", StringComparison.OrdinalIgnoreCase))
-                  inboxId = ServerApi.LongOf(folder, "id");
-            }
+            inboxId = ServerApi.Array(folders, "folders")
+               .Where(folder => string.Equals(ServerApi.StringOf(folder, "name"), "INBOX", StringComparison.OrdinalIgnoreCase))
+               .Select(folder => ServerApi.LongOf(folder, "id"))
+               .LastOrDefault();
 
             if (inboxId == 0)
                throw new InvalidOperationException(_account.Address + " has no INBOX in GET /api/v1/me/folders: " + folders.Body);
@@ -3233,16 +2992,12 @@ namespace hMailServer
 
       public Message get_ItemByDBID(long id)
       {
-         foreach (var message in Load())
-            if (message.ID == id)
-               return message;
-         return null;
+         return Load().FirstOrDefault(message => message.ID == id);
       }
 
       public Message Add()
       {
-         NotOnThisServer.Ignore(NotOnThisServer.NoMessageObject);
-         return null;
+         throw NotOnThisServer.Skipped(NotOnThisServer.NoMessageObject);
       }
 
       public void Refresh()
@@ -3279,31 +3034,31 @@ namespace hMailServer
       public string Subject
       {
          get { return ServerApi.StringOf(Read(), "subject"); }
-         set { NotOnThisServer.Ignore(NotOnThisServer.NoMessageObject); }
+         set { NotOnThisServer.Ignore(NotOnThisServer.NoMessageObject, value); }
       }
 
       public string From
       {
          get { return ServerApi.StringOf(Read(), "from"); }
-         set { NotOnThisServer.Ignore(NotOnThisServer.NoMessageObject); }
+         set { NotOnThisServer.Ignore(NotOnThisServer.NoMessageObject, value); }
       }
 
       public string To
       {
          get { return ServerApi.StringOf(Read(), "to"); }
-         set { NotOnThisServer.Ignore(NotOnThisServer.NoMessageObject); }
+         set { NotOnThisServer.Ignore(NotOnThisServer.NoMessageObject, value); }
       }
 
       public string Body
       {
          get { return ServerApi.StringOf(Read(), "text"); }
-         set { NotOnThisServer.Ignore(NotOnThisServer.NoMessageObject); }
+         set { NotOnThisServer.Ignore(NotOnThisServer.NoMessageObject, value); }
       }
 
       public string HTMLBody
       {
          get { return ServerApi.StringOf(Read(), "html"); }
-         set { NotOnThisServer.Ignore(NotOnThisServer.NoMessageObject); }
+         set { NotOnThisServer.Ignore(NotOnThisServer.NoMessageObject, value); }
       }
 
       public long UID => ServerApi.LongOf(Read(), "uid");
@@ -3315,42 +3070,33 @@ namespace hMailServer
       // routes carry none of them.
       public string Filename
       {
-         get
-         {
-            NotOnThisServer.Ignore(NotOnThisServer.NoMessageObject);
-            return null;
-         }
+         get { throw NotOnThisServer.Skipped(NotOnThisServer.NoMessageObject); }
       }
 
       public MessageHeaders Headers
       {
-         get
-         {
-            NotOnThisServer.Ignore(NotOnThisServer.NoMessageObject);
-            return null;
-         }
+         get { throw NotOnThisServer.Skipped(NotOnThisServer.NoMessageObject); }
       }
 
       public string FromAddress
       {
          get { return ServerApi.StringOf(Read(), "from"); }
-         set { NotOnThisServer.Ignore(NotOnThisServer.NoMessageObject); }
+         set { NotOnThisServer.Ignore(NotOnThisServer.NoMessageObject, value); }
       }
 
       public int FlagSeen
       {
          get
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoMessageObject);
-            return 0;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoMessageObject);
          }
-         set { NotOnThisServer.Ignore(NotOnThisServer.NoMessageObject); }
+         set { NotOnThisServer.Ignore(NotOnThisServer.NoMessageObject, value); }
       }
 
       public string Date
       {
          get { return ServerApi.StringOf(Read(), "date"); }
-         set { NotOnThisServer.Ignore(NotOnThisServer.NoMessageObject); }
+         set { NotOnThisServer.Ignore(NotOnThisServer.NoMessageObject, value); }
       }
 
       public long FolderID
@@ -3362,8 +3108,7 @@ namespace hMailServer
       {
          get
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoMessageObject);
-            return 0;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoMessageObject);
          }
       }
 
@@ -3371,8 +3116,7 @@ namespace hMailServer
       {
          get
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoMessageObject);
-            return 0;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoMessageObject);
          }
       }
 
@@ -3380,10 +3124,9 @@ namespace hMailServer
       {
          get
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoMessageObject);
-            return 0;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoMessageObject);
          }
-         set { NotOnThisServer.Ignore(NotOnThisServer.NoMessageObject); }
+         set { NotOnThisServer.Ignore(NotOnThisServer.NoMessageObject, value); }
       }
 
       public void Delete()
@@ -3393,39 +3136,26 @@ namespace hMailServer
 
       public string Charset
       {
-         get
-         {
-            NotOnThisServer.Ignore(NotOnThisServer.NoMessageObject);
-            return null;
-         }
-         set { NotOnThisServer.Ignore(NotOnThisServer.NoMessageObject); }
+         get { throw NotOnThisServer.Skipped(NotOnThisServer.NoMessageObject); }
+         set { NotOnThisServer.Ignore(NotOnThisServer.NoMessageObject, value); }
       }
 
       public DateTime InternalDate
       {
          get
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoMessageObject);
-            return DateTime.MinValue;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoMessageObject);
          }
       }
 
       public MessageRecipients Recipients
       {
-         get
-         {
-            NotOnThisServer.Ignore(NotOnThisServer.NoMessageObject);
-            return null;
-         }
+         get { throw NotOnThisServer.Skipped(NotOnThisServer.NoMessageObject); }
       }
 
       public Attachments Attachments
       {
-         get
-         {
-            NotOnThisServer.Ignore(NotOnThisServer.NoMessageObject);
-            return null;
-         }
+         get { throw NotOnThisServer.Skipped(NotOnThisServer.NoMessageObject); }
       }
 
       public void set_HeaderValue(string name, string value)
@@ -3435,8 +3165,7 @@ namespace hMailServer
 
       public string get_HeaderValue(string name)
       {
-         NotOnThisServer.Ignore(NotOnThisServer.NoMessageObject);
-         return null;
+         throw NotOnThisServer.Skipped(NotOnThisServer.NoMessageObject);
       }
 
       public void RefreshContent()
@@ -3459,10 +3188,7 @@ namespace hMailServer
    {
       public int Count => 0;
 
-      public MessageHeader Add()
-      {
-         return null;
-      }
+      public MessageHeader Add() { throw NotOnThisServer.Skipped("adds a MessageHeader, which no REST route carries yet"); }
 
       [System.Runtime.CompilerServices.IndexerName("At")]
       public MessageHeader this[int index] => null;
@@ -3500,10 +3226,7 @@ namespace hMailServer
    {
       public int Count => 0;
 
-      public MessageRecipient Add()
-      {
-         return null;
-      }
+      public MessageRecipient Add() { throw NotOnThisServer.Skipped("adds a MessageRecipient, which no REST route carries yet"); }
 
       [System.Runtime.CompilerServices.IndexerName("At")]
       public MessageRecipient this[int index] => null;
@@ -3540,10 +3263,7 @@ namespace hMailServer
          return null;
       }
 
-      public Attachment Add(string filename)
-      {
-         return null;
-      }
+      public Attachment Add(string filename) { throw NotOnThisServer.Skipped("adds a Attachment, which no REST route carries yet"); }
 
       public void Clear()
       {

--- a/hmailserver/test/LinuxRegressionTests/Shims/Infrastructure.cs
+++ b/hmailserver/test/LinuxRegressionTests/Shims/Infrastructure.cs
@@ -68,9 +68,8 @@ namespace RegressionTests.Infrastructure
             return null;
 
          string newest = null;
-         foreach (var file in ServerApi.Array(answer))
+         foreach (var name in ServerApi.Array(answer).Select(file => ServerApi.StringOf(file, "name")))
          {
-            var name = ServerApi.StringOf(file, "name");
             if (name != null && name.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) &&
                 (newest == null || string.CompareOrdinal(name, newest) > 0))
                newest = name;
@@ -575,8 +574,7 @@ namespace RegressionTests.Infrastructure
 
       public static string AssertLiveLogContents()
       {
-         NotOnThisServer.Ignore(NotOnThisServer.NoLiveLog);
-         return null;
+         throw NotOnThisServer.Skipped(NotOnThisServer.NoLiveLog);
       }
 
       public static void AssertSpamAssassinIsRunning()

--- a/hmailserver/test/LinuxRegressionTests/Shims/Infrastructure.cs
+++ b/hmailserver/test/LinuxRegressionTests/Shims/Infrastructure.cs
@@ -67,15 +67,11 @@ namespace RegressionTests.Infrastructure
          if (!answer.Ok)
             return null;
 
-         string newest = null;
-         foreach (var name in ServerApi.Array(answer).Select(file => ServerApi.StringOf(file, "name")))
-         {
-            if (name != null && name.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) &&
-                (newest == null || string.CompareOrdinal(name, newest) > 0))
-               newest = name;
-         }
-
-         return newest;
+         return ServerApi.Array(answer)
+            .Select(file => ServerApi.StringOf(file, "name"))
+            .Where(name => name != null && name.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            .OrderByDescending(name => name, StringComparer.Ordinal)
+            .FirstOrDefault();
       }
 
       private static string[] Tail(string name)

--- a/hmailserver/test/LinuxRegressionTests/Shims/NotOnThisServer.cs
+++ b/hmailserver/test/LinuxRegressionTests/Shims/NotOnThisServer.cs
@@ -25,6 +25,38 @@ namespace RegressionTests.Shared
          Assert.Ignore("Not runnable against this server: " + reason);
       }
 
+      /// <summary>
+      ///    A setter that has no route to write through: the value the fixture
+      ///    tried to set is part of the reason, because a skip list that says what
+      ///    the test wanted is a better list of API gaps than one that only says
+      ///    where it stopped.
+      /// </summary>
+      public static void Ignore(string reason, object attempted)
+      {
+         Assert.Ignore("Not runnable against this server: " + reason + " (the test tried to set " + Describe(attempted) + ")");
+      }
+
+      /// <summary>
+      ///    For a getter that can only skip: <c>get { throw NotOnThisServer.Skipped(reason); }</c>.
+      ///    Throwing the exception is what Assert.Ignore does; writing it as a throw
+      ///    lets the compiler and the analysers see that the getter never returns,
+      ///    where an Ignore() call followed by <c>return null</c> reads as a
+      ///    property that answers null.
+      /// </summary>
+      public static IgnoreException Skipped(string reason)
+      {
+         return new IgnoreException("Not runnable against this server: " + reason);
+      }
+
+      private static string Describe(object value)
+      {
+         if (value == null)
+            return "null";
+         if (value is string s)
+            return "\"" + s + "\"";
+         return value.ToString();
+      }
+
       public const string NoSettingsWrite =
          "needs a server setting written, and this server's REST API has no PUT /api/v1/settings (it arrived with wave 162)";
 

--- a/hmailserver/test/LinuxRegressionTests/Shims/SslSetup.cs
+++ b/hmailserver/test/LinuxRegressionTests/Shims/SslSetup.cs
@@ -51,10 +51,10 @@ namespace RegressionTests.SSL
          if (!System.IO.File.Exists(exampleKey))
             Assert.Fail("Private key " + exampleKey + " was not found");
 
-         long certificateId = 0;
-         foreach (var certificate in ServerApi.Array(ServerApi.Get("/api/v1/certificates").Expect(200, "GET /api/v1/certificates")))
-            if (string.Equals(ServerApi.StringOf(certificate, "name"), "Example", StringComparison.OrdinalIgnoreCase))
-               certificateId = ServerApi.LongOf(certificate, "id");
+         long certificateId = ServerApi.Array(ServerApi.Get("/api/v1/certificates").Expect(200, "GET /api/v1/certificates"))
+            .Where(certificate => string.Equals(ServerApi.StringOf(certificate, "name"), "Example", StringComparison.OrdinalIgnoreCase))
+            .Select(certificate => ServerApi.LongOf(certificate, "id"))
+            .LastOrDefault();
 
          if (certificateId == 0)
          {
@@ -69,12 +69,11 @@ namespace RegressionTests.SSL
          foreach (var port in ServerApi.Array(ServerApi.Get("/api/v1/ports").Expect(200, "GET /api/v1/ports")))
          {
             var number = (int) ServerApi.LongOf(port, "port");
-            foreach (var wanted in SslPorts)
-               if (wanted.Port == number)
-               {
-                  var id = ServerApi.LongOf(port, "id");
-                  ServerApi.Delete("/api/v1/ports/" + id).Expect(200, "DELETE /api/v1/ports/" + id);
-               }
+            if (SslPorts.Any(wanted => wanted.Port == number))
+            {
+               var id = ServerApi.LongOf(port, "id");
+               ServerApi.Delete("/api/v1/ports/" + id).Expect(200, "DELETE /api/v1/ports/" + id);
+            }
          }
 
          foreach (var wanted in SslPorts)

--- a/hmailserver/test/LinuxRegressionTests/Shims/SuiteDns.cs
+++ b/hmailserver/test/LinuxRegressionTests/Shims/SuiteDns.cs
@@ -26,50 +26,42 @@ namespace RegressionTests.Shared
       {
          public Zone_ WithMx(string name, int preference, string exchange)
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoSuiteDns);
-            return this;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoSuiteDns);
          }
 
          public Zone_ WithA(string name, string address)
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoSuiteDns);
-            return this;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoSuiteDns);
          }
 
          public Zone_ WithCname(string name, string target)
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoSuiteDns);
-            return this;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoSuiteDns);
          }
 
          public Zone_ WithTxt(string name, string text)
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoSuiteDns);
-            return this;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoSuiteDns);
          }
 
          public Zone_ ClearQueries()
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoSuiteDns);
-            return this;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoSuiteDns);
          }
 
          public Zone_ WithNxDomain(string name)
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoSuiteDns);
-            return this;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoSuiteDns);
          }
 
          public Zone_ WithPtr(string address, string name)
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoSuiteDns);
-            return this;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoSuiteDns);
          }
 
          public Zone_ WithAaaa(string name, string address)
          {
-            NotOnThisServer.Ignore(NotOnThisServer.NoSuiteDns);
-            return this;
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoSuiteDns);
          }
       }
    }

--- a/hmailserver/test/LinuxRegressionTests/Shims/TestFixtureBase.cs
+++ b/hmailserver/test/LinuxRegressionTests/Shims/TestFixtureBase.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using hMailServer;
 using NUnit.Framework;
 using RegressionTests.Infrastructure;
@@ -141,18 +142,9 @@ namespace RegressionTests.Shared
       /// </summary>
       private static string[] WithoutKnownPlatformGaps(string[] errorLines)
       {
-         var kept = new List<string>(errorLines.Length);
-
-         foreach (var line in errorLines)
-         {
-            if (line.Contains("HM6406") &&
-                line.Contains("resolves names through the Windows DNS client"))
-               continue;
-
-            kept.Add(line);
-         }
-
-         return kept.ToArray();
+         return errorLines
+            .Where(line => !(line.Contains("HM6406") && line.Contains("resolves names through the Windows DNS client")))
+            .ToArray();
       }
    }
 }

--- a/hmailserver/test/LinuxRegressionTests/Shims/TestSetup.cs
+++ b/hmailserver/test/LinuxRegressionTests/Shims/TestSetup.cs
@@ -621,11 +621,9 @@ namespace RegressionTests.Shared
                answer.Expect(200, "DELETE " + route + "/" + id);
          }
 
-         foreach (var answer in missing.Select(body => ServerApi.Post(route, body)))
-         {
-            if (answer.Status != 201 && answer.Status != 409)
-               answer.Expect(201, "POST " + route + " (putting back a row the run started with)");
-         }
+         foreach (var answer in missing.Select(body => ServerApi.Post(route, body))
+                     .Where(answer => answer.Status != 201 && answer.Status != 409))
+            answer.Expect(201, "POST " + route + " (putting back a row the run started with)");
       }
 
       // ---- The server's ini, put back the way the rows are ----

--- a/hmailserver/test/LinuxRegressionTests/Shims/TestSetup.cs
+++ b/hmailserver/test/LinuxRegressionTests/Shims/TestSetup.cs
@@ -12,6 +12,7 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
+using System.Linq;
 using hMailServer;
 using NUnit.Framework;
 using RegressionTests.Infrastructure;
@@ -98,20 +99,16 @@ namespace RegressionTests.Shared
 
          if (ServerApi.HasDomainWriteRoutes)
          {
-            foreach (var domain in ServerApi.Array(ServerApi.Get("/api/v1/domains").Expect(200, "GET /api/v1/domains")))
-            {
-               var name = ServerApi.StringOf(domain, "name");
+            foreach (var name in ServerApi.Array(ServerApi.Get("/api/v1/domains").Expect(200, "GET /api/v1/domains"))
+                        .Select(domain => ServerApi.StringOf(domain, "name")))
                ServerApi.Delete("/api/v1/domains/" + name).Expect(200, "DELETE /api/v1/domains/" + name);
-            }
 
             _domainsMade.Clear();
             return AddDomain(TestDomainName);
          }
 
-         var present = false;
-         foreach (var domain in ServerApi.Array(ServerApi.Get("/api/v1/domains").Expect(200, "GET /api/v1/domains")))
-            if (string.Equals(ServerApi.StringOf(domain, "name"), TestDomainName, StringComparison.OrdinalIgnoreCase))
-               present = true;
+         var present = ServerApi.Array(ServerApi.Get("/api/v1/domains").Expect(200, "GET /api/v1/domains"))
+            .Any(domain => string.Equals(ServerApi.StringOf(domain, "name"), TestDomainName, StringComparison.OrdinalIgnoreCase));
 
          if (!present)
             Assert.Fail("The test domain " + TestDomainName + " does not exist on " + TestTarget.Describe() +
@@ -124,19 +121,13 @@ namespace RegressionTests.Shared
 
       private void EmptyTheTestDomain()
       {
-         foreach (var account in ServerApi.Array(ServerApi.Get("/api/v1/domains/" + TestDomainName + "/accounts")
-                     .Expect(200, "listing the accounts of " + TestDomainName)))
-         {
-            var address = ServerApi.StringOf(account, "address");
+         foreach (var address in ServerApi.Array(ServerApi.Get("/api/v1/domains/" + TestDomainName + "/accounts")
+                     .Expect(200, "listing the accounts of " + TestDomainName)).Select(account => ServerApi.StringOf(account, "address")))
             ServerApi.Delete("/api/v1/accounts/" + address).Expect(200, "DELETE /api/v1/accounts/" + address);
-         }
 
-         foreach (var list in ServerApi.Array(ServerApi.Get("/api/v1/domains/" + TestDomainName + "/lists")
-                     .Expect(200, "listing the distribution lists of " + TestDomainName)))
-         {
-            var address = ServerApi.StringOf(list, "address");
+         foreach (var address in ServerApi.Array(ServerApi.Get("/api/v1/domains/" + TestDomainName + "/lists")
+                     .Expect(200, "listing the distribution lists of " + TestDomainName)).Select(list => ServerApi.StringOf(list, "address")))
             ServerApi.Delete("/api/v1/lists/" + address).Expect(200, "DELETE /api/v1/lists/" + address);
-         }
       }
 
       /// <summary>
@@ -167,11 +158,8 @@ namespace RegressionTests.Shared
 
          _listsMade.Clear();
 
-         foreach (var name in _domainsMade.ToArray())
+         foreach (var name in _domainsMade.ToArray().Where(name => !string.Equals(name, TestDomainName, StringComparison.OrdinalIgnoreCase)))
          {
-            if (string.Equals(name, TestDomainName, StringComparison.OrdinalIgnoreCase))
-               continue;
-
             var answer = ServerApi.Delete("/api/v1/domains/" + name);
             if (answer.Status != 200 && answer.Status != 404)
                Console.WriteLine("Could not delete the domain " + name + " after the test: " + answer.Status + " " + answer.Body);
@@ -255,7 +243,7 @@ namespace RegressionTests.Shared
          // /api/v1/accounts/{address} (wave 162); before that it advertised
          // the field and ignored it, which a test must not mistake for a limit.
          if (maxSize != 0 && !ServerApi.HasAccountUpdateRoute)
-            NotOnThisServer.Ignore(NotOnThisServer.NoAccountMaxSize);
+            throw NotOnThisServer.Skipped(NotOnThisServer.NoAccountMaxSize);
 
          return CreateAccount_(domain, address, password, maxSize);
       }
@@ -420,11 +408,8 @@ namespace RegressionTests.Shared
          if (!answer.Json.HasValue || answer.Json.Value.ValueKind != JsonValueKind.Object)
             return values;
 
-         foreach (var property in answer.Json.Value.EnumerateObject())
+         foreach (var property in answer.Json.Value.EnumerateObject().Where(property => System.Array.IndexOf(ReadOnlyKeys, property.Name) < 0))
          {
-            if (System.Array.IndexOf(ReadOnlyKeys, property.Name) >= 0)
-               continue;
-
             values[property.Name] = property.Value.ValueKind == JsonValueKind.String
                ? ServerApi.Quote(property.Value.GetString())
                : property.Value.GetRawText();
@@ -456,19 +441,16 @@ namespace RegressionTests.Shared
          if (_baseline == null)
          {
             ApplySuiteDefaults();
-
-            _baseline = new Dictionary<string, Dictionary<string, string>>();
-            foreach (var group in SettingsGroups)
-               _baseline[group] = ReadGroup(group);
-
+            RememberBaseline();
             return;
          }
 
+         var body = new StringBuilder();
          foreach (var group in SettingsGroups)
          {
             var wanted = _baseline[group];
             var current = ReadGroup(group);
-            var body = new StringBuilder();
+            body.Clear();
 
             foreach (var entry in current)
             {
@@ -488,18 +470,26 @@ namespace RegressionTests.Shared
          }
       }
 
+      // The baseline is one per process, hence static; it is written from here
+      // rather than from the instance method that decides when, so that the
+      // static field has one static writer.
+      private static void RememberBaseline()
+      {
+         _baseline = new Dictionary<string, Dictionary<string, string>>();
+         foreach (var group in SettingsGroups)
+            _baseline[group] = ReadGroup(group);
+      }
+
       private static void ApplySuiteDefaults()
       {
+         var body = new StringBuilder();
          foreach (var group in SettingsGroups)
          {
             var current = ReadGroup(group);
-            var body = new StringBuilder();
+            body.Clear();
 
-            foreach (var wanted in SuiteDefaults)
+            foreach (var wanted in SuiteDefaults.Where(wanted => wanted.Group == group))
             {
-               if (wanted.Group != group)
-                  continue;
-
                string now;
                if (!current.TryGetValue(wanted.Key, out now) || now == wanted.Json)
                   continue;
@@ -549,14 +539,12 @@ namespace RegressionTests.Shared
       {
          var body = new StringBuilder("{");
 
-         foreach (var property in element.EnumerateObject())
+         // The id is the server's, and treat_security_as_local_domain is the same
+         // field as treat_recipient_as_local_domain under its older name; sending
+         // both would be sending it twice.
+         foreach (var property in element.EnumerateObject()
+                     .Where(property => property.Name != "id" && property.Name != "treat_security_as_local_domain"))
          {
-            // The id is the server's, and treat_security_as_local_domain is the same
-            // field as treat_recipient_as_local_domain under its older name; sending
-            // both would be sending it twice.
-            if (property.Name == "id" || property.Name == "treat_security_as_local_domain")
-               continue;
-
             if (body.Length > 1)
                body.Append(',');
 
@@ -633,10 +621,8 @@ namespace RegressionTests.Shared
                answer.Expect(200, "DELETE " + route + "/" + id);
          }
 
-         foreach (var body in missing)
+         foreach (var answer in missing.Select(body => ServerApi.Post(route, body)))
          {
-            var answer = ServerApi.Post(route, body);
-
             if (answer.Status != 201 && answer.Status != 409)
                answer.Expect(201, "POST " + route + " (putting back a row the run started with)");
          }
@@ -688,22 +674,16 @@ namespace RegressionTests.Shared
          if (!ServerApi.HasRoute("/api/v1/rules", "post"))
             return;
 
-         foreach (var rule in ServerApi.Array(ServerApi.Get("/api/v1/rules").Expect(200, "GET /api/v1/rules")))
-         {
-            var id = ServerApi.LongOf(rule, "id");
+         foreach (var id in ServerApi.Array(ServerApi.Get("/api/v1/rules").Expect(200, "GET /api/v1/rules")).Select(rule => ServerApi.LongOf(rule, "id")))
             ServerApi.Delete("/api/v1/rules/" + id).Expect(200, "DELETE /api/v1/rules/" + id);
-         }
       }
 
       public void RemoveAllRoutes()
       {
          if (!ServerApi.HasRouteWriteRoutes)
             return;
-         foreach (var route in ServerApi.Array(ServerApi.Get("/api/v1/routes").Expect(200, "GET /api/v1/routes")))
-         {
-            var id = ServerApi.LongOf(route, "id");
+         foreach (var id in ServerApi.Array(ServerApi.Get("/api/v1/routes").Expect(200, "GET /api/v1/routes")).Select(route => ServerApi.LongOf(route, "id")))
             ServerApi.Delete("/api/v1/routes/" + id).Expect(200, "DELETE /api/v1/routes/" + id);
-         }
       }
 
       // ---- The delivery queue, through /api/v1/queue ----
@@ -768,8 +748,7 @@ namespace RegressionTests.Shared
       /// </summary>
       public static string Escape(string input)
       {
-         NotOnThisServer.Ignore(NotOnThisServer.NoDatabaseObject);
-         return input;
+         throw NotOnThisServer.Skipped(NotOnThisServer.NoDatabaseObject);
       }
 
       public Domain AddDomain(string name, bool active)
@@ -855,17 +834,12 @@ namespace RegressionTests.Shared
 
          var allAddresses = new StringBuilder();
 
-         foreach (var networkInterface in NetworkInterface.GetAllNetworkInterfaces())
+         foreach (var networkInterface in NetworkInterface.GetAllNetworkInterfaces()
+                     .Where(candidate => candidate.OperationalStatus == OperationalStatus.Up &&
+                                         candidate.NetworkInterfaceType != NetworkInterfaceType.Loopback))
          {
-            if (networkInterface.OperationalStatus != OperationalStatus.Up)
-               continue;
-
-            if (networkInterface.NetworkInterfaceType == NetworkInterfaceType.Loopback)
-               continue;
-
-            foreach (var unicastAddress in networkInterface.GetIPProperties().UnicastAddresses)
+            foreach (var address in networkInterface.GetIPProperties().UnicastAddresses.Select(unicast => unicast.Address))
             {
-               var address = unicastAddress.Address;
                allAddresses.AppendLine($"Family: {address.AddressFamily}, Address: {address}");
 
                if (address.AddressFamily != AddressFamily.InterNetwork)
@@ -884,9 +858,8 @@ namespace RegressionTests.Shared
          // TestTarget exists to detect, and a server bound to loopback only - and
          // failing here would fail every test in the run rather than the handful
          // that need to reach the server from outside the "My computer" range.
-         NotOnThisServer.Ignore(NotOnThisServer.NoAddressOutsideMyComputer +
+         throw NotOnThisServer.Skipped(NotOnThisServer.NoAddressOutsideMyComputer +
                                 " (addresses seen: " + allAddresses.ToString().Replace("\n", " ").Trim() + ")");
-         return null;
       }
 
       /// <summary>

--- a/hmailserver/test/RegressionTests/API/RestApiDomains.cs
+++ b/hmailserver/test/RegressionTests/API/RestApiDomains.cs
@@ -196,7 +196,7 @@ namespace RegressionTests.API
             "The domain's accounts must be gone with it.");
 
          string dataDirectory = _settings.Directories.DataDirectory;
-         Assert.IsFalse(Directory.Exists(Path.Combine(dataDirectory, name)),
+         Assert.IsFalse(Directory.Exists(Paths.Combine(dataDirectory, name)),
             "The domain's data directory must be removed with it, as COM's delete removes it.");
 
          // Deleting it again, and switching it, are 404 - it is not there.

--- a/hmailserver/test/RegressionTests/IMAP/AttachmentTextSearch.cs
+++ b/hmailserver/test/RegressionTests/IMAP/AttachmentTextSearch.cs
@@ -122,7 +122,11 @@ namespace RegressionTests.IMAP
          indexing.Index();
          for (var i = 0; i < 1000; i++)
          {
-            if (indexing.TotalIndexedCount == indexing.TotalMessageCount)
+            // Read into locals first: the analyser cannot resolve the interop's
+            // properties and reported the two reads as one value compared with itself.
+            long indexed = indexing.TotalIndexedCount;
+            long total = indexing.TotalMessageCount;
+            if (indexed == total)
             {
                indexing.Index();
                return;

--- a/hmailserver/test/RegressionTests/IMAP/FullTextSearch.cs
+++ b/hmailserver/test/RegressionTests/IMAP/FullTextSearch.cs
@@ -79,7 +79,11 @@ namespace RegressionTests.IMAP
 
          for (var i = 0; i < 1000; i++)
          {
-            if (indexing.TotalIndexedCount == indexing.TotalMessageCount)
+            // Read into locals first: the analyser cannot resolve the interop's
+            // properties and reported the two reads as one value compared with itself.
+            long indexed = indexing.TotalIndexedCount;
+            long total = indexing.TotalMessageCount;
+            if (indexed == total)
             {
                // The same wake that finished the metadata also runs the
                // full-text batch; one more prod covers a message that landed

--- a/hmailserver/test/RegressionTests/Infrastructure/BackupRestoreSafety.cs
+++ b/hmailserver/test/RegressionTests/Infrastructure/BackupRestoreSafety.cs
@@ -451,11 +451,16 @@ namespace RegressionTests.Infrastructure
          // Deliberately no assertion inside the delegate. Assert.Catch treats an
          // AssertionException like any other exception, so an assertion in here would
          // let the test pass on the strength of its own failure.
-         Exception thrown = Assert.Catch(() =>
+         Exception thrown = null;
+         try
          {
             var backup = _application.BackupManager.LoadBackup(truncated);
             Console.WriteLine("LoadBackup returned an object for a truncated archive: " + backup);
-         });
+         }
+         catch (Exception e) when (!ExceptionPolicy.IsFatal(e))
+         {
+            thrown = e;
+         }
 
          Assert.IsNotNull(thrown,
             "Opening a truncated archive should have failed. Backup log: " + ReadBackupLog());
@@ -478,11 +483,16 @@ namespace RegressionTests.Infrastructure
 
          CustomAsserts.AssertDeleteFile(_application.Settings.Backup.LogFile);
 
-         Exception thrown = Assert.Catch(() =>
+         Exception thrown = null;
+         try
          {
             var backup = _application.BackupManager.LoadBackup(archive);
             Console.WriteLine("LoadBackup returned an object for a newer archive: " + backup);
-         });
+         }
+         catch (Exception e) when (!ExceptionPolicy.IsFatal(e))
+         {
+            thrown = e;
+         }
 
          Assert.IsNotNull(thrown,
             "An archive from hMailServer 99.0.0 should not have opened. Backup log: " + ReadBackupLog());

--- a/hmailserver/test/RegressionTests/Infrastructure/InstallationPaths.cs
+++ b/hmailserver/test/RegressionTests/Infrastructure/InstallationPaths.cs
@@ -110,7 +110,7 @@ namespace RegressionTests.Infrastructure
       {
          string originalEventFolder = IniFileSetting.Read("Directories", "EventFolder");
          string programDirectory = _settings.Directories.ProgramDirectory;
-         string expected = Path.Combine(programDirectory, "EventScriptsProbe");
+         string expected = Paths.Combine(programDirectory, "EventScriptsProbe");
 
          try
          {

--- a/hmailserver/test/RegressionTests/Infrastructure/Persistence/Maintenance.cs
+++ b/hmailserver/test/RegressionTests/Infrastructure/Persistence/Maintenance.cs
@@ -84,8 +84,7 @@ namespace RegressionTests.Infrastructure.Persistence
             CustomAsserts.AssertRecipientsInDeliveryQueue(1, false);
 
             // The whole point: this must not throw.
-            Assert.DoesNotThrow(() =>
-               _application.Utilities.PerformMaintenance(eMaintenanceOperation.eUpdateIMAPFolderUID));
+            Assert.That(() => _application.Utilities.PerformMaintenance(eMaintenanceOperation.eUpdateIMAPFolderUID), Throws.Nothing);
 
             // And the folder that did have a message must have been brought up to
             // date rather than skipped - the old code could abort before reaching it.

--- a/hmailserver/test/RegressionTests/Security/PasswordHashCost.cs
+++ b/hmailserver/test/RegressionTests/Security/PasswordHashCost.cs
@@ -90,10 +90,13 @@ namespace RegressionTests.Security
       [TearDown]
       public void RestoreDefaults()
       {
-         WriteSetting("PasswordHashIterations", "0");
-         WriteSetting("PasswordHashMemoryKB", "0");
-         WriteSetting("PasswordHashTimeCost", "0");
-         WriteSetting("PreferredHashAlgorithm", CryptPbkdf2.ToString());
+         // Removing the keys, not writing the defaults: a key written as its default
+         // is still a key the pre-flight reports as left behind, and it failed the
+         // next pre-flight after every completed run until 11 September 2026.
+         WriteSetting("PasswordHashIterations", null);
+         WriteSetting("PasswordHashMemoryKB", null);
+         WriteSetting("PasswordHashTimeCost", null);
+         WriteSetting("PreferredHashAlgorithm", null);
          Apply();
       }
 

--- a/hmailserver/test/RegressionTests/Security/PasswordPepper.cs
+++ b/hmailserver/test/RegressionTests/Security/PasswordPepper.cs
@@ -97,9 +97,10 @@ namespace RegressionTests.Security
          }
          finally
          {
-            // Restore defaults so later tests are unaffected.
-            WriteSetting("PasswordPepper", "");
-            WriteSetting("PreferredHashAlgorithm", CryptPbkdf2.ToString());
+            // Restore defaults so later tests are unaffected - by removing the keys,
+            // which is what leaves nothing for the pre-flight to report.
+            WriteSetting("PasswordPepper", null);
+            WriteSetting("PreferredHashAlgorithm", null);
             _application.Reinitialize();
             _settings.ClearLogonFailureList();
          }

--- a/hmailserver/test/RegressionTests/Security/PasswordScrypt.cs
+++ b/hmailserver/test/RegressionTests/Security/PasswordScrypt.cs
@@ -41,8 +41,10 @@ namespace RegressionTests.Security
       [TearDown]
       public void RestoreDefaults()
       {
-         WriteSetting("PreferredHashAlgorithm", CryptPbkdf2.ToString());
-         WriteSetting("MinimumAcceptedHashAlgorithm", "0");
+         // Removed rather than written back: a key at its default is still a key
+         // the pre-flight reports as left behind.
+         WriteSetting("PreferredHashAlgorithm", null);
+         WriteSetting("MinimumAcceptedHashAlgorithm", null);
          Apply();
       }
 

--- a/hmailserver/test/RegressionTests/Shared/TestPorts.cs
+++ b/hmailserver/test/RegressionTests/Shared/TestPorts.cs
@@ -3,6 +3,7 @@
 
 using System.Net;
 using System.Net.Sockets;
+using System.Linq;
 
 namespace RegressionTests.Shared
 {
@@ -82,11 +83,8 @@ namespace RegressionTests.Shared
             if (IPAddress.TryParse(Host, out parsed))
                return parsed;
 
-            foreach (var address in Dns.GetHostAddresses(Host))
-               if (address.AddressFamily == AddressFamily.InterNetwork)
-                  return address;
-
-            throw new SocketException((int) SocketError.HostNotFound);
+            return Dns.GetHostAddresses(Host).FirstOrDefault(address => address.AddressFamily == AddressFamily.InterNetwork)
+               ?? throw new SocketException((int) SocketError.HostNotFound);
          }
       }
    }

--- a/hmailserver/test/RegressionTests/Stress/StabilitySanityTests.cs
+++ b/hmailserver/test/RegressionTests/Stress/StabilitySanityTests.cs
@@ -90,8 +90,9 @@ namespace RegressionTests.Stress
             "silently truncating it loses data, and reporting nothing leaves a REST caller with a 500 for " +
             "their own mistake.");
 
-         Assert.That(refusal.Message, Does.Contain("60"),
-            "The refusal should name the limit it enforced, so a caller can fix the value. Got: " + refusal.Message);
+         string refusalMessage = refusal?.Message ?? "";
+         Assert.That(refusalMessage, Does.Contain("60"),
+            "The refusal should name the limit it enforced, so a caller can fix the value. Got: " + refusalMessage);
 
          // Nothing should have been written to the ERROR log: this is a refused
          // request, not a server fault. AssertDeleteFile is kept because a failure


### PR DESCRIPTION
GitHub's Code Quality scan had 229 open findings, 227 of them in test code that landed with the Linux port and the REST write surface. The local CodeQL loop (the same CLI and suites as the managed scan, C#, JavaScript and Python) now reports **zero** on this tree, after three rounds:

- **The two shapes that made 195 of them.** A shim getter that can only skip was `Ignore(); return null;` - the return is unreachable, but the analyser read a property that answers null and flagged every fixture using the result (111 errors). A shim setter with no route to write through ignored the value it was handed (84 warnings). Both are now written as they are meant: the getter throws the skip (`NotOnThisServer.Skipped`), the setter puts the attempted value into the skip's reason - which also makes the skip list a better list of API gaps. A collection's `Add()` or indexer that answered null, a null reference waiting in the fixture, skips with the gap named. Eight conditional skips whose real return the broad rewrite had swallowed were restored and are listed in the commit.
- **The rest, as the queries suggest.** Loops that filtered or mapped by hand become `Where`, `Select`, `Any` and `FirstOrDefault`; two `StringBuilder`s leave their loops; the settings baseline is written by a static method; `Path.Combine` gives way to the project's `Paths.Combine`; two obsolete NUnit assertions (`Assert.Catch`, `Assert.DoesNotThrow`) become a try/catch and `Throws.Nothing`; two indexing-count comparisons read into locals first, because the analyser cannot resolve the COM interop's properties and saw one value compared with itself; an unused JavaScript variable goes and a comparison of a boolean with 403 becomes the 404 it always was.
- **Test hygiene, found on the way.** The three password fixtures wrote their defaults back in teardown, which left the keys in the ini and failed the next pre-flight after every clean run. They remove the keys now; the pre-flight after this gate reports no leftovers for the first time.

**Verified.** Full Windows suite on this tree: 2,175 tests, 2,166 passed, 0 failed, 9 skipped, no ERROR log. The Linux test project compiles; the portal script harness passes 88 checks; `dotnet format` is clean.
