### PR TITLE
A container image on GHCR from every v* tag: the run's own .deb on ubuntu:24.04, run as its own user, the database from the environment, smoke-tested on a bridge network beside PostgreSQL

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -839,6 +839,159 @@ jobs:
           fi
           bash build/db-upgrade-gate.sh "$BACKEND"
 
+  # The container image. The x86-64 .deb the build job made, installed on the
+  # distribution release it was built for, run as its own user - see
+  # platform/packaging/docker/Dockerfile. Pushed to GHCR on a v* tag only, as
+  # <version> and as latest for a stable release; a pre-release tag gets its
+  # version only, so that :latest never points at an alpha. This is also what the
+  # OpenSSF Scorecard Packaging check looks for: a publishing workflow.
+  image:
+    name: the container image, from the amd64 package
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Fetch the amd64 packages the build job made
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: linux-packages-x86-64
+          path: hmailserver/source/Server/platform/packaging/docker/packages
+
+      - name: The .deb is there, and its version is the tag's
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          cd hmailserver/source/Server/platform/packaging/docker
+          deb=$(ls packages/hmailserver_*_amd64.deb)
+          echo "package: $deb"
+          version="${REF_NAME#v}"
+          case "$deb" in
+            *"hmailserver_${version}_amd64.deb") echo "matches ${version}" ;;
+            *) echo "::error::the .deb is not ${version}'s: ${deb}"; exit 1 ;;
+          esac
+          # only that one goes into the image; the AppImage and the .rpm are not for it
+          find packages -type f ! -name 'hmailserver_*_amd64.deb' -delete
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
+
+      - name: Log in to GHCR
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Tags and labels from the git tag
+        id: meta
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/hmailserver
+          # v6.3.2 -> 6.3.2 and latest; v6.4.0-alpha1 -> 6.4.0-alpha1 only
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
+          labels: |
+            org.opencontainers.image.title=hMailServer
+            org.opencontainers.image.description=hMailServer, a mail server for SMTP, IMAP and POP3, on Linux
+            org.opencontainers.image.licenses=AGPL-3.0-or-later
+            org.opencontainers.image.vendor=Progressive Robot Ltd
+
+      - name: Build and push
+        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
+        with:
+          context: hmailserver/source/Server/platform/packaging/docker
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: false
+          sbom: false
+
+      - name: The pushed image starts, listens, and is administrable
+        env:
+          IMAGE: ghcr.io/${{ github.repository_owner }}/hmailserver:${{ steps.meta.outputs.version }}
+        run: |
+          set -euo pipefail
+          # The real first start, the way the Dockerfile's own example runs it: a
+          # bridge network with a PostgreSQL container beside the image, the
+          # entrypoint writing [Database], the REST listener and the administrator
+          # password from the environment, creating the database, and the server
+          # coming up on 25 and on 8045 over TLS. Not host networking: on a host
+          # with a mail server of its own, the image's HEALTHCHECK against
+          # 127.0.0.1:25 would be answered by that server and pass for the wrong
+          # reason (seen on the lab VM, whose Postfix answered for it). On the
+          # bridge, 127.0.0.1 inside the container is the container's own
+          # loopback, and nothing but hmailserver can answer there.
+          docker network create hm-smoke-net
+          docker run -d --name hm-smoke-pg --network hm-smoke-net \
+            -e POSTGRES_USER=hmailserver -e POSTGRES_PASSWORD=hmtest -e POSTGRES_DB=postgres \
+            postgres:16@sha256:f1c3376c26f2609ab9f29f71f824103fe2fcd8ee0346485cb6122a4f93df6f94
+          for i in $(seq 1 40); do
+            docker exec hm-smoke-pg pg_isready -U hmailserver >/dev/null 2>&1 && break
+            sleep 2
+          done
+          docker exec hm-smoke-pg pg_isready -U hmailserver
+          # The server requires TLS on a REST listener bound off loopback; a
+          # throwaway certificate, readable by the container's user.
+          mkdir -p rest
+          openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:P-256 -nodes \
+            -keyout rest/rest.key -out rest/rest.pem -subj /CN=hm-smoke -days 2 >/dev/null 2>&1
+          chmod 0644 rest/rest.key rest/rest.pem
+          docker run -d --name hm-smoke --network hm-smoke-net \
+            -p 127.0.0.1:2525:25 -p 127.0.0.1:8045:8045 \
+            -v "$PWD/rest:/certs:ro" \
+            -e HM_DB_TYPE=PostgreSQL -e HM_DB_HOST=hm-smoke-pg -e HM_DB_NAME=hmsmoke \
+            -e HM_DB_USER=hmailserver -e HM_DB_PASSWORD=hmtest \
+            -e HM_ADMIN_PASSWORD=smoke-secret -e HM_REST_PORT=8045 -e HM_REST_BIND_ADDRESS=0.0.0.0 \
+            -e HM_REST_CERTIFICATE_FILE=/certs/rest.pem -e HM_REST_PRIVATE_KEY_FILE=/certs/rest.key \
+            "$IMAGE"
+          state=starting
+          for i in $(seq 1 45); do
+            state=$(docker inspect --format '{{.State.Health.Status}}' hm-smoke 2>/dev/null || echo starting)
+            [ "$state" = healthy ] && break
+            [ "$(docker inspect --format '{{.State.Running}}' hm-smoke 2>/dev/null)" = false ] && break
+            sleep 2
+          done
+          docker logs hm-smoke | tail -20
+          [ "$state" = healthy ] || { echo "::error::the image did not become healthy (state: ${state})"; exit 1; }
+          # Healthy means the container's own port 25 accepted a connection. So
+          # that this cannot pass for the wrong reason: the listeners are inside
+          # the container (LISTEN rows for 0x19 and 0x1F6D in its /proc/net/tcp),
+          # what answers through the published port is hMailServer's banner, and
+          # the API answers as configured - 200 to the administrator, 401 to a
+          # wrong password, 201 to a domain created through it.
+          listening=$(docker exec hm-smoke sh -c 'grep -cE ":(0019|1F6D) 00000000:0000 0A" /proc/net/tcp' || true)
+          [ "${listening}" -ge 2 ] || { echo "::error::expected listeners on 25 and 8045 inside the container, found ${listening}."; exit 1; }
+          banner=$(timeout 5 bash -c 'exec 3<>/dev/tcp/127.0.0.1/2525; head -c 120 <&3' | head -1 | tr -d '\r')
+          echo "banner: ${banner}"
+          case "$banner" in
+            220\ *\ ESMTP*) echo "the banner is hMailServer's" ;;
+            *) echo "::error::the banner through the published port is not hMailServer's: '${banner}'"; exit 1 ;;
+          esac
+          code=$(curl -sk -o status.json -w '%{http_code}' -u Administrator:smoke-secret https://127.0.0.1:8045/api/v1/status)
+          echo "status: HTTP ${code} $(head -c 200 status.json)"
+          [ "$code" = 200 ] || { echo "::error::GET /api/v1/status as Administrator answered ${code}, not 200."; exit 1; }
+          code=$(curl -sk -o /dev/null -w '%{http_code}' -u Administrator:wrong https://127.0.0.1:8045/api/v1/status)
+          [ "$code" = 401 ] || { echo "::error::a wrong password answered ${code}, not 401."; exit 1; }
+          code=$(curl -sk -o domain.json -w '%{http_code}' -u Administrator:smoke-secret \
+            -H 'Content-Type: application/json' -d '{"name":"smoke.example"}' https://127.0.0.1:8045/api/v1/domains)
+          echo "domain: HTTP ${code} $(head -c 200 domain.json)"
+          [ "$code" = 201 ] || { echo "::error::POST /api/v1/domains answered ${code}, not 201."; exit 1; }
+          # The password is in the file as a hash, not as itself.
+          if docker exec hm-smoke grep -q 'smoke-secret' /etc/hmailserver/hMailServer.ini; then
+            echo "::error::the administrator password is in hMailServer.ini in clear."; exit 1
+          fi
+          docker rm -f hm-smoke hm-smoke-pg >/dev/null
+          docker network rm hm-smoke-net >/dev/null
+
   publish:
     name: attach the packages to the release
     needs: [ build, package-install, stamps ]

--- a/hmailserver/source/Server/platform/packaging/docker/Dockerfile
+++ b/hmailserver/source/Server/platform/packaging/docker/Dockerfile
@@ -1,0 +1,67 @@
+# Copyright (c) 2026 Christopher Holloway / Progressive Robot Ltd
+# https://www.progressiverobot.com
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# The hMailServer container image: the Linux .deb the tag's own workflow built,
+# installed on the distribution release it was built for, run as its own user.
+#
+#   docker run -d --name hmailserver \
+#      -e HM_DB_TYPE=PostgreSQL -e HM_DB_HOST=db -e HM_DB_NAME=hmailserver \
+#      -e HM_DB_USER=hmailserver -e HM_DB_PASSWORD=... \
+#      -e HM_ADMIN_PASSWORD=... \
+#      -e HM_REST_PORT=8045 -e HM_REST_BIND_ADDRESS=0.0.0.0 \
+#      -e HM_REST_CERTIFICATE_FILE=/certs/rest.pem -e HM_REST_PRIVATE_KEY_FILE=/certs/rest.key \
+#      -v /srv/hmailserver/certs:/certs:ro \
+#      -p 25:25 -p 587:587 -p 993:993 -p 8045:8045 \
+#      -v hm-data:/var/lib/hmailserver -v hm-logs:/var/log/hmailserver -v hm-etc:/etc/hmailserver \
+#      ghcr.io/progressiverobot/hmailserver:6.3.2
+#
+# The database is not in the image and never will be: point HM_DB_* at a
+# PostgreSQL or MariaDB server. On first start the entrypoint writes the
+# [Database] section from those variables, the REST listener from HM_REST_*, the
+# administrator password as a hash through the server's own --set-admin-password,
+# creates the database if it does not exist, upgrades it if it is behind, and
+# then runs the server in the foreground. On Linux the REST API is the
+# administration (there is no Control Panel and no COM), and the server requires
+# TLS on it unless it is bound to loopback - which inside a container is the
+# container's own loopback - so a reachable API means a certificate and key
+# mounted in, or host networking. See docker-entrypoint.sh for every variable.
+# Ubuntu 24.04 is the base because the package's dependencies are the sonames of
+# the runner that built it (see the roadmap's Linux section); a different base
+# would refuse the .deb.
+
+FROM ubuntu:24.04@sha256:224a1869083a311ef3f13648a154ba79832fbef6364d31493642ca03082da254
+
+ARG HM_DEB=packages/hmailserver_*_amd64.deb
+
+# The package's post-install script creates the hmailserver user and the data,
+# log and configuration directories, and is written to run where there is no
+# systemd. libcap2-bin is for setcap below; ca-certificates for the TLS the
+# server does as a client (MTA-STS, ACME, outbound SMTP).
+COPY ${HM_DEB} /tmp/hmailserver.deb
+RUN apt-get update \
+ && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      /tmp/hmailserver.deb ca-certificates libcap2-bin \
+ && rm -rf /var/lib/apt/lists/* /tmp/hmailserver.deb \
+ # Ports 25, 110, 143, 465, 587, 993 and 995 are below 1024 and the process does
+ # not run as root: the one capability it needs, on the binary rather than on
+ # the container.
+ && setcap cap_net_bind_service=+ep /usr/bin/hmailserver
+
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod 0755 /usr/local/bin/docker-entrypoint.sh \
+ && chown -R hmailserver:hmailserver /etc/hmailserver
+
+VOLUME ["/var/lib/hmailserver", "/var/log/hmailserver", "/etc/hmailserver"]
+EXPOSE 25 110 143 465 587 993 995 4190 8045
+
+USER hmailserver
+WORKDIR /var/lib/hmailserver
+
+# Alive means listening: SMTP accepts a connection. No curl in the image; bash
+# opens the socket itself.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
+  CMD bash -c 'exec 3<>/dev/tcp/127.0.0.1/25 && exec 3>&-' || exit 1
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+CMD ["hmailserver", "--foreground"]

--- a/hmailserver/source/Server/platform/packaging/docker/docker-entrypoint.sh
+++ b/hmailserver/source/Server/platform/packaging/docker/docker-entrypoint.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Christopher Holloway / Progressive Robot Ltd
+# https://www.progressiverobot.com
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# The container's entrypoint. The environment becomes the configuration, each
+# part only when it is set, each idempotent, and then the server runs:
+#
+#   HM_DB_TYPE (PostgreSQL|MySQL), HM_DB_HOST, HM_DB_PORT, HM_DB_NAME,
+#   HM_DB_USER, HM_DB_PASSWORD   -> the [Database] section of hMailServer.ini,
+#                                   rewritten from these on every start so the
+#                                   environment is the truth, not a stale file
+#   HM_ADMIN_PASSWORD            -> [Security] AdministratorPassword, through the
+#                                   server's own --set-admin-password, so the file
+#                                   holds a PBKDF2 hash and never the password.
+#                                   Without it the REST API refuses to start, and
+#                                   on Linux the REST API is the administration.
+#   HM_REST_PORT, HM_REST_BIND_ADDRESS, HM_REST_CERTIFICATE_FILE,
+#   HM_REST_PRIVATE_KEY_FILE     -> [Settings] RestApiPort, RestApiBindAddress,
+#                                   RestApiCertificateFile, RestApiPrivateKeyFile.
+#                                   The packaged file has the port at 0 (off) and
+#                                   the bind at 127.0.0.1, which inside a container
+#                                   is the container's own loopback; to reach the
+#                                   API from outside, bind 0.0.0.0 with a
+#                                   certificate and key (the server requires TLS
+#                                   off loopback), or run with host networking.
+#   HM_DB_PASSWORD_FILE, HM_ADMIN_PASSWORD_FILE
+#                                -> the same two secrets read from a file (a Docker
+#                                   or Compose secret) instead of the environment
+#   HM_CREATE_DATABASE (default 1) -> hmailserver --create-database, which is a
+#                                   no-op when the database already exists
+#   HM_UPGRADE_DATABASE (default 1) -> hmailserver --upgrade-database, which is a
+#                                   no-op when the schema is current
+#
+# then exec the command - hmailserver --foreground unless told otherwise - so
+# signals reach the server and it is PID 1's child, not a grandchild.
+set -eu
+
+INI="${HM_INI:-/etc/hmailserver/hMailServer.ini}"
+
+# VAR_FILE, when set, is where VAR's value is read from; setting both is a
+# mistake, not a precedence question.
+file_env() {
+   local var="$1" file_var="${1}_FILE"
+   if [ -n "${!file_var:-}" ]; then
+      if [ -n "${!var:-}" ]; then
+         echo "$var and $file_var are both set; set one of them" >&2
+         exit 64
+      fi
+      if [ ! -r "${!file_var}" ]; then
+         echo "$file_var names ${!file_var}, which cannot be read" >&2
+         exit 66
+      fi
+      export "$var"="$(cat "${!file_var}")"
+   fi
+}
+
+needs_writable_ini() {
+   if [ ! -w "$INI" ]; then
+      echo "$INI is not writable by $(id -un); $1 cannot be written from the environment" >&2
+      exit 1
+   fi
+}
+
+# set_key SECTION KEY VALUE: the key's line in that section is replaced (a
+# commented-out ";KEY=" counts, so the packaged file's ;RestApiCertificateFile=
+# becomes a live setting); a missing key is added at the end of the section; a
+# missing section is added at the end of the file. Written back through the
+# existing file, so its owner and mode stay.
+set_key() {
+   local tmp
+   tmp="$(mktemp)"
+   awk -v s="[$1]" -v k="$2" -v v="$3" '
+      BEGIN { insec = 0; done = 0 }
+      /^\[/ {
+         if (insec && !done) { print k "=" v; done = 1 }
+         insec = ($0 == s)
+      }
+      insec && !done && $0 ~ ("^;?" k "=") { print k "=" v; done = 1; next }
+      { print }
+      END {
+         if (!done) {
+            if (!insec) print s
+            print k "=" v
+         }
+      }' "$INI" > "$tmp"
+   cat "$tmp" > "$INI"
+   rm -f "$tmp"
+}
+
+write_database_section() {
+   # Everything except the [Database] section is kept as it is; that section is
+   # replaced. awk drops the old section (from its header to the next header)
+   # and the new one is appended.
+   local tmp
+   tmp="$(mktemp)"
+   awk 'BEGIN{skip=0} /^\[/{skip=($0=="[Database]")} !skip{print}' "$INI" > "$tmp"
+   {
+      cat "$tmp"
+      printf '\n[Database]\nType=%s\nServer=%s\nPort=%s\nDatabase=%s\nUsername=%s\nPassword=%s\nPasswordencryption=0\n' \
+         "$HM_DB_TYPE" "${HM_DB_HOST:-db}" "${HM_DB_PORT:-$default_port}" "${HM_DB_NAME:-hmailserver}" \
+         "${HM_DB_USER:-hmailserver}" "${HM_DB_PASSWORD:-}"
+   } > "$INI"
+   rm -f "$tmp"
+}
+
+file_env HM_DB_PASSWORD
+file_env HM_ADMIN_PASSWORD
+
+if [ -n "${HM_DB_TYPE:-}" ]; then
+   case "$HM_DB_TYPE" in
+      PostgreSQL|postgresql|postgres|pgsql) HM_DB_TYPE=PostgreSQL; default_port=5432 ;;
+      MySQL|mysql|MariaDB|mariadb)          HM_DB_TYPE=MySQL;      default_port=3306 ;;
+      MSSQL|mssql)                          HM_DB_TYPE=MSSQL;      default_port=1433 ;;
+      *) echo "HM_DB_TYPE must be PostgreSQL, MySQL or MSSQL, not '$HM_DB_TYPE'" >&2; exit 64 ;;
+   esac
+   needs_writable_ini "the [Database] section"
+   write_database_section
+   echo "[Database] written from the environment: $HM_DB_TYPE on ${HM_DB_HOST:-db}:${HM_DB_PORT:-$default_port}, database ${HM_DB_NAME:-hmailserver}"
+fi
+
+rest_written=""
+if [ -n "${HM_REST_PORT:-}" ]; then
+   needs_writable_ini "RestApiPort"
+   set_key Settings RestApiPort "$HM_REST_PORT"
+   rest_written="${rest_written} port ${HM_REST_PORT}"
+fi
+if [ -n "${HM_REST_BIND_ADDRESS:-}" ]; then
+   needs_writable_ini "RestApiBindAddress"
+   set_key Settings RestApiBindAddress "$HM_REST_BIND_ADDRESS"
+   rest_written="${rest_written} bind ${HM_REST_BIND_ADDRESS}"
+fi
+if [ -n "${HM_REST_CERTIFICATE_FILE:-}" ]; then
+   needs_writable_ini "RestApiCertificateFile"
+   set_key Settings RestApiCertificateFile "$HM_REST_CERTIFICATE_FILE"
+   rest_written="${rest_written} certificate ${HM_REST_CERTIFICATE_FILE}"
+fi
+if [ -n "${HM_REST_PRIVATE_KEY_FILE:-}" ]; then
+   needs_writable_ini "RestApiPrivateKeyFile"
+   set_key Settings RestApiPrivateKeyFile "$HM_REST_PRIVATE_KEY_FILE"
+   rest_written="${rest_written} key ${HM_REST_PRIVATE_KEY_FILE}"
+fi
+[ -z "$rest_written" ] || echo "[Settings] REST API written from the environment:${rest_written}"
+
+if [ -n "${HM_ADMIN_PASSWORD:-}" ]; then
+   needs_writable_ini "AdministratorPassword"
+   # The server's own verb: one line on standard input, a PBKDF2 hash in the
+   # file, the file's owner and mode kept. The password itself is in no file.
+   printf '%s\n' "$HM_ADMIN_PASSWORD" | hmailserver --config "$INI" --set-admin-password
+   echo "[Security] AdministratorPassword written as a hash from HM_ADMIN_PASSWORD"
+fi
+
+if [ "${HM_CREATE_DATABASE:-1}" != 0 ]; then
+   # Exit status 0 also when the database already exists; anything else is a
+   # reason not to start.
+   hmailserver --config "$INI" --create-database
+fi
+
+if [ "${HM_UPGRADE_DATABASE:-1}" != 0 ]; then
+   hmailserver --config "$INI" --upgrade-database
+fi
+
+if [ "${1:-}" = "hmailserver" ] && ! printf '%s\n' "$@" | grep -q -- '--config'; then
+   shift
+   set -- hmailserver --config "$INI" "$@"
+fi
+exec "$@"


### PR DESCRIPTION
## Summary

A container image, published to GHCR by the Linux workflow on every `v*` tag: `ghcr.io/progressiverobot/hmailserver:<version>`, and `:latest` for a stable release only, so that `latest` never points at an alpha.

- **`platform/packaging/docker/Dockerfile`.** The x86-64 `.deb` the same workflow run built, installed on `ubuntu:24.04` (pinned by digest; the base has to be the distribution release the package was built on, because the package's dependencies are the builder's Boost sonames, which the roadmap records). `cap_net_bind_service` on the binary and nothing else, so the process runs as the `hmailserver` user the package creates and still binds 25, 143, 465, 587, 993 and 995. Volumes for data, logs and configuration. A `HEALTHCHECK` that opens a connection to the container's own port 25.
- **`docker-entrypoint.sh`.** The environment becomes the configuration. `HM_DB_TYPE`, `HM_DB_HOST`, `HM_DB_PORT`, `HM_DB_NAME`, `HM_DB_USER` and `HM_DB_PASSWORD` become the `[Database]` section, rewritten on every start so the environment is the truth. `HM_ADMIN_PASSWORD` becomes the administrator password through the server's own `--set-admin-password`, so the file holds a PBKDF2 hash and never the password; without one the REST API refuses to start, and on Linux the REST API is the administration. `HM_REST_PORT`, `HM_REST_BIND_ADDRESS`, `HM_REST_CERTIFICATE_FILE` and `HM_REST_PRIVATE_KEY_FILE` become the REST listener (the packaged file leaves it off and bound to loopback, which inside a container is the container's own loopback; the server requires TLS off loopback, so a reachable API means a certificate and key mounted in, or host networking). `HM_DB_PASSWORD_FILE` and `HM_ADMIN_PASSWORD_FILE` read the two secrets from a file, for Docker and Compose secrets. Then `--create-database` (a no-op when it exists) and `--upgrade-database` (a no-op when it is current), each switchable off; then `exec hmailserver --foreground`, so signals reach the server. The database is not in the image and never will be.
- **The `image` job.** Fetches the amd64 packages the build job made, checks the `.deb` is the tag's version, builds and pushes with Buildx, and then smoke-tests the pushed image the way the Dockerfile's own example runs it: a bridge network with a PostgreSQL container (pinned by digest) beside it, a throwaway certificate for the API, the entrypoint writing the database, the listener and the password from the environment and creating the database; the health check green; LISTEN rows for 25 and 8045 inside the container's own `/proc/net/tcp`; the banner through the published port matching `220 <host> ESMTP`; the API answering 200 to the administrator, 401 to a wrong password and 201 to a domain created through it; and the password in no file in clear. Not host networking: on a host with a mail server of its own, the health check would be answered by that server and pass for the wrong reason, which is exactly what the first proof on the lab VM did (its Postfix answered).

This is also what OpenSSF Scorecard's Packaging check looks for: a workflow that publishes a package.

**What building it found.** The first cut of the image ran a server nobody could administer: the packaged configuration has the REST API off and no administrator password, and on Linux there is no other administration surface. The entrypoint's `HM_ADMIN_PASSWORD` and `HM_REST_*` are the fix, and the smoke now proves the API, not just the SMTP banner.

**Proof.** On the Ubuntu 26.04 lab VM, this Dockerfile and entrypoint were built with the 6.3.1 amd64 `.deb` from the release and run on a bridge network beside `postgres:16` with every command the job's smoke runs: `[Database]`, the REST listener and the password written from the environment (`AdministratorPassword=$h1$210000$...` in the file); the database created at schema 6031 and the upgrade a no-op; the container healthy; both listeners inside it; the banner `220 <container> ESMTP`; `GET /api/v1/status` 200 with the server's status, 401 with a wrong password, `POST /api/v1/domains` 201. The job itself runs only on a tag, so its first execution in CI is the next release's.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring / internal
- [ ] Documentation
- [x] Build / installer

## Checklist

- [x] Builds warning-free (`/WX`) with `build/build.ps1` - no compiled code changes
- [x] Regression suite passes with no failures - no server or test code changes; the image was started and probed on the lab VM as described
- [ ] New behavior covered by regression tests - the job's smoke is the test
- [x] SQL uses parameterised queries only - no SQL
- [x] DB schema changes include scripts for MySQL, MS SQL and PostgreSQL in `source/DBScripts/` - no schema change
- [x] New settings exposed via COM API or `hMailServer.INI` pattern as appropriate - the `HM_*` variables write existing `hMailServer.ini` keys
