### PR TITLE
The Control Panel after a screenshot of every page: selection-gated row actions everywhere, the white password box themed, the unreadable consistency table themed, the rules page's clipped row and narrow box fixed, no tab strip on one-tab pages, and six captions that pointed at hMailServer.ini now name the page

### DIFF
--- a/hmailserver/source/Tools/ControlPanel/Resources/Strings.cs.resx
+++ b/hmailserver/source/Tools/ControlPanel/Resources/Strings.cs.resx
@@ -2917,8 +2917,8 @@ Pošty se to nedotkne - index je z ní odvozen - ale dokud přestavba nedožene,
   <data name="Enter a valid port number." xml:space="preserve">
     <value>Zadejte platné číslo portu.</value>
   </data>
-  <data name="Enter an address and search. The trace records nothing at all unless MessageTraceEnabled is set in hMailServer.ini - it is off by default because it stores who corresponds with whom." xml:space="preserve">
-    <value>Zadejte adresu a hledejte. Trasování nezaznamenává vůbec nic, dokud není v hMailServer.ini nastaveno MessageTraceEnabled - ve výchozím stavu je vypnuté, protože ukládá, kdo si s kým dopisuje.</value>
+  <data name="Enter an address and search. The trace records nothing at all until message tracing is switched on, on the Logging page - it is off by default because it stores who corresponds with whom." xml:space="preserve">
+    <value>Zadejte adresu a vyhledejte. Trasování nezaznamenává vůbec nic, dokud není trasování zpráv zapnuto na stránce Logování – ve výchozím nastavení je vypnuto, protože ukládá, kdo si s kým dopisuje.</value>
   </data>
   <data name="Enter part of a name and press Search, or search with an empty box to list all users." xml:space="preserve">
     <value>Zadejte část jména a stiskněte Hledat, nebo hledejte s prázdným polem pro výpis všech uživatelů.</value>
@@ -3438,6 +3438,9 @@ Pošty se to nedotkne - index je z ní odvozen - ale dokud přestavba nedožene,
   </data>
   <data name="Host/Name:  {0}" xml:space="preserve">
     <value>Hostitel/Název:  {0}</value>
+  </data>
+  <data name="Hosted domain" xml:space="preserve">
+    <value>Hostovaná doména</value>
   </data>
   <data name="Hours between checks (1 to 168)" xml:space="preserve">
     <value>Hodiny mezi kontrolami (1 až 168)</value>
@@ -4554,8 +4557,8 @@ Ověřený instalátor se předá pomocníkovi aktualizace: služba se zastaví,
   <data name="No encryption is available on this port. Inbound mail from other servers is normally unencrypted anyway, but this port also accepts AUTH, and a client using it sends its password in the clear." xml:space="preserve">
     <value>Na tomto portu není k dispozici žádné šifrování. Příchozí pošta z jiných serverů beztak obvykle šifrovaná není, ale tento port přijímá i AUTH a klient, který jej použije, posílá své heslo v otevřeném textu.</value>
   </data>
-  <data name="No events for that address. Either nothing has happened to it, or the trace was switched off at the time - it records only while MessageTraceEnabled is set." xml:space="preserve">
-    <value>Pro tuto adresu nejsou žádné události. Buď se s ní nic nestalo, nebo bylo v té době trasování vypnuté – zaznamenává se jen tehdy, když je nastaveno MessageTraceEnabled.</value>
+  <data name="No events for that address. Either nothing has happened to it, or the trace was switched off at the time - it records only while message tracing is on (Logging page)." xml:space="preserve">
+    <value>Pro tuto adresu nejsou žádné události. Buď se s ní nic nestalo, nebo bylo trasování v té době vypnuté – zaznamenává pouze tehdy, když je trasování zpráv zapnuté (stránka Logování).</value>
   </data>
   <data name="No events for that message." xml:space="preserve">
     <value>Pro tuto zprávu nejsou žádné události.</value>
@@ -4710,8 +4713,8 @@ Ověřený instalátor se předá pomocníkovi aktualizace: služba se zastaví,
   <data name="Not checked from here, honestly: verifying the PTR needs the server's PUBLIC IP address, which this panel cannot determine (behind NAT the machine does not know it either), and this page's checker reads TXT records only. Test from outside instead: nslookup &lt;your public IP&gt; shows the PTR; it should name the host above." xml:space="preserve">
     <value>Odsud se to upřímně řečeno nekontroluje: ověření PTR vyžaduje VEŘEJNOU IP adresu serveru, kterou tento panel nedokáže zjistit (za NATem ji nezná ani samotný počítač), a kontrola na této stránce čte pouze TXT záznamy. Otestujte to místo toho zvenčí: nslookup &lt;your public IP&gt; zobrazí PTR; měl by uvádět hostitele výše.</value>
   </data>
-  <data name="Not checked yet (Check for updates, or UpdateCheckEnabled=1 in hMailServer.INI for a daily check)" xml:space="preserve">
-    <value>Zatím nezkontrolováno (Zkontrolovat aktualizace, nebo UpdateCheckEnabled=1 v hMailServer.INI pro denní kontrolu)</value>
+  <data name="Not checked yet (Check for updates, or turn on the daily check under Updates on the API &amp; monitoring page)" xml:space="preserve">
+    <value>Zatím nezkontrolováno (klikněte na Zkontrolovat aktualizace nebo zapněte denní kontrolu v části Aktualizace na stránce API a monitorování)</value>
   </data>
   <data name="Not checked yet. Publish the record, allow time for propagation, then press &quot;Check DNS&quot;." xml:space="preserve">
     <value>Zatím nezkontrolováno. Publikujte záznam, dejte čas na jeho rozšíření a poté stiskněte „Zkontrolovat DNS“.</value>
@@ -4758,11 +4761,14 @@ Ověřený instalátor se předá pomocníkovi aktualizace: služba se zastaví,
   <data name="Nothing here needs a decision: no mailbox is being skipped and none is being disabled." xml:space="preserve">
     <value>Nic zde nevyžaduje rozhodnutí: žádná poštovní schránka se nepřeskakuje a žádná se nezakazuje.</value>
   </data>
+  <data name="Nothing here yet - Add creates the first entry." xml:space="preserve">
+    <value>Zatím tu nic není – tlačítko Přidat vytvoří první položku.</value>
+  </data>
   <data name="Nothing is ever marked as spam: marking needs a mark threshold above 0, and a 0 there means &quot;never&quot; rather than &quot;always&quot;. Messages reaching {0} are still refused." xml:space="preserve">
     <value>Nic se nikdy neoznačí jako spam: označování vyžaduje práh pro označení vyšší než 0 a 0 tam znamená „nikdy“, ne „vždy“. Zprávy dosahující {0} jsou i tak odmítnuty.</value>
   </data>
-  <data name="Nothing is held. Quarantining is off unless QuarantineEnabled is set in hMailServer.ini - until then, spam over the delete threshold is refused during the SMTP conversation rather than stored." xml:space="preserve">
-    <value>Nic se nepozdržuje. Karanténa je vypnutá, dokud se v hMailServer.ini nenastaví QuarantineEnabled – do té doby je spam nad prahem pro smazání odmítnut už během SMTP konverzace, místo aby se ukládal.</value>
+  <data name="Nothing is held. Quarantining is switched off - turn it on under Anti-spam settings - and until it is on, spam over the delete threshold is refused during the SMTP conversation rather than stored." xml:space="preserve">
+    <value>Nic není zadrženo. Karanténa je vypnutá – zapněte ji v Nastavení antispamu – a dokud není zapnutá, spam nad prahem pro smazání je odmítnut během konverzace SMTP místo uložení.</value>
   </data>
   <data name="Nothing matched &quot;{0}&quot;. Try what you are trying to achieve (&quot;stop spam&quot;, &quot;let a device send mail&quot;), a page name, or an hMailServer.INI key." xml:space="preserve">
     <value>Dotazu „{0}“ nic neodpovídalo. Zkuste popsat, čeho chcete dosáhnout („zastavit spam“, „nechat zařízení odesílat poštu“), název stránky, nebo klíč z hMailServer.INI.</value>
@@ -5749,6 +5755,9 @@ Spusťte to, pokud klienti hlásí zprávy pod špatným UID, nebo po obnovení 
   <data name="Remember this many previous passwords (0 = no history)" xml:space="preserve">
     <value>Pamatovat si tento počet předchozích hesel (0 = žádná historie)</value>
   </data>
+  <data name="Remote domain" xml:space="preserve">
+    <value>Vzdálená doména</value>
+  </data>
   <data name="Remove _expired" xml:space="preserve">
     <value>Odstranit _vypršelé</value>
   </data>
@@ -6708,12 +6717,6 @@ Pokračovat?</value>
   <data name="Set TlsRptFromAddress in the [Settings] section of hMailServer.ini to a mailbox reports should be sent from. Leaving it empty is a valid choice - it just means the collected statistics are discarded and no reports are ever sent." xml:space="preserve">
     <value>V sekci [Settings] souboru hMailServer.ini nastavte TlsRptFromAddress na poštovní schránku, ze které se mají hlášení odesílat. Ponechat je prázdné je platná volba – znamená to jen, že se sesbírané statistiky zahazují a žádná hlášení se nikdy neodešlou.</value>
   </data>
-  <data name="Set WebServicesHttpPort and/or WebServicesHttpsPort in hMailServer.ini so the URLs answer, then publish autoconfig.&lt;domain&gt; and autodiscover.&lt;domain&gt; DNS records for each mail domain, pointing at this server. These are address records, and this page checks TXT records only, so they cannot be confirmed from here." xml:space="preserve">
-    <value>Nastavte v hMailServer.ini WebServicesHttpPort a/nebo WebServicesHttpsPort, aby URL odpovídaly, a poté pro každou poštovní doménu publikujte DNS záznamy autoconfig.&lt;domain&gt; a autodiscover.&lt;domain&gt; ukazující na tento server. Jde o adresní záznamy a tato stránka kontroluje pouze TXT záznamy, takže je odsud potvrdit nelze.</value>
-  </data>
-  <data name="Set WebServicesHttpsPort in hMailServer.ini (RFC 8461 requires the policy over HTTPS), give the listener a certificate that covers mta-sts.&lt;domain&gt;, then for each domain publish an A/AAAA (or CNAME) record for mta-sts.&lt;domain&gt; pointing at this server and a TXT record at _mta-sts.&lt;domain&gt; (v=STSv1; id=...). This page checks the TXT record; the address record and the certificate's name coverage cannot be checked from here." xml:space="preserve">
-    <value>Nastavte v hMailServer.ini WebServicesHttpsPort (RFC 8461 vyžaduje politiku přes HTTPS), přiřaďte listeneru certifikát, který pokrývá mta-sts.&lt;domain&gt;, a poté pro každou doménu publikujte záznam A/AAAA (nebo CNAME) pro mta-sts.&lt;domain&gt; ukazující na tento server a TXT záznam na _mta-sts.&lt;domain&gt; (v=STSv1; id=...). Tato stránka kontroluje TXT záznam; adresní záznam ani to, zda certifikát daný název pokrývá, odsud zkontrolovat nelze.</value>
-  </data>
   <data name="Set a new server administration password." xml:space="preserve">
     <value>Nastavte nové heslo pro správu serveru.</value>
   </data>
@@ -6725,6 +6728,12 @@ Pokračovat?</value>
   </data>
   <data name="Set header value" xml:space="preserve">
     <value>Nastavit hodnotu hlavičky</value>
+  </data>
+  <data name="Set the HTTP or HTTPS port on the Web services &amp; autoconfiguration page so the URLs answer, then publish autoconfig.&lt;domain&gt; and autodiscover.&lt;domain&gt; DNS records for each mail domain, pointing at this server. These are address records, and this page checks TXT records only, so they cannot be confirmed from here." xml:space="preserve">
+    <value>Nastavte port HTTP nebo HTTPS na stránce Webové služby a autokonfigurace WebServicesHttpPort a/nebo WebServicesHttpsPort, aby URL odpovídaly, a poté pro každou poštovní doménu publikujte DNS záznamy autoconfig.&lt;domain&gt; a autodiscover.&lt;domain&gt; ukazující na tento server. Jde o adresní záznamy a tato stránka kontroluje pouze TXT záznamy, takže je odsud potvrdit nelze.</value>
+  </data>
+  <data name="Set the HTTPS port on the Web services &amp; autoconfiguration page (RFC 8461 requires the policy over HTTPS), give the listener a certificate that covers mta-sts.&lt;domain&gt;, then for each domain publish an A/AAAA (or CNAME) record for mta-sts.&lt;domain&gt; pointing at this server and a TXT record at _mta-sts.&lt;domain&gt; (v=STSv1; id=...). This page checks the TXT record; the address record and the certificate's name coverage cannot be checked from here." xml:space="preserve">
+    <value>Nastavte port HTTPS na stránce Webové služby a autokonfigurace WebServicesHttpsPort (RFC 8461 vyžaduje politiku přes HTTPS), přiřaďte listeneru certifikát, který pokrývá mta-sts.&lt;domain&gt;, a poté pro každou doménu publikujte záznam A/AAAA (nebo CNAME) pro mta-sts.&lt;domain&gt; ukazující na tento server a TXT záznam na _mta-sts.&lt;domain&gt; (v=STSv1; id=...). Tato stránka kontroluje TXT záznam; adresní záznam ani to, zda certifikát daný název pokrývá, odsud zkontrolovat nelze.</value>
   </data>
   <data name="Set the SMTP relayer, and its credentials if the provider needs them." xml:space="preserve">
     <value>Nastavte SMTP relay a jeho přihlašovací údaje, pokud je poskytovatel vyžaduje.</value>

--- a/hmailserver/source/Tools/ControlPanel/Resources/Strings.da.resx
+++ b/hmailserver/source/Tools/ControlPanel/Resources/Strings.da.resx
@@ -2917,8 +2917,8 @@ Ingen post røres – indekset er udledt af den – men indtil genopbygningen ha
   <data name="Enter a valid port number." xml:space="preserve">
     <value>Indtast et gyldigt portnummer.</value>
   </data>
-  <data name="Enter an address and search. The trace records nothing at all unless MessageTraceEnabled is set in hMailServer.ini - it is off by default because it stores who corresponds with whom." xml:space="preserve">
-    <value>Indtast en adresse, og søg. Sporingen registrerer slet ingenting, medmindre MessageTraceEnabled er sat i hMailServer.ini - den er slået fra som standard, fordi den gemmer, hvem der korresponderer med hvem.</value>
+  <data name="Enter an address and search. The trace records nothing at all until message tracing is switched on, on the Logging page - it is off by default because it stores who corresponds with whom." xml:space="preserve">
+    <value>Indtast en adresse og søg. Sporingen registrerer slet ingenting, før meddelelsessporing slås til på siden Logføring – den er som standard slået fra, fordi den gemmer, hvem der skriver med hvem.</value>
   </data>
   <data name="Enter part of a name and press Search, or search with an empty box to list all users." xml:space="preserve">
     <value>Indtast en del af et navn, og tryk på Søg, eller søg med et tomt felt for at vise alle brugere.</value>
@@ -3438,6 +3438,9 @@ Ingen post røres – indekset er udledt af den – men indtil genopbygningen ha
   </data>
   <data name="Host/Name:  {0}" xml:space="preserve">
     <value>Vært/navn:  {0}</value>
+  </data>
+  <data name="Hosted domain" xml:space="preserve">
+    <value>Hostet domæne</value>
   </data>
   <data name="Hours between checks (1 to 168)" xml:space="preserve">
     <value>Timer mellem kontroller (1 til 168)</value>
@@ -4554,8 +4557,8 @@ Det verificerede installationsprogram overdrages til opdateringshjælperen: tjen
   <data name="No encryption is available on this port. Inbound mail from other servers is normally unencrypted anyway, but this port also accepts AUTH, and a client using it sends its password in the clear." xml:space="preserve">
     <value>Der er ingen kryptering tilgængelig på denne port. Indgående post fra andre servere er normalt ukrypteret alligevel, men denne port accepterer også AUTH, og en klient, der bruger den, sender sin adgangskode i klartekst.</value>
   </data>
-  <data name="No events for that address. Either nothing has happened to it, or the trace was switched off at the time - it records only while MessageTraceEnabled is set." xml:space="preserve">
-    <value>Ingen hændelser for den adresse. Enten er der ikke sket noget med den, eller også var sporingen slået fra på det tidspunkt - den registrerer kun, mens MessageTraceEnabled er sat.</value>
+  <data name="No events for that address. Either nothing has happened to it, or the trace was switched off at the time - it records only while message tracing is on (Logging page)." xml:space="preserve">
+    <value>Ingen hændelser for den adresse. Enten er der ikke sket noget med den, eller sporingen var slået fra på det tidspunkt – den registrerer kun, mens meddelelsessporing er slået til (siden Logføring).</value>
   </data>
   <data name="No events for that message." xml:space="preserve">
     <value>Ingen hændelser for den meddelelse.</value>
@@ -4710,8 +4713,8 @@ Det verificerede installationsprogram overdrages til opdateringshjælperen: tjen
   <data name="Not checked from here, honestly: verifying the PTR needs the server's PUBLIC IP address, which this panel cannot determine (behind NAT the machine does not know it either), and this page's checker reads TXT records only. Test from outside instead: nslookup &lt;your public IP&gt; shows the PTR; it should name the host above." xml:space="preserve">
     <value>Ærligt talt ikke kontrolleret herfra: at verificere PTR-posten kræver serverens OFFENTLIGE IP-adresse, som dette panel ikke kan fastslå (bag NAT kender maskinen den heller ikke selv), og denne sides kontrol læser kun TXT-poster. Test i stedet udefra: nslookup &lt;your public IP&gt; viser PTR-posten; den bør nævne værten ovenfor.</value>
   </data>
-  <data name="Not checked yet (Check for updates, or UpdateCheckEnabled=1 in hMailServer.INI for a daily check)" xml:space="preserve">
-    <value>Ikke kontrolleret endnu (Søg efter opdateringer, eller UpdateCheckEnabled=1 i hMailServer.INI for en daglig kontrol)</value>
+  <data name="Not checked yet (Check for updates, or turn on the daily check under Updates on the API &amp; monitoring page)" xml:space="preserve">
+    <value>Ikke kontrolleret endnu (Søg efter opdateringer, eller slå den daglige kontrol til under Opdateringer på siden API og overvågning)</value>
   </data>
   <data name="Not checked yet. Publish the record, allow time for propagation, then press &quot;Check DNS&quot;." xml:space="preserve">
     <value>Ikke kontrolleret endnu. Offentliggør posten, giv tid til udbredelse, og tryk derefter på "Kontrollér DNS".</value>
@@ -4758,11 +4761,14 @@ Det verificerede installationsprogram overdrages til opdateringshjælperen: tjen
   <data name="Nothing here needs a decision: no mailbox is being skipped and none is being disabled." xml:space="preserve">
     <value>Intet her kræver en beslutning: ingen postkasse springes over, og ingen deaktiveres.</value>
   </data>
+  <data name="Nothing here yet - Add creates the first entry." xml:space="preserve">
+    <value>Her er intet endnu – Tilføj opretter den første post.</value>
+  </data>
   <data name="Nothing is ever marked as spam: marking needs a mark threshold above 0, and a 0 there means &quot;never&quot; rather than &quot;always&quot;. Messages reaching {0} are still refused." xml:space="preserve">
     <value>Intet markeres nogensinde som spam: markering kræver en markeringstærskel over 0, og 0 dér betyder "aldrig" snarere end "altid". Meddelelser, der når {0}, afvises stadig.</value>
   </data>
-  <data name="Nothing is held. Quarantining is off unless QuarantineEnabled is set in hMailServer.ini - until then, spam over the delete threshold is refused during the SMTP conversation rather than stored." xml:space="preserve">
-    <value>Intet tilbageholdes. Karantæne er slået fra, medmindre QuarantineEnabled er sat i hMailServer.ini - indtil da afvises spam over sletningstærsklen under SMTP-samtalen i stedet for at blive gemt.</value>
+  <data name="Nothing is held. Quarantining is switched off - turn it on under Anti-spam settings - and until it is on, spam over the delete threshold is refused during the SMTP conversation rather than stored." xml:space="preserve">
+    <value>Intet er tilbageholdt. Karantæne er slået fra – slå den til under Antispam-indstillinger – og indtil den er slået til, afvises spam over sletningstærsklen under SMTP-samtalen i stedet for at blive gemt.</value>
   </data>
   <data name="Nothing matched &quot;{0}&quot;. Try what you are trying to achieve (&quot;stop spam&quot;, &quot;let a device send mail&quot;), a page name, or an hMailServer.INI key." xml:space="preserve">
     <value>Intet matchede "{0}". Prøv det, du forsøger at opnå ("stop spam", "lad en enhed sende post"), et sidenavn eller en hMailServer.INI-nøgle.</value>
@@ -5749,6 +5755,9 @@ Kør dette, hvis klienter melder om meddelelser, der dukker op under det forkert
   <data name="Remember this many previous passwords (0 = no history)" xml:space="preserve">
     <value>Husk så mange tidligere adgangskoder (0 = ingen historik)</value>
   </data>
+  <data name="Remote domain" xml:space="preserve">
+    <value>Eksternt domæne</value>
+  </data>
   <data name="Remove _expired" xml:space="preserve">
     <value>Fjern _udløbne</value>
   </data>
@@ -6708,12 +6717,6 @@ Vil du fortsætte?</value>
   <data name="Set TlsRptFromAddress in the [Settings] section of hMailServer.ini to a mailbox reports should be sent from. Leaving it empty is a valid choice - it just means the collected statistics are discarded and no reports are ever sent." xml:space="preserve">
     <value>Sæt TlsRptFromAddress i sektionen [Settings] i hMailServer.ini til en postkasse, rapporter skal sendes fra. At lade den stå tom er et gyldigt valg - det betyder blot, at den indsamlede statistik kasseres, og at der aldrig sendes rapporter.</value>
   </data>
-  <data name="Set WebServicesHttpPort and/or WebServicesHttpsPort in hMailServer.ini so the URLs answer, then publish autoconfig.&lt;domain&gt; and autodiscover.&lt;domain&gt; DNS records for each mail domain, pointing at this server. These are address records, and this page checks TXT records only, so they cannot be confirmed from here." xml:space="preserve">
-    <value>Sæt WebServicesHttpPort og/eller WebServicesHttpsPort i hMailServer.ini, så URL'erne svarer, og publicér så DNS-posterne autoconfig.&lt;domain&gt; og autodiscover.&lt;domain&gt; for hvert postdomæne, pegende på denne server. Det er adresseposter, og denne side kontrollerer kun TXT-poster, så de kan ikke bekræftes herfra.</value>
-  </data>
-  <data name="Set WebServicesHttpsPort in hMailServer.ini (RFC 8461 requires the policy over HTTPS), give the listener a certificate that covers mta-sts.&lt;domain&gt;, then for each domain publish an A/AAAA (or CNAME) record for mta-sts.&lt;domain&gt; pointing at this server and a TXT record at _mta-sts.&lt;domain&gt; (v=STSv1; id=...). This page checks the TXT record; the address record and the certificate's name coverage cannot be checked from here." xml:space="preserve">
-    <value>Sæt WebServicesHttpsPort i hMailServer.ini (RFC 8461 kræver politikken over HTTPS), giv lytteren et certifikat, der dækker mta-sts.&lt;domain&gt;, og publicér så for hvert domæne en A/AAAA-post (eller CNAME) for mta-sts.&lt;domain&gt;, der peger på denne server, og en TXT-post på _mta-sts.&lt;domain&gt; (v=STSv1; id=...). Denne side kontrollerer TXT-posten; adresseposten og certifikatets navnedækning kan ikke kontrolleres herfra.</value>
-  </data>
   <data name="Set a new server administration password." xml:space="preserve">
     <value>Sæt en ny serveradministrationsadgangskode.</value>
   </data>
@@ -6725,6 +6728,12 @@ Vil du fortsætte?</value>
   </data>
   <data name="Set header value" xml:space="preserve">
     <value>Sæt headerværdi</value>
+  </data>
+  <data name="Set the HTTP or HTTPS port on the Web services &amp; autoconfiguration page so the URLs answer, then publish autoconfig.&lt;domain&gt; and autodiscover.&lt;domain&gt; DNS records for each mail domain, pointing at this server. These are address records, and this page checks TXT records only, so they cannot be confirmed from here." xml:space="preserve">
+    <value>Angiv HTTP- eller HTTPS-porten på siden Webtjenester og autokonfiguration, så URL'erne svarer, og publicér så DNS-posterne autoconfig.&lt;domain&gt; og autodiscover.&lt;domain&gt; for hvert postdomæne, pegende på denne server. Det er adresseposter, og denne side kontrollerer kun TXT-poster, så de kan ikke bekræftes herfra.</value>
+  </data>
+  <data name="Set the HTTPS port on the Web services &amp; autoconfiguration page (RFC 8461 requires the policy over HTTPS), give the listener a certificate that covers mta-sts.&lt;domain&gt;, then for each domain publish an A/AAAA (or CNAME) record for mta-sts.&lt;domain&gt; pointing at this server and a TXT record at _mta-sts.&lt;domain&gt; (v=STSv1; id=...). This page checks the TXT record; the address record and the certificate's name coverage cannot be checked from here." xml:space="preserve">
+    <value>Angiv HTTPS-porten på siden Webtjenester og autokonfiguration (RFC 8461 kræver politikken over HTTPS), giv lytteren et certifikat, der dækker mta-sts.&lt;domain&gt;, og publicér så for hvert domæne en A/AAAA-post (eller CNAME) for mta-sts.&lt;domain&gt;, der peger på denne server, og en TXT-post på _mta-sts.&lt;domain&gt; (v=STSv1; id=...). Denne side kontrollerer TXT-posten; adresseposten og certifikatets navnedækning kan ikke kontrolleres herfra.</value>
   </data>
   <data name="Set the SMTP relayer, and its credentials if the provider needs them." xml:space="preserve">
     <value>Sæt SMTP-relayeren og dens legitimationsoplysninger, hvis udbyderen har brug for dem.</value>

--- a/hmailserver/source/Tools/ControlPanel/Resources/Strings.de.resx
+++ b/hmailserver/source/Tools/ControlPanel/Resources/Strings.de.resx
@@ -2917,8 +2917,8 @@ Keine Mail wird angerührt - der Index ist daraus abgeleitet - aber bis der Neua
   <data name="Enter a valid port number." xml:space="preserve">
     <value>Geben Sie eine gültige Portnummer ein.</value>
   </data>
-  <data name="Enter an address and search. The trace records nothing at all unless MessageTraceEnabled is set in hMailServer.ini - it is off by default because it stores who corresponds with whom." xml:space="preserve">
-    <value>Geben Sie eine Adresse ein und suchen Sie. Der Trace zeichnet gar nichts auf, solange MessageTraceEnabled nicht in hMailServer.ini gesetzt ist - er ist in der Vorgabe aus, weil er speichert, wer mit wem korrespondiert.</value>
+  <data name="Enter an address and search. The trace records nothing at all until message tracing is switched on, on the Logging page - it is off by default because it stores who corresponds with whom." xml:space="preserve">
+    <value>Geben Sie eine Adresse ein und suchen Sie. Der Trace zeichnet nichts auf, bis die Nachrichtenverfolgung auf der Seite Protokollierung eingeschaltet wird – sie ist standardmäßig aus, weil sie speichert, wer mit wem korrespondiert.</value>
   </data>
   <data name="Enter part of a name and press Search, or search with an empty box to list all users." xml:space="preserve">
     <value>Geben Sie einen Teil eines Namens ein und klicken Sie auf Suchen, oder suchen Sie mit leerem Feld, um alle Benutzer aufzulisten.</value>
@@ -3438,6 +3438,9 @@ Keine Mail wird angerührt - der Index ist daraus abgeleitet - aber bis der Neua
   </data>
   <data name="Host/Name:  {0}" xml:space="preserve">
     <value>Host/Name:  {0}</value>
+  </data>
+  <data name="Hosted domain" xml:space="preserve">
+    <value>Gehostete Domäne</value>
   </data>
   <data name="Hours between checks (1 to 168)" xml:space="preserve">
     <value>Stunden zwischen Prüfungen (1 bis 168)</value>
@@ -4554,8 +4557,8 @@ Der geprüfte Installer wird dem Update-Helfer übergeben: der Dienst stoppt, di
   <data name="No encryption is available on this port. Inbound mail from other servers is normally unencrypted anyway, but this port also accepts AUTH, and a client using it sends its password in the clear." xml:space="preserve">
     <value>Auf diesem Port ist keine Verschlüsselung verfügbar. Eingehende Mail von anderen Servern ist ohnehin normalerweise unverschlüsselt, aber dieser Port nimmt auch AUTH an, und ein Client, der es verwendet, sendet sein Passwort im Klartext.</value>
   </data>
-  <data name="No events for that address. Either nothing has happened to it, or the trace was switched off at the time - it records only while MessageTraceEnabled is set." xml:space="preserve">
-    <value>Keine Ereignisse für diese Adresse. Entweder ist ihr nichts widerfahren, oder der Trace war zu der Zeit abgeschaltet - er zeichnet nur auf, solange MessageTraceEnabled gesetzt ist.</value>
+  <data name="No events for that address. Either nothing has happened to it, or the trace was switched off at the time - it records only while message tracing is on (Logging page)." xml:space="preserve">
+    <value>Keine Ereignisse für diese Adresse. Entweder ist mit ihr nichts geschehen, oder der Trace war zu der Zeit ausgeschaltet – er zeichnet nur auf, solange die Nachrichtenverfolgung eingeschaltet ist (Seite Protokollierung).</value>
   </data>
   <data name="No events for that message." xml:space="preserve">
     <value>Keine Ereignisse für diese Nachricht.</value>
@@ -4710,8 +4713,8 @@ Der geprüfte Installer wird dem Update-Helfer übergeben: der Dienst stoppt, di
   <data name="Not checked from here, honestly: verifying the PTR needs the server's PUBLIC IP address, which this panel cannot determine (behind NAT the machine does not know it either), and this page's checker reads TXT records only. Test from outside instead: nslookup &lt;your public IP&gt; shows the PTR; it should name the host above." xml:space="preserve">
     <value>Von hier aus ehrlich gesagt nicht geprüft: den PTR zu verifizieren braucht die ÖFFENTLICHE IP-Adresse des Servers, die dieses Panel nicht ermitteln kann (hinter NAT kennt der Rechner sie selbst nicht), und der Prüfer dieser Seite liest nur TXT-Einträge. Testen Sie stattdessen von außen: nslookup &lt;your public IP&gt; zeigt den PTR; er sollte den Host oben nennen.</value>
   </data>
-  <data name="Not checked yet (Check for updates, or UpdateCheckEnabled=1 in hMailServer.INI for a daily check)" xml:space="preserve">
-    <value>Noch nicht geprüft (Nach Updates suchen, oder UpdateCheckEnabled=1 in hMailServer.INI für eine tägliche Prüfung)</value>
+  <data name="Not checked yet (Check for updates, or turn on the daily check under Updates on the API &amp; monitoring page)" xml:space="preserve">
+    <value>Noch nicht geprüft (Nach Updates suchen, oder die tägliche Prüfung unter Updates auf der Seite API und Überwachung einschalten)</value>
   </data>
   <data name="Not checked yet. Publish the record, allow time for propagation, then press &quot;Check DNS&quot;." xml:space="preserve">
     <value>Noch nicht geprüft. Veröffentlichen Sie den Eintrag, geben Sie der Verbreitung Zeit und klicken Sie dann auf „DNS prüfen".</value>
@@ -4758,11 +4761,14 @@ Der geprüfte Installer wird dem Update-Helfer übergeben: der Dienst stoppt, di
   <data name="Nothing here needs a decision: no mailbox is being skipped and none is being disabled." xml:space="preserve">
     <value>Nichts hier braucht eine Entscheidung: kein Postfach wird übersprungen und keines wird deaktiviert.</value>
   </data>
+  <data name="Nothing here yet - Add creates the first entry." xml:space="preserve">
+    <value>Noch nichts vorhanden – Hinzufügen legt den ersten Eintrag an.</value>
+  </data>
   <data name="Nothing is ever marked as spam: marking needs a mark threshold above 0, and a 0 there means &quot;never&quot; rather than &quot;always&quot;. Messages reaching {0} are still refused." xml:space="preserve">
     <value>Es wird nie etwas als Spam markiert: das Markieren braucht eine Markierungsschwelle über 0, und eine 0 dort bedeutet „nie" statt „immer". Nachrichten, die {0} erreichen, werden weiterhin abgelehnt.</value>
   </data>
-  <data name="Nothing is held. Quarantining is off unless QuarantineEnabled is set in hMailServer.ini - until then, spam over the delete threshold is refused during the SMTP conversation rather than stored." xml:space="preserve">
-    <value>Es wird nichts zurückgehalten. Die Quarantäne ist aus, solange QuarantineEnabled nicht in hMailServer.ini gesetzt ist - bis dahin wird Spam über der Löschschwelle während des SMTP-Dialogs abgelehnt statt gespeichert.</value>
+  <data name="Nothing is held. Quarantining is switched off - turn it on under Anti-spam settings - and until it is on, spam over the delete threshold is refused during the SMTP conversation rather than stored." xml:space="preserve">
+    <value>Nichts wird zurückgehalten. Die Quarantäne ist ausgeschaltet – schalten Sie sie unter Anti-Spam-Einstellungen ein – und solange sie aus ist, wird Spam über der Löschschwelle während der SMTP-Sitzung abgewiesen statt gespeichert.</value>
   </data>
   <data name="Nothing matched &quot;{0}&quot;. Try what you are trying to achieve (&quot;stop spam&quot;, &quot;let a device send mail&quot;), a page name, or an hMailServer.INI key." xml:space="preserve">
     <value>Nichts passte auf „{0}". Versuchen Sie es mit dem, was Sie erreichen wollen („Spam stoppen", „ein Gerät Mail senden lassen"), einem Seitennamen oder einem Schlüssel aus hMailServer.INI.</value>
@@ -5749,6 +5755,9 @@ Führen Sie dies aus, wenn Clients melden, dass Nachrichten unter der falschen U
   <data name="Remember this many previous passwords (0 = no history)" xml:space="preserve">
     <value>So viele vorherige Passwörter merken (0 = keine Historie)</value>
   </data>
+  <data name="Remote domain" xml:space="preserve">
+    <value>Externe Domäne</value>
+  </data>
   <data name="Remove _expired" xml:space="preserve">
     <value>_Abgelaufene entfernen</value>
   </data>
@@ -6708,12 +6717,6 @@ Fortfahren?</value>
   <data name="Set TlsRptFromAddress in the [Settings] section of hMailServer.ini to a mailbox reports should be sent from. Leaving it empty is a valid choice - it just means the collected statistics are discarded and no reports are ever sent." xml:space="preserve">
     <value>Setzen Sie TlsRptFromAddress im Abschnitt [Settings] von hMailServer.ini auf ein Postfach, aus dem Berichte gesendet werden sollen. Es leer zu lassen ist eine gültige Wahl - es bedeutet nur, dass die gesammelten Statistiken verworfen werden und nie Berichte gesendet werden.</value>
   </data>
-  <data name="Set WebServicesHttpPort and/or WebServicesHttpsPort in hMailServer.ini so the URLs answer, then publish autoconfig.&lt;domain&gt; and autodiscover.&lt;domain&gt; DNS records for each mail domain, pointing at this server. These are address records, and this page checks TXT records only, so they cannot be confirmed from here." xml:space="preserve">
-    <value>Setzen Sie WebServicesHttpPort und/oder WebServicesHttpsPort in hMailServer.ini, damit die URLs antworten, und veröffentlichen Sie dann für jede Maildomäne die DNS-Einträge autoconfig.&lt;domain&gt; und autodiscover.&lt;domain&gt;, die auf diesen Server zeigen. Das sind Adresseinträge, und diese Seite prüft nur TXT-Einträge, sie können also von hier aus nicht bestätigt werden.</value>
-  </data>
-  <data name="Set WebServicesHttpsPort in hMailServer.ini (RFC 8461 requires the policy over HTTPS), give the listener a certificate that covers mta-sts.&lt;domain&gt;, then for each domain publish an A/AAAA (or CNAME) record for mta-sts.&lt;domain&gt; pointing at this server and a TXT record at _mta-sts.&lt;domain&gt; (v=STSv1; id=...). This page checks the TXT record; the address record and the certificate's name coverage cannot be checked from here." xml:space="preserve">
-    <value>Setzen Sie WebServicesHttpsPort in hMailServer.ini (RFC 8461 verlangt die Richtlinie über HTTPS), geben Sie dem Listener ein Zertifikat, das mta-sts.&lt;domain&gt; abdeckt, und veröffentlichen Sie dann für jede Domäne einen A/AAAA- (oder CNAME-)Eintrag für mta-sts.&lt;domain&gt;, der auf diesen Server zeigt, sowie einen TXT-Eintrag unter _mta-sts.&lt;domain&gt; (v=STSv1; id=...). Diese Seite prüft den TXT-Eintrag; der Adresseintrag und die Namensabdeckung des Zertifikats können von hier aus nicht geprüft werden.</value>
-  </data>
   <data name="Set a new server administration password." xml:space="preserve">
     <value>Ein neues Passwort für die Serververwaltung festlegen.</value>
   </data>
@@ -6725,6 +6728,12 @@ Fortfahren?</value>
   </data>
   <data name="Set header value" xml:space="preserve">
     <value>Headerwert setzen</value>
+  </data>
+  <data name="Set the HTTP or HTTPS port on the Web services &amp; autoconfiguration page so the URLs answer, then publish autoconfig.&lt;domain&gt; and autodiscover.&lt;domain&gt; DNS records for each mail domain, pointing at this server. These are address records, and this page checks TXT records only, so they cannot be confirmed from here." xml:space="preserve">
+    <value>Legen Sie den HTTP- oder HTTPS-Port auf der Seite Webdienste und Autokonfiguration fest, damit die URLs antworten, und veröffentlichen Sie dann für jede Maildomäne die DNS-Einträge autoconfig.&lt;domain&gt; und autodiscover.&lt;domain&gt;, die auf diesen Server zeigen. Das sind Adresseinträge, und diese Seite prüft nur TXT-Einträge, sie können also von hier aus nicht bestätigt werden.</value>
+  </data>
+  <data name="Set the HTTPS port on the Web services &amp; autoconfiguration page (RFC 8461 requires the policy over HTTPS), give the listener a certificate that covers mta-sts.&lt;domain&gt;, then for each domain publish an A/AAAA (or CNAME) record for mta-sts.&lt;domain&gt; pointing at this server and a TXT record at _mta-sts.&lt;domain&gt; (v=STSv1; id=...). This page checks the TXT record; the address record and the certificate's name coverage cannot be checked from here." xml:space="preserve">
+    <value>Legen Sie den HTTPS-Port auf der Seite Webdienste und Autokonfiguration fest (RFC 8461 verlangt die Richtlinie über HTTPS), geben Sie dem Listener ein Zertifikat, das mta-sts.&lt;domain&gt; abdeckt, und veröffentlichen Sie dann für jede Domäne einen A/AAAA- (oder CNAME-)Eintrag für mta-sts.&lt;domain&gt;, der auf diesen Server zeigt, sowie einen TXT-Eintrag unter _mta-sts.&lt;domain&gt; (v=STSv1; id=...). Diese Seite prüft den TXT-Eintrag; der Adresseintrag und die Namensabdeckung des Zertifikats können von hier aus nicht geprüft werden.</value>
   </data>
   <data name="Set the SMTP relayer, and its credentials if the provider needs them." xml:space="preserve">
     <value>Den SMTP-Relayer festlegen, und seine Zugangsdaten, wenn der Provider sie braucht.</value>

--- a/hmailserver/source/Tools/ControlPanel/Resources/Strings.es.resx
+++ b/hmailserver/source/Tools/ControlPanel/Resources/Strings.es.resx
@@ -2917,8 +2917,8 @@ No se toca ningún correo - el índice se deriva de él - pero hasta que la reco
   <data name="Enter a valid port number." xml:space="preserve">
     <value>Introduzca un número de puerto válido.</value>
   </data>
-  <data name="Enter an address and search. The trace records nothing at all unless MessageTraceEnabled is set in hMailServer.ini - it is off by default because it stores who corresponds with whom." xml:space="preserve">
-    <value>Introduzca una dirección y busque. La traza no registra nada en absoluto a menos que MessageTraceEnabled esté definido en hMailServer.ini - está desactivada por defecto porque guarda quién se escribe con quién.</value>
+  <data name="Enter an address and search. The trace records nothing at all until message tracing is switched on, on the Logging page - it is off by default because it stores who corresponds with whom." xml:space="preserve">
+    <value>Introduzca una dirección y busque. La traza no registra nada hasta que se active el rastreo de mensajes en la página Registro; está desactivado de forma predeterminada porque almacena quién se escribe con quién.</value>
   </data>
   <data name="Enter part of a name and press Search, or search with an empty box to list all users." xml:space="preserve">
     <value>Introduzca parte de un nombre y pulse Buscar, o busque con el cuadro vacío para listar todos los usuarios.</value>
@@ -3438,6 +3438,9 @@ No se toca ningún correo - el índice se deriva de él - pero hasta que la reco
   </data>
   <data name="Host/Name:  {0}" xml:space="preserve">
     <value>Host/Nombre:  {0}</value>
+  </data>
+  <data name="Hosted domain" xml:space="preserve">
+    <value>Dominio alojado</value>
   </data>
   <data name="Hours between checks (1 to 168)" xml:space="preserve">
     <value>Horas entre comprobaciones (de 1 a 168)</value>
@@ -4554,8 +4557,8 @@ El instalador verificado se entrega al ayudante de actualización: el servicio s
   <data name="No encryption is available on this port. Inbound mail from other servers is normally unencrypted anyway, but this port also accepts AUTH, and a client using it sends its password in the clear." xml:space="preserve">
     <value>En este puerto no hay cifrado disponible. El correo entrante de otros servidores normalmente no va cifrado de todos modos, pero este puerto también acepta AUTH, y un cliente que lo use envía su contraseña en claro.</value>
   </data>
-  <data name="No events for that address. Either nothing has happened to it, or the trace was switched off at the time - it records only while MessageTraceEnabled is set." xml:space="preserve">
-    <value>No hay eventos para esa dirección. O no le ha ocurrido nada, o la traza estaba desactivada en ese momento - solo registra mientras MessageTraceEnabled está definido.</value>
+  <data name="No events for that address. Either nothing has happened to it, or the trace was switched off at the time - it records only while message tracing is on (Logging page)." xml:space="preserve">
+    <value>No hay eventos para esa dirección. O no le ha ocurrido nada, o la traza estaba desactivada en ese momento; solo registra mientras el rastreo de mensajes está activado (página Registro).</value>
   </data>
   <data name="No events for that message." xml:space="preserve">
     <value>No hay eventos para ese mensaje.</value>
@@ -4710,8 +4713,8 @@ El instalador verificado se entrega al ayudante de actualización: el servicio s
   <data name="Not checked from here, honestly: verifying the PTR needs the server's PUBLIC IP address, which this panel cannot determine (behind NAT the machine does not know it either), and this page's checker reads TXT records only. Test from outside instead: nslookup &lt;your public IP&gt; shows the PTR; it should name the host above." xml:space="preserve">
     <value>Sinceramente, no se comprueba desde aquí: verificar el PTR necesita la dirección IP PÚBLICA del servidor, que este panel no puede determinar (detrás de NAT la máquina tampoco la conoce), y el comprobador de esta página solo lee registros TXT. Pruebe desde fuera en su lugar: nslookup &lt;your public IP&gt; muestra el PTR; debería nombrar el host de arriba.</value>
   </data>
-  <data name="Not checked yet (Check for updates, or UpdateCheckEnabled=1 in hMailServer.INI for a daily check)" xml:space="preserve">
-    <value>Todavía no comprobado (Buscar actualizaciones, o UpdateCheckEnabled=1 en hMailServer.INI para una comprobación diaria)</value>
+  <data name="Not checked yet (Check for updates, or turn on the daily check under Updates on the API &amp; monitoring page)" xml:space="preserve">
+    <value>Aún no comprobado (Buscar actualizaciones, o active la comprobación diaria en Actualizaciones, en la página API y supervisión)</value>
   </data>
   <data name="Not checked yet. Publish the record, allow time for propagation, then press &quot;Check DNS&quot;." xml:space="preserve">
     <value>Todavía no comprobado. Publique el registro, deje tiempo para la propagación y luego pulse "Comprobar DNS".</value>
@@ -4758,11 +4761,14 @@ El instalador verificado se entrega al ayudante de actualización: el servicio s
   <data name="Nothing here needs a decision: no mailbox is being skipped and none is being disabled." xml:space="preserve">
     <value>Nada de aquí necesita una decisión: no se está omitiendo ningún buzón ni se está desactivando ninguno.</value>
   </data>
+  <data name="Nothing here yet - Add creates the first entry." xml:space="preserve">
+    <value>Aún no hay nada aquí: Añadir crea la primera entrada.</value>
+  </data>
   <data name="Nothing is ever marked as spam: marking needs a mark threshold above 0, and a 0 there means &quot;never&quot; rather than &quot;always&quot;. Messages reaching {0} are still refused." xml:space="preserve">
     <value>Nunca se marca nada como spam: marcar necesita un umbral de marcado mayor que 0, y un 0 ahí significa "nunca" y no "siempre". Los mensajes que alcanzan {0} se siguen rechazando.</value>
   </data>
-  <data name="Nothing is held. Quarantining is off unless QuarantineEnabled is set in hMailServer.ini - until then, spam over the delete threshold is refused during the SMTP conversation rather than stored." xml:space="preserve">
-    <value>No se retiene nada. La cuarentena está desactivada salvo que QuarantineEnabled esté definido en hMailServer.ini - hasta entonces, el spam que supera el umbral de borrado se rechaza durante la conversación SMTP en vez de almacenarse.</value>
+  <data name="Nothing is held. Quarantining is switched off - turn it on under Anti-spam settings - and until it is on, spam over the delete threshold is refused during the SMTP conversation rather than stored." xml:space="preserve">
+    <value>No hay nada retenido. La cuarentena está desactivada (actívela en Ajustes antispam) y, hasta que lo esté, el spam por encima del umbral de eliminación se rechaza durante la conversación SMTP en lugar de almacenarse.</value>
   </data>
   <data name="Nothing matched &quot;{0}&quot;. Try what you are trying to achieve (&quot;stop spam&quot;, &quot;let a device send mail&quot;), a page name, or an hMailServer.INI key." xml:space="preserve">
     <value>Nada coincidió con "{0}". Pruebe con lo que intenta conseguir ("parar el spam", "permitir que un dispositivo envíe correo"), con el nombre de una página o con una clave de hMailServer.INI.</value>
@@ -5749,6 +5755,9 @@ Ejecute esto si los clientes informan de mensajes que aparecen con un UID equivo
   <data name="Remember this many previous passwords (0 = no history)" xml:space="preserve">
     <value>Recordar este número de contraseñas anteriores (0 = sin historial)</value>
   </data>
+  <data name="Remote domain" xml:space="preserve">
+    <value>Dominio remoto</value>
+  </data>
   <data name="Remove _expired" xml:space="preserve">
     <value>Quitar los _caducados</value>
   </data>
@@ -6708,12 +6717,6 @@ SMTP 25 y 587, POP3 110, IMAP 143 - sin seguridad de conexión. Los puertos TLS 
   <data name="Set TlsRptFromAddress in the [Settings] section of hMailServer.ini to a mailbox reports should be sent from. Leaving it empty is a valid choice - it just means the collected statistics are discarded and no reports are ever sent." xml:space="preserve">
     <value>Defina TlsRptFromAddress en la sección [Settings] de hMailServer.ini con el buzón desde el que deben enviarse los informes. Dejarlo vacío es una opción válida: solo significa que las estadísticas recopiladas se descartan y nunca se envía ningún informe.</value>
   </data>
-  <data name="Set WebServicesHttpPort and/or WebServicesHttpsPort in hMailServer.ini so the URLs answer, then publish autoconfig.&lt;domain&gt; and autodiscover.&lt;domain&gt; DNS records for each mail domain, pointing at this server. These are address records, and this page checks TXT records only, so they cannot be confirmed from here." xml:space="preserve">
-    <value>Defina WebServicesHttpPort o WebServicesHttpsPort (o ambos) en hMailServer.ini para que las URL respondan, y luego publique registros DNS autoconfig.&lt;domain&gt; y autodiscover.&lt;domain&gt; para cada dominio de correo, apuntando a este servidor. Son registros de dirección, y esta página comprueba solo registros TXT, así que no pueden confirmarse desde aquí.</value>
-  </data>
-  <data name="Set WebServicesHttpsPort in hMailServer.ini (RFC 8461 requires the policy over HTTPS), give the listener a certificate that covers mta-sts.&lt;domain&gt;, then for each domain publish an A/AAAA (or CNAME) record for mta-sts.&lt;domain&gt; pointing at this server and a TXT record at _mta-sts.&lt;domain&gt; (v=STSv1; id=...). This page checks the TXT record; the address record and the certificate's name coverage cannot be checked from here." xml:space="preserve">
-    <value>Defina WebServicesHttpsPort en hMailServer.ini (el RFC 8461 exige que la política se sirva por HTTPS), dé al oyente un certificado que cubra mta-sts.&lt;domain&gt; y, después, para cada dominio publique un registro A/AAAA (o CNAME) para mta-sts.&lt;domain&gt; que apunte a este servidor y un registro TXT en _mta-sts.&lt;domain&gt; (v=STSv1; id=...). Esta página comprueba el registro TXT; el registro de dirección y la cobertura de nombres del certificado no pueden comprobarse desde aquí.</value>
-  </data>
   <data name="Set a new server administration password." xml:space="preserve">
     <value>Defina una nueva contraseña de administración del servidor.</value>
   </data>
@@ -6725,6 +6728,12 @@ SMTP 25 y 587, POP3 110, IMAP 143 - sin seguridad de conexión. Los puertos TLS 
   </data>
   <data name="Set header value" xml:space="preserve">
     <value>Establecer el valor de una cabecera</value>
+  </data>
+  <data name="Set the HTTP or HTTPS port on the Web services &amp; autoconfiguration page so the URLs answer, then publish autoconfig.&lt;domain&gt; and autodiscover.&lt;domain&gt; DNS records for each mail domain, pointing at this server. These are address records, and this page checks TXT records only, so they cannot be confirmed from here." xml:space="preserve">
+    <value>Establezca el puerto HTTP o HTTPS en la página Servicios web y autoconfiguración para que las URL respondan, y luego publique registros DNS autoconfig.&lt;domain&gt; y autodiscover.&lt;domain&gt; para cada dominio de correo, apuntando a este servidor. Son registros de dirección, y esta página comprueba solo registros TXT, así que no pueden confirmarse desde aquí.</value>
+  </data>
+  <data name="Set the HTTPS port on the Web services &amp; autoconfiguration page (RFC 8461 requires the policy over HTTPS), give the listener a certificate that covers mta-sts.&lt;domain&gt;, then for each domain publish an A/AAAA (or CNAME) record for mta-sts.&lt;domain&gt; pointing at this server and a TXT record at _mta-sts.&lt;domain&gt; (v=STSv1; id=...). This page checks the TXT record; the address record and the certificate's name coverage cannot be checked from here." xml:space="preserve">
+    <value>Establezca el puerto HTTPS en la página Servicios web y autoconfiguración (el RFC 8461 exige que la política se sirva por HTTPS), dé al oyente un certificado que cubra mta-sts.&lt;domain&gt; y, después, para cada dominio publique un registro A/AAAA (o CNAME) para mta-sts.&lt;domain&gt; que apunte a este servidor y un registro TXT en _mta-sts.&lt;domain&gt; (v=STSv1; id=...). Esta página comprueba el registro TXT; el registro de dirección y la cobertura de nombres del certificado no pueden comprobarse desde aquí.</value>
   </data>
   <data name="Set the SMTP relayer, and its credentials if the provider needs them." xml:space="preserve">
     <value>Defina el relé SMTP y sus credenciales si el proveedor las necesita.</value>

--- a/hmailserver/source/Tools/ControlPanel/Resources/Strings.fi.resx
+++ b/hmailserver/source/Tools/ControlPanel/Resources/Strings.fi.resx
@@ -2917,8 +2917,8 @@ Postiin ei kosketa - indeksi johdetaan siitä - mutta kunnes uudelleenrakennus s
   <data name="Enter a valid port number." xml:space="preserve">
     <value>Anna kelvollinen portin numero.</value>
   </data>
-  <data name="Enter an address and search. The trace records nothing at all unless MessageTraceEnabled is set in hMailServer.ini - it is off by default because it stores who corresponds with whom." xml:space="preserve">
-    <value>Anna osoite ja hae. Jäljitys ei tallenna yhtään mitään, ellei MessageTraceEnabled ole asetettu hMailServer.ini-tiedostossa - se on oletuksena pois päältä, koska se tallentaa, kuka kirjoittaa kenelle.</value>
+  <data name="Enter an address and search. The trace records nothing at all until message tracing is switched on, on the Logging page - it is off by default because it stores who corresponds with whom." xml:space="preserve">
+    <value>Anna osoite ja hae. Jäljitys ei tallenna mitään ennen kuin viestien jäljitys otetaan käyttöön Lokitus-sivulla – se on oletuksena pois käytöstä, koska se tallentaa, kuka kirjoittaa kenelle.</value>
   </data>
   <data name="Enter part of a name and press Search, or search with an empty box to list all users." xml:space="preserve">
     <value>Anna osa nimestä ja paina Hae, tai hae tyhjällä kentällä luetellaksesi kaikki käyttäjät.</value>
@@ -3438,6 +3438,9 @@ Postiin ei kosketa - indeksi johdetaan siitä - mutta kunnes uudelleenrakennus s
   </data>
   <data name="Host/Name:  {0}" xml:space="preserve">
     <value>Kone/Nimi:  {0}</value>
+  </data>
+  <data name="Hosted domain" xml:space="preserve">
+    <value>Isännöity verkkotunnus</value>
   </data>
   <data name="Hours between checks (1 to 168)" xml:space="preserve">
     <value>Tarkistusten väli tunteina (1–168)</value>
@@ -4554,8 +4557,8 @@ Tarkistettu asennusohjelma luovutetaan päivitysapurille: palvelu pysähtyy, uus
   <data name="No encryption is available on this port. Inbound mail from other servers is normally unencrypted anyway, but this port also accepts AUTH, and a client using it sends its password in the clear." xml:space="preserve">
     <value>Tässä portissa ei ole salausta saatavilla. Muilta palvelimilta saapuva posti on yleensä muutenkin salaamatonta, mutta tämä portti hyväksyy myös AUTH-komennon, ja sitä käyttävä asiakas lähettää salasanansa selväkielisenä.</value>
   </data>
-  <data name="No events for that address. Either nothing has happened to it, or the trace was switched off at the time - it records only while MessageTraceEnabled is set." xml:space="preserve">
-    <value>Ei tapahtumia tuolle osoitteelle. Joko sille ei ole tapahtunut mitään, tai jäljitys oli tuolloin pois päältä - se tallentaa vain, kun MessageTraceEnabled on asetettu.</value>
+  <data name="No events for that address. Either nothing has happened to it, or the trace was switched off at the time - it records only while message tracing is on (Logging page)." xml:space="preserve">
+    <value>Osoitteelle ei ole tapahtumia. Joko sille ei ole tapahtunut mitään tai jäljitys oli tuolloin pois käytöstä – se tallentaa vain, kun viestien jäljitys on käytössä (Lokitus-sivu).</value>
   </data>
   <data name="No events for that message." xml:space="preserve">
     <value>Ei tapahtumia tuolle viestille.</value>
@@ -4710,8 +4713,8 @@ Tarkistettu asennusohjelma luovutetaan päivitysapurille: palvelu pysähtyy, uus
   <data name="Not checked from here, honestly: verifying the PTR needs the server's PUBLIC IP address, which this panel cannot determine (behind NAT the machine does not know it either), and this page's checker reads TXT records only. Test from outside instead: nslookup &lt;your public IP&gt; shows the PTR; it should name the host above." xml:space="preserve">
     <value>Ei tarkistettu täältä, rehellisesti sanoen: PTR:n tarkistaminen vaatii palvelimen JULKISEN IP-osoitteen, jota tämä paneeli ei voi selvittää (NAT:n takana kone ei tiedä sitä itsekään), ja tämän sivun tarkistin lukee vain TXT-tietueita. Testaa sen sijaan ulkopuolelta: nslookup &lt;your public IP&gt; näyttää PTR:n; sen pitäisi nimetä yllä oleva kone.</value>
   </data>
-  <data name="Not checked yet (Check for updates, or UpdateCheckEnabled=1 in hMailServer.INI for a daily check)" xml:space="preserve">
-    <value>Ei vielä tarkistettu (Tarkista päivitykset, tai UpdateCheckEnabled=1 hMailServer.INI-tiedostossa päivittäistä tarkistusta varten)</value>
+  <data name="Not checked yet (Check for updates, or turn on the daily check under Updates on the API &amp; monitoring page)" xml:space="preserve">
+    <value>Ei vielä tarkistettu (Tarkista päivitykset tai ota päivittäinen tarkistus käyttöön kohdassa Päivitykset sivulla API ja valvonta)</value>
   </data>
   <data name="Not checked yet. Publish the record, allow time for propagation, then press &quot;Check DNS&quot;." xml:space="preserve">
     <value>Ei vielä tarkistettu. Julkaise tietue, anna aikaa leviämiselle ja paina sitten "Tarkista DNS".</value>
@@ -4758,11 +4761,14 @@ Tarkistettu asennusohjelma luovutetaan päivitysapurille: palvelu pysähtyy, uus
   <data name="Nothing here needs a decision: no mailbox is being skipped and none is being disabled." xml:space="preserve">
     <value>Mikään täällä ei vaadi päätöstä: yhtään postilaatikkoa ei ohiteta eikä yhtään poisteta käytöstä.</value>
   </data>
+  <data name="Nothing here yet - Add creates the first entry." xml:space="preserve">
+    <value>Täällä ei ole vielä mitään – Lisää luo ensimmäisen merkinnän.</value>
+  </data>
   <data name="Nothing is ever marked as spam: marking needs a mark threshold above 0, and a 0 there means &quot;never&quot; rather than &quot;always&quot;. Messages reaching {0} are still refused." xml:space="preserve">
     <value>Mitään ei koskaan merkitä roskapostiksi: merkintä vaatii merkintäkynnyksen yli 0, ja 0 siinä tarkoittaa "ei koskaan" eikä "aina". Viestit, jotka saavuttavat {0}, hylätään silti.</value>
   </data>
-  <data name="Nothing is held. Quarantining is off unless QuarantineEnabled is set in hMailServer.ini - until then, spam over the delete threshold is refused during the SMTP conversation rather than stored." xml:space="preserve">
-    <value>Mitään ei pidätetä. Karanteeni on pois päältä, ellei QuarantineEnabled ole asetettu hMailServer.ini-tiedostossa - siihen asti poistokynnyksen ylittävä roskaposti hylätään SMTP-keskustelun aikana tallentamisen sijaan.</value>
+  <data name="Nothing is held. Quarantining is switched off - turn it on under Anti-spam settings - and until it is on, spam over the delete threshold is refused during the SMTP conversation rather than stored." xml:space="preserve">
+    <value>Mitään ei ole pidätetty. Karanteeni on pois käytöstä – ota se käyttöön kohdassa Roskapostisuojauksen asetukset – ja siihen asti poistokynnyksen ylittävä roskaposti hylätään SMTP-keskustelun aikana tallentamisen sijaan.</value>
   </data>
   <data name="Nothing matched &quot;{0}&quot;. Try what you are trying to achieve (&quot;stop spam&quot;, &quot;let a device send mail&quot;), a page name, or an hMailServer.INI key." xml:space="preserve">
     <value>Mikään ei täsmännyt hakuun "{0}". Kokeile sitä, mitä yrität saada aikaan ("pysäytä roskaposti", "anna laitteen lähettää postia"), sivun nimeä tai hMailServer.INI-avainta.</value>
@@ -5749,6 +5755,9 @@ Aja tämä, jos asiakkaat raportoivat viestien näkyvän väärän UID:n alla, t
   <data name="Remember this many previous passwords (0 = no history)" xml:space="preserve">
     <value>Muista näin monta aiempaa salasanaa (0 = ei historiaa)</value>
   </data>
+  <data name="Remote domain" xml:space="preserve">
+    <value>Etäverkkotunnus</value>
+  </data>
   <data name="Remove _expired" xml:space="preserve">
     <value>P_oista vanhentuneet</value>
   </data>
@@ -6708,12 +6717,6 @@ Jatketaanko?</value>
   <data name="Set TlsRptFromAddress in the [Settings] section of hMailServer.ini to a mailbox reports should be sent from. Leaving it empty is a valid choice - it just means the collected statistics are discarded and no reports are ever sent." xml:space="preserve">
     <value>Aseta TlsRptFromAddress hMailServer.ini-tiedoston [Settings]-osiossa postilaatikoksi, josta raportit lähetetään. Tyhjäksi jättäminen on kelvollinen valinta - se tarkoittaa vain, että kerätyt tilastot hylätään eikä raportteja koskaan lähetetä.</value>
   </data>
-  <data name="Set WebServicesHttpPort and/or WebServicesHttpsPort in hMailServer.ini so the URLs answer, then publish autoconfig.&lt;domain&gt; and autodiscover.&lt;domain&gt; DNS records for each mail domain, pointing at this server. These are address records, and this page checks TXT records only, so they cannot be confirmed from here." xml:space="preserve">
-    <value>Aseta WebServicesHttpPort ja/tai WebServicesHttpsPort hMailServer.ini-tiedostossa, jotta URL-osoitteet vastaavat, ja julkaise sitten jokaiselle postiverkkotunnukselle autoconfig.&lt;domain&gt;- ja autodiscover.&lt;domain&gt;-DNS-tietueet, jotka osoittavat tähän palvelimeen. Nämä ovat osoitetietueita, ja tämä sivu tarkistaa vain TXT-tietueet, joten niitä ei voi vahvistaa täältä.</value>
-  </data>
-  <data name="Set WebServicesHttpsPort in hMailServer.ini (RFC 8461 requires the policy over HTTPS), give the listener a certificate that covers mta-sts.&lt;domain&gt;, then for each domain publish an A/AAAA (or CNAME) record for mta-sts.&lt;domain&gt; pointing at this server and a TXT record at _mta-sts.&lt;domain&gt; (v=STSv1; id=...). This page checks the TXT record; the address record and the certificate's name coverage cannot be checked from here." xml:space="preserve">
-    <value>Aseta WebServicesHttpsPort hMailServer.ini-tiedostossa (RFC 8461 vaatii käytännön HTTPS:n yli), anna kuuntelijalle varmenne, joka kattaa nimen mta-sts.&lt;domain&gt;, ja julkaise sitten jokaiselle verkkotunnukselle A/AAAA-tietue (tai CNAME) nimelle mta-sts.&lt;domain&gt;, joka osoittaa tähän palvelimeen, sekä TXT-tietue osoitteeseen _mta-sts.&lt;domain&gt; (v=STSv1; id=...). Tämä sivu tarkistaa TXT-tietueen; osoitetietuetta ja varmenteen nimikattavuutta ei voi tarkistaa täältä.</value>
-  </data>
   <data name="Set a new server administration password." xml:space="preserve">
     <value>Aseta uusi palvelimen hallintasalasana.</value>
   </data>
@@ -6725,6 +6728,12 @@ Jatketaanko?</value>
   </data>
   <data name="Set header value" xml:space="preserve">
     <value>Aseta otsakkeen arvo</value>
+  </data>
+  <data name="Set the HTTP or HTTPS port on the Web services &amp; autoconfiguration page so the URLs answer, then publish autoconfig.&lt;domain&gt; and autodiscover.&lt;domain&gt; DNS records for each mail domain, pointing at this server. These are address records, and this page checks TXT records only, so they cannot be confirmed from here." xml:space="preserve">
+    <value>Aseta HTTP- tai HTTPS-portti sivulla Verkkopalvelut ja automaattinen määritys-tiedostossa, jotta URL-osoitteet vastaavat, ja julkaise sitten jokaiselle postiverkkotunnukselle autoconfig.&lt;domain&gt;- ja autodiscover.&lt;domain&gt;-DNS-tietueet, jotka osoittavat tähän palvelimeen. Nämä ovat osoitetietueita, ja tämä sivu tarkistaa vain TXT-tietueet, joten niitä ei voi vahvistaa täältä.</value>
+  </data>
+  <data name="Set the HTTPS port on the Web services &amp; autoconfiguration page (RFC 8461 requires the policy over HTTPS), give the listener a certificate that covers mta-sts.&lt;domain&gt;, then for each domain publish an A/AAAA (or CNAME) record for mta-sts.&lt;domain&gt; pointing at this server and a TXT record at _mta-sts.&lt;domain&gt; (v=STSv1; id=...). This page checks the TXT record; the address record and the certificate's name coverage cannot be checked from here." xml:space="preserve">
+    <value>Aseta HTTPS-portti sivulla Verkkopalvelut ja automaattinen määritys-tiedostossa (RFC 8461 vaatii käytännön HTTPS:n yli), anna kuuntelijalle varmenne, joka kattaa nimen mta-sts.&lt;domain&gt;, ja julkaise sitten jokaiselle verkkotunnukselle A/AAAA-tietue (tai CNAME) nimelle mta-sts.&lt;domain&gt;, joka osoittaa tähän palvelimeen, sekä TXT-tietue osoitteeseen _mta-sts.&lt;domain&gt; (v=STSv1; id=...). Tämä sivu tarkistaa TXT-tietueen; osoitetietuetta ja varmenteen nimikattavuutta ei voi tarkistaa täältä.</value>
   </data>
   <data name="Set the SMTP relayer, and its credentials if the provider needs them." xml:space="preserve">
     <value>Aseta SMTP-välittäjä ja sen tunnistetiedot, jos palveluntarjoaja niitä tarvitsee.</value>

--- a/hmailserver/source/Tools/ControlPanel/Resources/Strings.fr.resx
+++ b/hmailserver/source/Tools/ControlPanel/Resources/Strings.fr.resx
@@ -2917,8 +2917,8 @@ Aucun courrier n'est touché - l'index en est dérivé - mais jusqu'à ce que la
   <data name="Enter a valid port number." xml:space="preserve">
     <value>Saisissez un numéro de port valide.</value>
   </data>
-  <data name="Enter an address and search. The trace records nothing at all unless MessageTraceEnabled is set in hMailServer.ini - it is off by default because it stores who corresponds with whom." xml:space="preserve">
-    <value>Saisissez une adresse et cherchez. La trace n'enregistre rien du tout tant que MessageTraceEnabled n'est pas défini dans hMailServer.ini - elle est désactivée par défaut parce qu'elle stocke qui correspond avec qui.</value>
+  <data name="Enter an address and search. The trace records nothing at all until message tracing is switched on, on the Logging page - it is off by default because it stores who corresponds with whom." xml:space="preserve">
+    <value>Saisissez une adresse et lancez la recherche. La trace n'enregistre rien tant que le traçage des messages n'est pas activé sur la page Journalisation – il est désactivé par défaut car il conserve qui correspond avec qui.</value>
   </data>
   <data name="Enter part of a name and press Search, or search with an empty box to list all users." xml:space="preserve">
     <value>Saisissez une partie d'un nom et appuyez sur Rechercher, ou cherchez avec une case vide pour lister tous les utilisateurs.</value>
@@ -3438,6 +3438,9 @@ Aucun courrier n'est touché - l'index en est dérivé - mais jusqu'à ce que la
   </data>
   <data name="Host/Name:  {0}" xml:space="preserve">
     <value>Hôte/Nom :  {0}</value>
+  </data>
+  <data name="Hosted domain" xml:space="preserve">
+    <value>Domaine hébergé</value>
   </data>
   <data name="Hours between checks (1 to 168)" xml:space="preserve">
     <value>Heures entre les recherches (1 à 168)</value>
@@ -4554,8 +4557,8 @@ L'installateur vérifié est remis à l'assistant de mise à jour : le service s
   <data name="No encryption is available on this port. Inbound mail from other servers is normally unencrypted anyway, but this port also accepts AUTH, and a client using it sends its password in the clear." xml:space="preserve">
     <value>Aucun chiffrement n'est disponible sur ce port. Le courrier entrant venant d'autres serveurs est de toute façon normalement non chiffré, mais ce port accepte aussi AUTH, et un client qui l'utilise envoie son mot de passe en clair.</value>
   </data>
-  <data name="No events for that address. Either nothing has happened to it, or the trace was switched off at the time - it records only while MessageTraceEnabled is set." xml:space="preserve">
-    <value>Aucun événement pour cette adresse. Soit rien ne lui est arrivé, soit la trace était désactivée à ce moment-là - elle n'enregistre que tant que MessageTraceEnabled est défini.</value>
+  <data name="No events for that address. Either nothing has happened to it, or the trace was switched off at the time - it records only while message tracing is on (Logging page)." xml:space="preserve">
+    <value>Aucun événement pour cette adresse. Soit rien ne lui est arrivé, soit la trace était désactivée à ce moment-là – elle n'enregistre que lorsque le traçage des messages est activé (page Journalisation).</value>
   </data>
   <data name="No events for that message." xml:space="preserve">
     <value>Aucun événement pour ce message.</value>
@@ -4710,8 +4713,8 @@ L'installateur vérifié est remis à l'assistant de mise à jour : le service s
   <data name="Not checked from here, honestly: verifying the PTR needs the server's PUBLIC IP address, which this panel cannot determine (behind NAT the machine does not know it either), and this page's checker reads TXT records only. Test from outside instead: nslookup &lt;your public IP&gt; shows the PTR; it should name the host above." xml:space="preserve">
     <value>Pas vérifié d'ici, en toute franchise : vérifier le PTR nécessite l'adresse IP PUBLIQUE du serveur, que ce panneau ne peut pas déterminer (derrière un NAT, la machine ne la connaît pas non plus), et le vérificateur de cette page ne lit que les enregistrements TXT. Testez plutôt depuis l'extérieur : nslookup &lt;your public IP&gt; affiche le PTR ; il devrait nommer l'hôte ci-dessus.</value>
   </data>
-  <data name="Not checked yet (Check for updates, or UpdateCheckEnabled=1 in hMailServer.INI for a daily check)" xml:space="preserve">
-    <value>Pas encore vérifié (Rechercher les mises à jour, ou UpdateCheckEnabled=1 dans hMailServer.INI pour une vérification quotidienne)</value>
+  <data name="Not checked yet (Check for updates, or turn on the daily check under Updates on the API &amp; monitoring page)" xml:space="preserve">
+    <value>Pas encore vérifié (Rechercher des mises à jour, ou activez la vérification quotidienne sous Mises à jour sur la page API et supervision)</value>
   </data>
   <data name="Not checked yet. Publish the record, allow time for propagation, then press &quot;Check DNS&quot;." xml:space="preserve">
     <value>Pas encore vérifié. Publiez l'enregistrement, laissez le temps à la propagation, puis appuyez sur « Vérifier le DNS ».</value>
@@ -4758,11 +4761,14 @@ L'installateur vérifié est remis à l'assistant de mise à jour : le service s
   <data name="Nothing here needs a decision: no mailbox is being skipped and none is being disabled." xml:space="preserve">
     <value>Rien ici ne demande de décision : aucune boîte n'est ignorée et aucune n'est désactivée.</value>
   </data>
+  <data name="Nothing here yet - Add creates the first entry." xml:space="preserve">
+    <value>Rien ici pour l'instant – Ajouter crée la première entrée.</value>
+  </data>
   <data name="Nothing is ever marked as spam: marking needs a mark threshold above 0, and a 0 there means &quot;never&quot; rather than &quot;always&quot;. Messages reaching {0} are still refused." xml:space="preserve">
     <value>Rien n'est jamais marqué comme spam : le marquage nécessite un seuil de marquage supérieur à 0, et un 0 signifie ici « jamais » plutôt que « toujours ». Les messages atteignant {0} sont tout de même refusés.</value>
   </data>
-  <data name="Nothing is held. Quarantining is off unless QuarantineEnabled is set in hMailServer.ini - until then, spam over the delete threshold is refused during the SMTP conversation rather than stored." xml:space="preserve">
-    <value>Rien n'est retenu. La mise en quarantaine est désactivée tant que QuarantineEnabled n'est pas défini dans hMailServer.ini - jusque-là, le spam au-dessus du seuil de suppression est refusé pendant la conversation SMTP plutôt que stocké.</value>
+  <data name="Nothing is held. Quarantining is switched off - turn it on under Anti-spam settings - and until it is on, spam over the delete threshold is refused during the SMTP conversation rather than stored." xml:space="preserve">
+    <value>Rien n'est retenu. La quarantaine est désactivée – activez-la dans Réglages anti-spam – et tant qu'elle ne l'est pas, le spam au-dessus du seuil de suppression est refusé pendant la conversation SMTP au lieu d'être stocké.</value>
   </data>
   <data name="Nothing matched &quot;{0}&quot;. Try what you are trying to achieve (&quot;stop spam&quot;, &quot;let a device send mail&quot;), a page name, or an hMailServer.INI key." xml:space="preserve">
     <value>Rien ne correspond à « {0} ». Essayez ce que vous cherchez à obtenir (« arrêter le spam », « permettre à un appareil d'envoyer du courrier »), un nom de page, ou une clé de hMailServer.INI.</value>
@@ -5749,6 +5755,9 @@ Exécutez ceci si des clients signalent des messages apparaissant sous le mauvai
   <data name="Remember this many previous passwords (0 = no history)" xml:space="preserve">
     <value>Mémoriser ce nombre de mots de passe précédents (0 = pas d'historique)</value>
   </data>
+  <data name="Remote domain" xml:space="preserve">
+    <value>Domaine distant</value>
+  </data>
   <data name="Remove _expired" xml:space="preserve">
     <value>Supprimer les _expirés</value>
   </data>
@@ -6708,12 +6717,6 @@ Continuer ?</value>
   <data name="Set TlsRptFromAddress in the [Settings] section of hMailServer.ini to a mailbox reports should be sent from. Leaving it empty is a valid choice - it just means the collected statistics are discarded and no reports are ever sent." xml:space="preserve">
     <value>Définissez TlsRptFromAddress dans la section [Settings] de hMailServer.ini sur une boîte depuis laquelle les rapports doivent être envoyés. Le laisser vide est un choix valable - cela signifie simplement que les statistiques collectées sont jetées et qu'aucun rapport n'est jamais envoyé.</value>
   </data>
-  <data name="Set WebServicesHttpPort and/or WebServicesHttpsPort in hMailServer.ini so the URLs answer, then publish autoconfig.&lt;domain&gt; and autodiscover.&lt;domain&gt; DNS records for each mail domain, pointing at this server. These are address records, and this page checks TXT records only, so they cannot be confirmed from here." xml:space="preserve">
-    <value>Définissez WebServicesHttpPort et/ou WebServicesHttpsPort dans hMailServer.ini pour que les URL répondent, puis publiez des enregistrements DNS autoconfig.&lt;domain&gt; et autodiscover.&lt;domain&gt; pour chaque domaine de messagerie, pointant vers ce serveur. Ce sont des enregistrements d'adresse, et cette page ne vérifie que les enregistrements TXT : ils ne peuvent donc pas être confirmés d'ici.</value>
-  </data>
-  <data name="Set WebServicesHttpsPort in hMailServer.ini (RFC 8461 requires the policy over HTTPS), give the listener a certificate that covers mta-sts.&lt;domain&gt;, then for each domain publish an A/AAAA (or CNAME) record for mta-sts.&lt;domain&gt; pointing at this server and a TXT record at _mta-sts.&lt;domain&gt; (v=STSv1; id=...). This page checks the TXT record; the address record and the certificate's name coverage cannot be checked from here." xml:space="preserve">
-    <value>Définissez WebServicesHttpsPort dans hMailServer.ini (la RFC 8461 exige la politique via HTTPS), donnez à l'écouteur un certificat qui couvre mta-sts.&lt;domain&gt;, puis, pour chaque domaine, publiez un enregistrement A/AAAA (ou CNAME) pour mta-sts.&lt;domain&gt; pointant vers ce serveur et un enregistrement TXT à _mta-sts.&lt;domain&gt; (v=STSv1; id=...). Cette page vérifie l'enregistrement TXT ; l'enregistrement d'adresse et la couverture du nom par le certificat ne peuvent pas être vérifiés d'ici.</value>
-  </data>
   <data name="Set a new server administration password." xml:space="preserve">
     <value>Définir un nouveau mot de passe d'administration du serveur.</value>
   </data>
@@ -6725,6 +6728,12 @@ Continuer ?</value>
   </data>
   <data name="Set header value" xml:space="preserve">
     <value>Définir la valeur d'un en-tête</value>
+  </data>
+  <data name="Set the HTTP or HTTPS port on the Web services &amp; autoconfiguration page so the URLs answer, then publish autoconfig.&lt;domain&gt; and autodiscover.&lt;domain&gt; DNS records for each mail domain, pointing at this server. These are address records, and this page checks TXT records only, so they cannot be confirmed from here." xml:space="preserve">
+    <value>Définissez le port HTTP ou HTTPS sur la page Services web et autoconfiguration pour que les URL répondent, puis publiez des enregistrements DNS autoconfig.&lt;domain&gt; et autodiscover.&lt;domain&gt; pour chaque domaine de messagerie, pointant vers ce serveur. Ce sont des enregistrements d'adresse, et cette page ne vérifie que les enregistrements TXT : ils ne peuvent donc pas être confirmés d'ici.</value>
+  </data>
+  <data name="Set the HTTPS port on the Web services &amp; autoconfiguration page (RFC 8461 requires the policy over HTTPS), give the listener a certificate that covers mta-sts.&lt;domain&gt;, then for each domain publish an A/AAAA (or CNAME) record for mta-sts.&lt;domain&gt; pointing at this server and a TXT record at _mta-sts.&lt;domain&gt; (v=STSv1; id=...). This page checks the TXT record; the address record and the certificate's name coverage cannot be checked from here." xml:space="preserve">
+    <value>Définissez le port HTTPS sur la page Services web et autoconfiguration (la RFC 8461 exige la politique via HTTPS), donnez à l'écouteur un certificat qui couvre mta-sts.&lt;domain&gt;, puis, pour chaque domaine, publiez un enregistrement A/AAAA (ou CNAME) pour mta-sts.&lt;domain&gt; pointant vers ce serveur et un enregistrement TXT à _mta-sts.&lt;domain&gt; (v=STSv1; id=...). Cette page vérifie l'enregistrement TXT ; l'enregistrement d'adresse et la couverture du nom par le certificat ne peuvent pas être vérifiés d'ici.</value>
   </data>
   <data name="Set the SMTP relayer, and its credentials if the provider needs them." xml:space="preserve">
     <value>Définissez le relayeur SMTP, et ses identifiants si le fournisseur en a besoin.</value>

--- a/hmailserver/source/Tools/ControlPanel/Resources/Strings.it.resx
+++ b/hmailserver/source/Tools/ControlPanel/Resources/Strings.it.resx
@@ -2917,8 +2917,8 @@ Nessuna posta viene toccata - l'indice ne è derivato - ma finché la ricostruzi
   <data name="Enter a valid port number." xml:space="preserve">
     <value>Indica un numero di porta valido.</value>
   </data>
-  <data name="Enter an address and search. The trace records nothing at all unless MessageTraceEnabled is set in hMailServer.ini - it is off by default because it stores who corresponds with whom." xml:space="preserve">
-    <value>Indica un indirizzo e cerca. Il tracciamento non registra assolutamente nulla a meno che MessageTraceEnabled non sia impostato in hMailServer.ini - è disattivato per impostazione predefinita perché memorizza chi corrisponde con chi.</value>
+  <data name="Enter an address and search. The trace records nothing at all until message tracing is switched on, on the Logging page - it is off by default because it stores who corresponds with whom." xml:space="preserve">
+    <value>Inserisci un indirizzo e cerca. La traccia non registra nulla finché il tracciamento dei messaggi non viene attivato nella pagina Registrazione – è disattivato per impostazione predefinita perché memorizza chi corrisponde con chi.</value>
   </data>
   <data name="Enter part of a name and press Search, or search with an empty box to list all users." xml:space="preserve">
     <value>Indica una parte di un nome e premi Cerca, oppure cerca con la casella vuota per elencare tutti gli utenti.</value>
@@ -3438,6 +3438,9 @@ Nessuna posta viene toccata - l'indice ne è derivato - ma finché la ricostruzi
   </data>
   <data name="Host/Name:  {0}" xml:space="preserve">
     <value>Host/Nome:  {0}</value>
+  </data>
+  <data name="Hosted domain" xml:space="preserve">
+    <value>Dominio ospitato</value>
   </data>
   <data name="Hours between checks (1 to 168)" xml:space="preserve">
     <value>Ore tra i controlli (da 1 a 168)</value>
@@ -4554,8 +4557,8 @@ Il programma di installazione verificato viene passato all'helper di aggiornamen
   <data name="No encryption is available on this port. Inbound mail from other servers is normally unencrypted anyway, but this port also accepts AUTH, and a client using it sends its password in the clear." xml:space="preserve">
     <value>Su questa porta non è disponibile alcuna cifratura. La posta in ingresso da altri server è comunque normalmente non cifrata, ma questa porta accetta anche AUTH, e un client che la usa invia la propria password in chiaro.</value>
   </data>
-  <data name="No events for that address. Either nothing has happened to it, or the trace was switched off at the time - it records only while MessageTraceEnabled is set." xml:space="preserve">
-    <value>Nessun evento per quell'indirizzo. O non gli è successo nulla, oppure il tracciamento era disattivato in quel momento - registra solo mentre MessageTraceEnabled è impostato.</value>
+  <data name="No events for that address. Either nothing has happened to it, or the trace was switched off at the time - it records only while message tracing is on (Logging page)." xml:space="preserve">
+    <value>Nessun evento per quell'indirizzo. O non gli è successo nulla, o la traccia era disattivata in quel momento – registra solo mentre il tracciamento dei messaggi è attivo (pagina Registrazione).</value>
   </data>
   <data name="No events for that message." xml:space="preserve">
     <value>Nessun evento per quel messaggio.</value>
@@ -4710,8 +4713,8 @@ Il programma di installazione verificato viene passato all'helper di aggiornamen
   <data name="Not checked from here, honestly: verifying the PTR needs the server's PUBLIC IP address, which this panel cannot determine (behind NAT the machine does not know it either), and this page's checker reads TXT records only. Test from outside instead: nslookup &lt;your public IP&gt; shows the PTR; it should name the host above." xml:space="preserve">
     <value>Onestamente, non verificato da qui: verificare il PTR richiede l'indirizzo IP PUBBLICO del server, che questo pannello non può determinare (dietro NAT nemmeno la macchina lo conosce), e il verificatore di questa pagina legge solo i record TXT. Conviene invece provare dall'esterno: nslookup &lt;your public IP&gt; mostra il PTR; dovrebbe indicare l'host qui sopra.</value>
   </data>
-  <data name="Not checked yet (Check for updates, or UpdateCheckEnabled=1 in hMailServer.INI for a daily check)" xml:space="preserve">
-    <value>Non ancora verificato ("Verifica aggiornamenti", oppure UpdateCheckEnabled=1 in hMailServer.INI per un controllo giornaliero)</value>
+  <data name="Not checked yet (Check for updates, or turn on the daily check under Updates on the API &amp; monitoring page)" xml:space="preserve">
+    <value>Non ancora controllato (Controlla aggiornamenti, oppure attiva il controllo giornaliero in Aggiornamenti nella pagina API e monitoraggio)</value>
   </data>
   <data name="Not checked yet. Publish the record, allow time for propagation, then press &quot;Check DNS&quot;." xml:space="preserve">
     <value>Non ancora verificato. Pubblicare il record, lasciare il tempo per la propagazione, poi premere "Verifica DNS".</value>
@@ -4758,11 +4761,14 @@ Il programma di installazione verificato viene passato all'helper di aggiornamen
   <data name="Nothing here needs a decision: no mailbox is being skipped and none is being disabled." xml:space="preserve">
     <value>Qui non serve alcuna decisione: nessuna casella viene saltata e nessuna viene disattivata.</value>
   </data>
+  <data name="Nothing here yet - Add creates the first entry." xml:space="preserve">
+    <value>Ancora nulla qui – Aggiungi crea la prima voce.</value>
+  </data>
   <data name="Nothing is ever marked as spam: marking needs a mark threshold above 0, and a 0 there means &quot;never&quot; rather than &quot;always&quot;. Messages reaching {0} are still refused." xml:space="preserve">
     <value>Nulla viene mai contrassegnato come spam: il contrassegno richiede una soglia di contrassegno superiore a 0, e uno 0 lì significa "mai" e non "sempre". I messaggi che raggiungono {0} vengono comunque rifiutati.</value>
   </data>
-  <data name="Nothing is held. Quarantining is off unless QuarantineEnabled is set in hMailServer.ini - until then, spam over the delete threshold is refused during the SMTP conversation rather than stored." xml:space="preserve">
-    <value>Nulla viene trattenuto. La quarantena è disattivata a meno che QuarantineEnabled non sia impostato in hMailServer.ini - fino ad allora, lo spam oltre la soglia di eliminazione viene rifiutato durante la conversazione SMTP anziché essere memorizzato.</value>
+  <data name="Nothing is held. Quarantining is switched off - turn it on under Anti-spam settings - and until it is on, spam over the delete threshold is refused during the SMTP conversation rather than stored." xml:space="preserve">
+    <value>Nulla è trattenuto. La quarantena è disattivata – attivala in Impostazioni antispam – e finché non lo è, lo spam oltre la soglia di eliminazione viene rifiutato durante la conversazione SMTP invece di essere archiviato.</value>
   </data>
   <data name="Nothing matched &quot;{0}&quot;. Try what you are trying to achieve (&quot;stop spam&quot;, &quot;let a device send mail&quot;), a page name, or an hMailServer.INI key." xml:space="preserve">
     <value>Nessuna corrispondenza per "{0}". Conviene provare con l'obiettivo da raggiungere ("bloccare lo spam", "far inviare posta a un dispositivo"), con il nome di una pagina, oppure con una chiave di hMailServer.INI.</value>
@@ -5749,6 +5755,9 @@ Esegui questa operazione se i client segnalano messaggi che compaiono con l'UID 
   <data name="Remember this many previous passwords (0 = no history)" xml:space="preserve">
     <value>Ricorda questo numero di password precedenti (0 = nessuno storico)</value>
   </data>
+  <data name="Remote domain" xml:space="preserve">
+    <value>Dominio remoto</value>
+  </data>
   <data name="Remove _expired" xml:space="preserve">
     <value>Rimuovi gli _scaduti</value>
   </data>
@@ -6708,12 +6717,6 @@ Continuare?</value>
   <data name="Set TlsRptFromAddress in the [Settings] section of hMailServer.ini to a mailbox reports should be sent from. Leaving it empty is a valid choice - it just means the collected statistics are discarded and no reports are ever sent." xml:space="preserve">
     <value>Imposta TlsRptFromAddress nella sezione [Settings] di hMailServer.ini su una casella da cui inviare i rapporti. Lasciarlo vuoto è una scelta valida - significa solo che le statistiche raccolte vengono scartate e nessun rapporto viene mai inviato.</value>
   </data>
-  <data name="Set WebServicesHttpPort and/or WebServicesHttpsPort in hMailServer.ini so the URLs answer, then publish autoconfig.&lt;domain&gt; and autodiscover.&lt;domain&gt; DNS records for each mail domain, pointing at this server. These are address records, and this page checks TXT records only, so they cannot be confirmed from here." xml:space="preserve">
-    <value>Imposta WebServicesHttpPort e/o WebServicesHttpsPort in hMailServer.ini perché gli URL rispondano, poi pubblica per ogni dominio di posta i record DNS autoconfig.&lt;domain&gt; e autodiscover.&lt;domain&gt; che puntano a questo server. Sono record di indirizzo, e questa pagina controlla solo i record TXT, quindi da qui non possono essere confermati.</value>
-  </data>
-  <data name="Set WebServicesHttpsPort in hMailServer.ini (RFC 8461 requires the policy over HTTPS), give the listener a certificate that covers mta-sts.&lt;domain&gt;, then for each domain publish an A/AAAA (or CNAME) record for mta-sts.&lt;domain&gt; pointing at this server and a TXT record at _mta-sts.&lt;domain&gt; (v=STSv1; id=...). This page checks the TXT record; the address record and the certificate's name coverage cannot be checked from here." xml:space="preserve">
-    <value>Imposta WebServicesHttpsPort in hMailServer.ini (la RFC 8461 richiede il criterio via HTTPS), assegna al listener un certificato che copra mta-sts.&lt;domain&gt;, poi per ogni dominio pubblica un record A/AAAA (o CNAME) per mta-sts.&lt;domain&gt; che punta a questo server e un record TXT su _mta-sts.&lt;domain&gt; (v=STSv1; id=...). Questa pagina controlla il record TXT; il record di indirizzo e la copertura del nome da parte del certificato non possono essere verificati da qui.</value>
-  </data>
   <data name="Set a new server administration password." xml:space="preserve">
     <value>Imposta una nuova password di amministrazione del server.</value>
   </data>
@@ -6725,6 +6728,12 @@ Continuare?</value>
   </data>
   <data name="Set header value" xml:space="preserve">
     <value>Imposta il valore dell'intestazione</value>
+  </data>
+  <data name="Set the HTTP or HTTPS port on the Web services &amp; autoconfiguration page so the URLs answer, then publish autoconfig.&lt;domain&gt; and autodiscover.&lt;domain&gt; DNS records for each mail domain, pointing at this server. These are address records, and this page checks TXT records only, so they cannot be confirmed from here." xml:space="preserve">
+    <value>Imposta la porta HTTP o HTTPS nella pagina Servizi web e configurazione automatica perché gli URL rispondano, poi pubblica per ogni dominio di posta i record DNS autoconfig.&lt;domain&gt; e autodiscover.&lt;domain&gt; che puntano a questo server. Sono record di indirizzo, e questa pagina controlla solo i record TXT, quindi da qui non possono essere confermati.</value>
+  </data>
+  <data name="Set the HTTPS port on the Web services &amp; autoconfiguration page (RFC 8461 requires the policy over HTTPS), give the listener a certificate that covers mta-sts.&lt;domain&gt;, then for each domain publish an A/AAAA (or CNAME) record for mta-sts.&lt;domain&gt; pointing at this server and a TXT record at _mta-sts.&lt;domain&gt; (v=STSv1; id=...). This page checks the TXT record; the address record and the certificate's name coverage cannot be checked from here." xml:space="preserve">
+    <value>Imposta la porta HTTPS nella pagina Servizi web e configurazione automatica (la RFC 8461 richiede il criterio via HTTPS), assegna al listener un certificato che copra mta-sts.&lt;domain&gt;, poi per ogni dominio pubblica un record A/AAAA (o CNAME) per mta-sts.&lt;domain&gt; che punta a questo server e un record TXT su _mta-sts.&lt;domain&gt; (v=STSv1; id=...). Questa pagina controlla il record TXT; il record di indirizzo e la copertura del nome da parte del certificato non possono essere verificati da qui.</value>
   </data>
   <data name="Set the SMTP relayer, and its credentials if the provider needs them." xml:space="preserve">
     <value>Imposta il relayer SMTP e, se il provider le richiede, le sue credenziali.</value>

--- a/hmailserver/source/Tools/ControlPanel/Resources/Strings.ja.resx
+++ b/hmailserver/source/Tools/ControlPanel/Resources/Strings.ja.resx
@@ -2917,8 +2917,8 @@
   <data name="Enter a valid port number." xml:space="preserve">
     <value>有効なポート番号を入力してください。</value>
   </data>
-  <data name="Enter an address and search. The trace records nothing at all unless MessageTraceEnabled is set in hMailServer.ini - it is off by default because it stores who corresponds with whom." xml:space="preserve">
-    <value>アドレスを入力して検索してください。hMailServer.ini で MessageTraceEnabled が設定されていない限り、トレースは何も記録しません。誰と誰がやり取りしているかを保存するため、既定ではオフになっています。</value>
+  <data name="Enter an address and search. The trace records nothing at all until message tracing is switched on, on the Logging page - it is off by default because it stores who corresponds with whom." xml:space="preserve">
+    <value>アドレスを入力して検索してください。メッセージ トレースはログ ページでオンにするまで何も記録しません。誰と誰がやり取りしたかを保存するため、既定ではオフになっています。</value>
   </data>
   <data name="Enter part of a name and press Search, or search with an empty box to list all users." xml:space="preserve">
     <value>名前の一部を入力して「検索」を押すか、空のまま検索してすべてのユーザーを一覧表示してください。</value>
@@ -3438,6 +3438,9 @@
   </data>
   <data name="Host/Name:  {0}" xml:space="preserve">
     <value>ホスト/名前:  {0}</value>
+  </data>
+  <data name="Hosted domain" xml:space="preserve">
+    <value>ホストしているドメイン</value>
   </data>
   <data name="Hours between checks (1 to 168)" xml:space="preserve">
     <value>チェックの間隔 (時間、1 から 168)</value>
@@ -4554,8 +4557,8 @@
   <data name="No encryption is available on this port. Inbound mail from other servers is normally unencrypted anyway, but this port also accepts AUTH, and a client using it sends its password in the clear." xml:space="preserve">
     <value>このポートでは暗号化が利用できません。ほかのサーバーからの受信メールはもともと暗号化されていないのが普通ですが、このポートは AUTH も受け付けるため、それを使うクライアントはパスワードを平文で送信します。</value>
   </data>
-  <data name="No events for that address. Either nothing has happened to it, or the trace was switched off at the time - it records only while MessageTraceEnabled is set." xml:space="preserve">
-    <value>そのアドレスのイベントはありません。何も起きていないか、その時点でトレースがオフだったかのどちらかです。トレースは MessageTraceEnabled が設定されている間だけ記録します。</value>
+  <data name="No events for that address. Either nothing has happened to it, or the trace was switched off at the time - it records only while message tracing is on (Logging page)." xml:space="preserve">
+    <value>そのアドレスのイベントはありません。何も起きていないか、当時トレースがオフだったかのどちらかです。メッセージ トレースがオンの間だけ記録されます (ログ ページ)。</value>
   </data>
   <data name="No events for that message." xml:space="preserve">
     <value>そのメッセージのイベントはありません。</value>
@@ -4710,8 +4713,8 @@
   <data name="Not checked from here, honestly: verifying the PTR needs the server's PUBLIC IP address, which this panel cannot determine (behind NAT the machine does not know it either), and this page's checker reads TXT records only. Test from outside instead: nslookup &lt;your public IP&gt; shows the PTR; it should name the host above." xml:space="preserve">
     <value>正直に言って、ここからは確認していません: PTR の検証にはサーバーの「公開」IP アドレスが必要ですが、このパネルはそれを特定できず (NAT の背後ではコンピューター自身も知りません)、このページのチェッカーは TXT レコードしか読み取りません。代わりに外部からテストしてください: nslookup &lt;あなたの公開 IP&gt; で PTR が表示され、上のホスト名を指しているはずです。</value>
   </data>
-  <data name="Not checked yet (Check for updates, or UpdateCheckEnabled=1 in hMailServer.INI for a daily check)" xml:space="preserve">
-    <value>まだ確認していません (「更新プログラムを確認」を実行するか、毎日確認するには hMailServer.INI で UpdateCheckEnabled=1 を設定)</value>
+  <data name="Not checked yet (Check for updates, or turn on the daily check under Updates on the API &amp; monitoring page)" xml:space="preserve">
+    <value>未確認です (更新プログラムを確認するか、API と監視ページの更新プログラムで毎日の確認をオンにしてください)</value>
   </data>
   <data name="Not checked yet. Publish the record, allow time for propagation, then press &quot;Check DNS&quot;." xml:space="preserve">
     <value>まだ確認していません。レコードを公開し、伝播の時間を置いてから「DNS を確認」を押してください。</value>
@@ -4758,11 +4761,14 @@
   <data name="Nothing here needs a decision: no mailbox is being skipped and none is being disabled." xml:space="preserve">
     <value>ここで決めることは何もありません: スキップされるメールボックスも、無効化されるメールボックスもありません。</value>
   </data>
+  <data name="Nothing here yet - Add creates the first entry." xml:space="preserve">
+    <value>まだ何もありません。追加で最初の項目を作成します。</value>
+  </data>
   <data name="Nothing is ever marked as spam: marking needs a mark threshold above 0, and a 0 there means &quot;never&quot; rather than &quot;always&quot;. Messages reaching {0} are still refused." xml:space="preserve">
     <value>スパムとしてマークされるものはありません: マークにはマークしきい値が 0 より大きい必要があり、そこでの 0 は「常に」ではなく「決してしない」を意味します。{0} に達したメッセージは引き続き拒否されます。</value>
   </data>
-  <data name="Nothing is held. Quarantining is off unless QuarantineEnabled is set in hMailServer.ini - until then, spam over the delete threshold is refused during the SMTP conversation rather than stored." xml:space="preserve">
-    <value>何も保留されていません。hMailServer.ini で QuarantineEnabled が設定されていない限り検疫はオフで、それまでは削除しきい値を超えたスパムは保存されるのではなく SMTP のやり取り中に拒否されます。</value>
+  <data name="Nothing is held. Quarantining is switched off - turn it on under Anti-spam settings - and until it is on, spam over the delete threshold is refused during the SMTP conversation rather than stored." xml:space="preserve">
+    <value>保留中のメッセージはありません。検疫はオフです。スパム対策の設定でオンにしてください。オンになるまで、削除しきい値を超えるスパムは保存されず、SMTP セッション中に拒否されます。</value>
   </data>
   <data name="Nothing matched &quot;{0}&quot;. Try what you are trying to achieve (&quot;stop spam&quot;, &quot;let a device send mail&quot;), a page name, or an hMailServer.INI key." xml:space="preserve">
     <value>"{0}" に一致するものはありません。達成したいこと (「スパムを止める」「機器にメールを送らせる」)、ページ名、または hMailServer.INI のキーで試してください。</value>
@@ -5749,6 +5755,9 @@
   <data name="Remember this many previous passwords (0 = no history)" xml:space="preserve">
     <value>記憶する過去のパスワードの数 (0 = 履歴なし)</value>
   </data>
+  <data name="Remote domain" xml:space="preserve">
+    <value>リモート ドメイン</value>
+  </data>
   <data name="Remove _expired" xml:space="preserve">
     <value>期限切れを削除(_E)</value>
   </data>
@@ -6708,12 +6717,6 @@ SMTP 25 と 587、POP3 110、IMAP 143 で、接続のセキュリティはあり
   <data name="Set TlsRptFromAddress in the [Settings] section of hMailServer.ini to a mailbox reports should be sent from. Leaving it empty is a valid choice - it just means the collected statistics are discarded and no reports are ever sent." xml:space="preserve">
     <value>hMailServer.ini の [Settings] セクションで TlsRptFromAddress を、レポートの送信元にするメールボックスに設定してください。空のままにするのも有効な選択です。収集した統計が破棄され、レポートが送信されないというだけです。</value>
   </data>
-  <data name="Set WebServicesHttpPort and/or WebServicesHttpsPort in hMailServer.ini so the URLs answer, then publish autoconfig.&lt;domain&gt; and autodiscover.&lt;domain&gt; DNS records for each mail domain, pointing at this server. These are address records, and this page checks TXT records only, so they cannot be confirmed from here." xml:space="preserve">
-    <value>hMailServer.ini で WebServicesHttpPort と WebServicesHttpsPort のいずれかまたは両方を設定して URL が応答するようにし、次に各メール ドメインについて、このサーバーを指す autoconfig.&lt;domain&gt; と autodiscover.&lt;domain&gt; の DNS レコードを公開してください。これらはアドレス レコードであり、このページは TXT レコードしか確認しないため、ここからは確認できません。</value>
-  </data>
-  <data name="Set WebServicesHttpsPort in hMailServer.ini (RFC 8461 requires the policy over HTTPS), give the listener a certificate that covers mta-sts.&lt;domain&gt;, then for each domain publish an A/AAAA (or CNAME) record for mta-sts.&lt;domain&gt; pointing at this server and a TXT record at _mta-sts.&lt;domain&gt; (v=STSv1; id=...). This page checks the TXT record; the address record and the certificate's name coverage cannot be checked from here." xml:space="preserve">
-    <value>hMailServer.ini で WebServicesHttpsPort を設定し (RFC 8461 はポリシーを HTTPS で提供することを要求します)、リスナーに mta-sts.&lt;domain&gt; をカバーする証明書を与え、次に各ドメインについて、このサーバーを指す mta-sts.&lt;domain&gt; の A/AAAA (または CNAME) レコードと、mta-sts.&lt;domain&gt; の TXT レコード (v=STSv1; id=...) を公開してください。このページは TXT レコードを確認します。アドレス レコードと証明書の名前のカバー範囲はここからは確認できません。(_M)</value>
-  </data>
   <data name="Set a new server administration password." xml:space="preserve">
     <value>新しいサーバー管理パスワードを設定します。</value>
   </data>
@@ -6725,6 +6728,12 @@ SMTP 25 と 587、POP3 110、IMAP 143 で、接続のセキュリティはあり
   </data>
   <data name="Set header value" xml:space="preserve">
     <value>ヘッダー値を設定</value>
+  </data>
+  <data name="Set the HTTP or HTTPS port on the Web services &amp; autoconfiguration page so the URLs answer, then publish autoconfig.&lt;domain&gt; and autodiscover.&lt;domain&gt; DNS records for each mail domain, pointing at this server. These are address records, and this page checks TXT records only, so they cannot be confirmed from here." xml:space="preserve">
+    <value>URL が応答するように、Web サービスと自動設定ページで HTTP または HTTPS ポートを設定し、次に各メール ドメインについて、このサーバーを指す autoconfig.&lt;domain&gt; と autodiscover.&lt;domain&gt; の DNS レコードを公開してください。これらはアドレス レコードであり、このページは TXT レコードのみを確認するため、ここからは確認できません。</value>
+  </data>
+  <data name="Set the HTTPS port on the Web services &amp; autoconfiguration page (RFC 8461 requires the policy over HTTPS), give the listener a certificate that covers mta-sts.&lt;domain&gt;, then for each domain publish an A/AAAA (or CNAME) record for mta-sts.&lt;domain&gt; pointing at this server and a TXT record at _mta-sts.&lt;domain&gt; (v=STSv1; id=...). This page checks the TXT record; the address record and the certificate's name coverage cannot be checked from here." xml:space="preserve">
+    <value>Web サービスと自動設定ページで HTTPS ポートを設定し (RFC 8461 はポリシーを HTTPS で提供することを要求します)、リスナーに mta-sts.&lt;domain&gt; をカバーする証明書を与え、次に各ドメインについて、このサーバーを指す mta-sts.&lt;domain&gt; の A/AAAA (または CNAME) レコードと、_mta-sts.&lt;domain&gt; の TXT レコード (v=STSv1; id=...) を公開してください。このページは TXT レコードを確認します。アドレス レコードと証明書の名前のカバー範囲はここからは確認できません。</value>
   </data>
   <data name="Set the SMTP relayer, and its credentials if the provider needs them." xml:space="preserve">
     <value>SMTP リレーと、プロバイダーが必要とする場合はその資格情報を設定します。</value>

--- a/hmailserver/source/Tools/ControlPanel/Resources/Strings.nb.resx
+++ b/hmailserver/source/Tools/ControlPanel/Resources/Strings.nb.resx
@@ -2917,8 +2917,8 @@ Ingen post røres - indeksen er utledet fra den - men til gjenoppbyggingen har t
   <data name="Enter a valid port number." xml:space="preserve">
     <value>Skriv inn et gyldig portnummer.</value>
   </data>
-  <data name="Enter an address and search. The trace records nothing at all unless MessageTraceEnabled is set in hMailServer.ini - it is off by default because it stores who corresponds with whom." xml:space="preserve">
-    <value>Skriv inn en adresse og søk. Sporingen registrerer ingenting i det hele tatt med mindre MessageTraceEnabled er satt i hMailServer.ini - den er av som standard fordi den lagrer hvem som korresponderer med hvem.</value>
+  <data name="Enter an address and search. The trace records nothing at all until message tracing is switched on, on the Logging page - it is off by default because it stores who corresponds with whom." xml:space="preserve">
+    <value>Skriv inn en adresse og søk. Sporingen registrerer ingenting før meldingssporing slås på på siden Logging – den er av som standard fordi den lagrer hvem som korresponderer med hvem.</value>
   </data>
   <data name="Enter part of a name and press Search, or search with an empty box to list all users." xml:space="preserve">
     <value>Skriv inn en del av et navn og trykk Søk, eller søk med tomt felt for å liste alle brukere.</value>
@@ -3438,6 +3438,9 @@ Ingen post røres - indeksen er utledet fra den - men til gjenoppbyggingen har t
   </data>
   <data name="Host/Name:  {0}" xml:space="preserve">
     <value>Vert/Navn:  {0}</value>
+  </data>
+  <data name="Hosted domain" xml:space="preserve">
+    <value>Hostet domene</value>
   </data>
   <data name="Hours between checks (1 to 168)" xml:space="preserve">
     <value>Timer mellom kontroller (1 til 168)</value>
@@ -4554,8 +4557,8 @@ Det verifiserte installasjonsprogrammet overleveres til oppdateringshjelperen: t
   <data name="No encryption is available on this port. Inbound mail from other servers is normally unencrypted anyway, but this port also accepts AUTH, and a client using it sends its password in the clear." xml:space="preserve">
     <value>Ingen kryptering er tilgjengelig på denne porten. Inngående post fra andre servere er normalt ukryptert uansett, men denne porten godtar også AUTH, og en klient som bruker den sender passordet sitt i klartekst.</value>
   </data>
-  <data name="No events for that address. Either nothing has happened to it, or the trace was switched off at the time - it records only while MessageTraceEnabled is set." xml:space="preserve">
-    <value>Ingen hendelser for den adressen. Enten har ingenting skjedd med den, eller så var sporingen slått av på det tidspunktet - den registrerer bare mens MessageTraceEnabled er satt.</value>
+  <data name="No events for that address. Either nothing has happened to it, or the trace was switched off at the time - it records only while message tracing is on (Logging page)." xml:space="preserve">
+    <value>Ingen hendelser for den adressen. Enten har ingenting skjedd med den, eller sporingen var slått av på det tidspunktet – den registrerer bare mens meldingssporing er på (siden Logging).</value>
   </data>
   <data name="No events for that message." xml:space="preserve">
     <value>Ingen hendelser for den meldingen.</value>
@@ -4710,8 +4713,8 @@ Det verifiserte installasjonsprogrammet overleveres til oppdateringshjelperen: t
   <data name="Not checked from here, honestly: verifying the PTR needs the server's PUBLIC IP address, which this panel cannot determine (behind NAT the machine does not know it either), and this page's checker reads TXT records only. Test from outside instead: nslookup &lt;your public IP&gt; shows the PTR; it should name the host above." xml:space="preserve">
     <value>Ikke kontrollert herfra, ærlig talt: å verifisere PTR krever serverens OFFENTLIGE IP-adresse, som dette panelet ikke kan fastslå (bak NAT vet maskinen det heller ikke), og denne sidens kontroll leser bare TXT-oppføringer. Test utenfra i stedet: nslookup &lt;your public IP&gt; viser PTR; den bør navngi verten ovenfor.</value>
   </data>
-  <data name="Not checked yet (Check for updates, or UpdateCheckEnabled=1 in hMailServer.INI for a daily check)" xml:space="preserve">
-    <value>Ikke kontrollert ennå (Se etter oppdateringer, eller UpdateCheckEnabled=1 i hMailServer.INI for en daglig kontroll)</value>
+  <data name="Not checked yet (Check for updates, or turn on the daily check under Updates on the API &amp; monitoring page)" xml:space="preserve">
+    <value>Ikke kontrollert ennå (Se etter oppdateringer, eller slå på den daglige kontrollen under Oppdateringer på siden API og overvåking)</value>
   </data>
   <data name="Not checked yet. Publish the record, allow time for propagation, then press &quot;Check DNS&quot;." xml:space="preserve">
     <value>Ikke kontrollert ennå. Publiser oppføringen, gi tid til spredning, og trykk deretter «Kontroller DNS».</value>
@@ -4758,11 +4761,14 @@ Det verifiserte installasjonsprogrammet overleveres til oppdateringshjelperen: t
   <data name="Nothing here needs a decision: no mailbox is being skipped and none is being disabled." xml:space="preserve">
     <value>Ingenting her krever en beslutning: ingen postboks hoppes over og ingen deaktiveres.</value>
   </data>
+  <data name="Nothing here yet - Add creates the first entry." xml:space="preserve">
+    <value>Ingenting her ennå – Legg til oppretter den første oppføringen.</value>
+  </data>
   <data name="Nothing is ever marked as spam: marking needs a mark threshold above 0, and a 0 there means &quot;never&quot; rather than &quot;always&quot;. Messages reaching {0} are still refused." xml:space="preserve">
     <value>Ingenting merkes noen gang som spam: merking krever en merketerskel over 0, og 0 der betyr «aldri» i stedet for «alltid». Meldinger som når {0} avvises fortsatt.</value>
   </data>
-  <data name="Nothing is held. Quarantining is off unless QuarantineEnabled is set in hMailServer.ini - until then, spam over the delete threshold is refused during the SMTP conversation rather than stored." xml:space="preserve">
-    <value>Ingenting holdes tilbake. Karantene er av med mindre QuarantineEnabled er satt i hMailServer.ini - inntil da avvises spam over sletteterskelen under SMTP-samtalen i stedet for å lagres.</value>
+  <data name="Nothing is held. Quarantining is switched off - turn it on under Anti-spam settings - and until it is on, spam over the delete threshold is refused during the SMTP conversation rather than stored." xml:space="preserve">
+    <value>Ingenting holdes tilbake. Karantene er slått av – slå den på under Antispam-innstillinger – og inntil den er på, avvises spam over sletteterskelen under SMTP-samtalen i stedet for å bli lagret.</value>
   </data>
   <data name="Nothing matched &quot;{0}&quot;. Try what you are trying to achieve (&quot;stop spam&quot;, &quot;let a device send mail&quot;), a page name, or an hMailServer.INI key." xml:space="preserve">
     <value>Ingenting traff «{0}». Prøv det du forsøker å oppnå («stoppe spam», «la en enhet sende post»), et sidenavn, eller en hMailServer.INI-nøkkel.</value>
@@ -5749,6 +5755,9 @@ Kjør dette hvis klienter melder om meldinger som dukker opp under feil UID, ell
   <data name="Remember this many previous passwords (0 = no history)" xml:space="preserve">
     <value>Husk så mange tidligere passord (0 = ingen historikk)</value>
   </data>
+  <data name="Remote domain" xml:space="preserve">
+    <value>Eksternt domene</value>
+  </data>
   <data name="Remove _expired" xml:space="preserve">
     <value>Fjern _utløpte</value>
   </data>
@@ -6708,12 +6717,6 @@ Fortsette?</value>
   <data name="Set TlsRptFromAddress in the [Settings] section of hMailServer.ini to a mailbox reports should be sent from. Leaving it empty is a valid choice - it just means the collected statistics are discarded and no reports are ever sent." xml:space="preserve">
     <value>Sett TlsRptFromAddress i seksjonen [Settings] i hMailServer.ini til en postboks rapporter skal sendes fra. Å la den stå tom er et gyldig valg - det betyr bare at den innsamlede statistikken forkastes og at rapporter aldri sendes.</value>
   </data>
-  <data name="Set WebServicesHttpPort and/or WebServicesHttpsPort in hMailServer.ini so the URLs answer, then publish autoconfig.&lt;domain&gt; and autodiscover.&lt;domain&gt; DNS records for each mail domain, pointing at this server. These are address records, and this page checks TXT records only, so they cannot be confirmed from here." xml:space="preserve">
-    <value>Sett WebServicesHttpPort og/eller WebServicesHttpsPort i hMailServer.ini slik at URL-ene svarer, og publiser så DNS-oppføringene autoconfig.&lt;domain&gt; og autodiscover.&lt;domain&gt; for hvert postdomene, som peker på denne serveren. Dette er adresseoppføringer, og denne siden sjekker bare TXT-oppføringer, så de kan ikke bekreftes herfra.</value>
-  </data>
-  <data name="Set WebServicesHttpsPort in hMailServer.ini (RFC 8461 requires the policy over HTTPS), give the listener a certificate that covers mta-sts.&lt;domain&gt;, then for each domain publish an A/AAAA (or CNAME) record for mta-sts.&lt;domain&gt; pointing at this server and a TXT record at _mta-sts.&lt;domain&gt; (v=STSv1; id=...). This page checks the TXT record; the address record and the certificate's name coverage cannot be checked from here." xml:space="preserve">
-    <value>Sett WebServicesHttpsPort i hMailServer.ini (RFC 8461 krever policyen over HTTPS), gi lytteren et sertifikat som dekker mta-sts.&lt;domain&gt;, og publiser så for hvert domene en A/AAAA-oppføring (eller CNAME) for mta-sts.&lt;domain&gt; som peker på denne serveren, og en TXT-oppføring på _mta-sts.&lt;domain&gt; (v=STSv1; id=...). Denne siden sjekker TXT-oppføringen; adresseoppføringen og sertifikatets navnedekning kan ikke sjekkes herfra.</value>
-  </data>
   <data name="Set a new server administration password." xml:space="preserve">
     <value>Sett et nytt serveradministrasjonspassord.</value>
   </data>
@@ -6725,6 +6728,12 @@ Fortsette?</value>
   </data>
   <data name="Set header value" xml:space="preserve">
     <value>Sett headerverdi</value>
+  </data>
+  <data name="Set the HTTP or HTTPS port on the Web services &amp; autoconfiguration page so the URLs answer, then publish autoconfig.&lt;domain&gt; and autodiscover.&lt;domain&gt; DNS records for each mail domain, pointing at this server. These are address records, and this page checks TXT records only, so they cannot be confirmed from here." xml:space="preserve">
+    <value>Angi HTTP- eller HTTPS-porten på siden Webtjenester og autokonfigurasjon slik at URL-ene svarer, og publiser så DNS-oppføringene autoconfig.&lt;domain&gt; og autodiscover.&lt;domain&gt; for hvert postdomene, som peker på denne serveren. Dette er adresseoppføringer, og denne siden sjekker bare TXT-oppføringer, så de kan ikke bekreftes herfra.</value>
+  </data>
+  <data name="Set the HTTPS port on the Web services &amp; autoconfiguration page (RFC 8461 requires the policy over HTTPS), give the listener a certificate that covers mta-sts.&lt;domain&gt;, then for each domain publish an A/AAAA (or CNAME) record for mta-sts.&lt;domain&gt; pointing at this server and a TXT record at _mta-sts.&lt;domain&gt; (v=STSv1; id=...). This page checks the TXT record; the address record and the certificate's name coverage cannot be checked from here." xml:space="preserve">
+    <value>Angi HTTPS-porten på siden Webtjenester og autokonfigurasjon (RFC 8461 krever policyen over HTTPS), gi lytteren et sertifikat som dekker mta-sts.&lt;domain&gt;, og publiser så for hvert domene en A/AAAA-oppføring (eller CNAME) for mta-sts.&lt;domain&gt; som peker på denne serveren, og en TXT-oppføring på _mta-sts.&lt;domain&gt; (v=STSv1; id=...). Denne siden sjekker TXT-oppføringen; adresseoppføringen og sertifikatets navnedekning kan ikke sjekkes herfra.</value>
   </data>
   <data name="Set the SMTP relayer, and its credentials if the provider needs them." xml:space="preserve">
     <value>Sett SMTP-relayeren, og legitimasjonen dens hvis leverandøren trenger den.</value>

--- a/hmailserver/source/Tools/ControlPanel/Resources/Strings.nl.resx
+++ b/hmailserver/source/Tools/ControlPanel/Resources/Strings.nl.resx
@@ -2917,8 +2917,8 @@ Er wordt geen mail aangeraakt - de index is ervan afgeleid - maar totdat het opn
   <data name="Enter a valid port number." xml:space="preserve">
     <value>Voer een geldig poortnummer in.</value>
   </data>
-  <data name="Enter an address and search. The trace records nothing at all unless MessageTraceEnabled is set in hMailServer.ini - it is off by default because it stores who corresponds with whom." xml:space="preserve">
-    <value>Voer een adres in en zoek. De trace legt helemaal niets vast tenzij MessageTraceEnabled is ingesteld in hMailServer.ini - dat staat standaard uit omdat het vastlegt wie met wie correspondeert.</value>
+  <data name="Enter an address and search. The trace records nothing at all until message tracing is switched on, on the Logging page - it is off by default because it stores who corresponds with whom." xml:space="preserve">
+    <value>Voer een adres in en zoek. De tracering legt niets vast totdat berichttracering wordt ingeschakeld op de pagina Logboekregistratie – standaard staat deze uit omdat ze opslaat wie met wie correspondeert.</value>
   </data>
   <data name="Enter part of a name and press Search, or search with an empty box to list all users." xml:space="preserve">
     <value>Voer een deel van een naam in en druk op Zoeken, of zoek met een leeg vak om alle gebruikers op te sommen.</value>
@@ -3438,6 +3438,9 @@ Er wordt geen mail aangeraakt - de index is ervan afgeleid - maar totdat het opn
   </data>
   <data name="Host/Name:  {0}" xml:space="preserve">
     <value>Host/Naam:  {0}</value>
+  </data>
+  <data name="Hosted domain" xml:space="preserve">
+    <value>Gehost domein</value>
   </data>
   <data name="Hours between checks (1 to 168)" xml:space="preserve">
     <value>Uren tussen controles (1 tot 168)</value>
@@ -4554,8 +4557,8 @@ Het geverifieerde installatieprogramma wordt aan de updatehelper doorgegeven: de
   <data name="No encryption is available on this port. Inbound mail from other servers is normally unencrypted anyway, but this port also accepts AUTH, and a client using it sends its password in the clear." xml:space="preserve">
     <value>Op deze poort is geen versleuteling beschikbaar. Inkomende mail van andere servers is toch al meestal onversleuteld, maar deze poort accepteert ook AUTH, en een client die dat gebruikt, stuurt zijn wachtwoord in klare tekst.</value>
   </data>
-  <data name="No events for that address. Either nothing has happened to it, or the trace was switched off at the time - it records only while MessageTraceEnabled is set." xml:space="preserve">
-    <value>Geen gebeurtenissen voor dat adres. Ofwel is er niets mee gebeurd, ofwel stond de tracering op dat moment uit - er wordt alleen vastgelegd zolang MessageTraceEnabled is ingesteld.</value>
+  <data name="No events for that address. Either nothing has happened to it, or the trace was switched off at the time - it records only while message tracing is on (Logging page)." xml:space="preserve">
+    <value>Geen gebeurtenissen voor dat adres. Of er is niets mee gebeurd, of de tracering stond op dat moment uit – ze legt alleen vast zolang berichttracering aan staat (pagina Logboekregistratie).</value>
   </data>
   <data name="No events for that message." xml:space="preserve">
     <value>Geen gebeurtenissen voor dat bericht.</value>
@@ -4710,8 +4713,8 @@ Het geverifieerde installatieprogramma wordt aan de updatehelper doorgegeven: de
   <data name="Not checked from here, honestly: verifying the PTR needs the server's PUBLIC IP address, which this panel cannot determine (behind NAT the machine does not know it either), and this page's checker reads TXT records only. Test from outside instead: nslookup &lt;your public IP&gt; shows the PTR; it should name the host above." xml:space="preserve">
     <value>Eerlijk gezegd wordt dit hiervandaan niet gecontroleerd: het verifiëren van de PTR vereist het PUBLIEKE IP-adres van de server, dat dit paneel niet kan bepalen (achter NAT weet de machine het zelf ook niet), en de controlefunctie van deze pagina leest alleen TXT-records. Test in plaats daarvan van buitenaf: nslookup &lt;your public IP&gt; toont de PTR; die hoort de host hierboven te noemen.</value>
   </data>
-  <data name="Not checked yet (Check for updates, or UpdateCheckEnabled=1 in hMailServer.INI for a daily check)" xml:space="preserve">
-    <value>Nog niet gecontroleerd (Controleren op updates, of UpdateCheckEnabled=1 in hMailServer.INI voor een dagelijkse controle)</value>
+  <data name="Not checked yet (Check for updates, or turn on the daily check under Updates on the API &amp; monitoring page)" xml:space="preserve">
+    <value>Nog niet gecontroleerd (Controleren op updates, of zet de dagelijkse controle aan onder Updates op de pagina API en monitoring)</value>
   </data>
   <data name="Not checked yet. Publish the record, allow time for propagation, then press &quot;Check DNS&quot;." xml:space="preserve">
     <value>Nog niet gecontroleerd. Publiceer het record, geef het tijd om te propageren, en druk dan op "DNS controleren".</value>
@@ -4758,11 +4761,14 @@ Het geverifieerde installatieprogramma wordt aan de updatehelper doorgegeven: de
   <data name="Nothing here needs a decision: no mailbox is being skipped and none is being disabled." xml:space="preserve">
     <value>Hier hoeft niets te worden besloten: er wordt geen postvak overgeslagen en er wordt er geen uitgeschakeld.</value>
   </data>
+  <data name="Nothing here yet - Add creates the first entry." xml:space="preserve">
+    <value>Nog niets hier – Toevoegen maakt het eerste item.</value>
+  </data>
   <data name="Nothing is ever marked as spam: marking needs a mark threshold above 0, and a 0 there means &quot;never&quot; rather than &quot;always&quot;. Messages reaching {0} are still refused." xml:space="preserve">
     <value>Er wordt nooit iets als spam gemarkeerd: markeren vereist een markeerdrempel boven 0, en een 0 daar betekent "nooit" en niet "altijd". Berichten die {0} halen, worden nog steeds geweigerd.</value>
   </data>
-  <data name="Nothing is held. Quarantining is off unless QuarantineEnabled is set in hMailServer.ini - until then, spam over the delete threshold is refused during the SMTP conversation rather than stored." xml:space="preserve">
-    <value>Er wordt niets vastgehouden. Quarantaine staat uit tenzij QuarantineEnabled is ingesteld in hMailServer.ini - tot die tijd wordt spam boven de verwijderdrempel tijdens het SMTP-gesprek geweigerd in plaats van opgeslagen.</value>
+  <data name="Nothing is held. Quarantining is switched off - turn it on under Anti-spam settings - and until it is on, spam over the delete threshold is refused during the SMTP conversation rather than stored." xml:space="preserve">
+    <value>Er wordt niets vastgehouden. Quarantaine staat uit – zet deze aan onder Antispaminstellingen – en zolang deze uit staat, wordt spam boven de verwijderdrempel tijdens het SMTP-gesprek geweigerd in plaats van opgeslagen.</value>
   </data>
   <data name="Nothing matched &quot;{0}&quot;. Try what you are trying to achieve (&quot;stop spam&quot;, &quot;let a device send mail&quot;), a page name, or an hMailServer.INI key." xml:space="preserve">
     <value>Niets kwam overeen met "{0}". Probeer wat u wilt bereiken ("spam stoppen", "een apparaat mail laten verzenden"), een paginanaam, of een sleutel uit hMailServer.INI.</value>
@@ -5749,6 +5755,9 @@ Voer dit uit als clients melden dat berichten onder de verkeerde UID verschijnen
   <data name="Remember this many previous passwords (0 = no history)" xml:space="preserve">
     <value>Dit aantal vorige wachtwoorden onthouden (0 = geen geschiedenis)</value>
   </data>
+  <data name="Remote domain" xml:space="preserve">
+    <value>Extern domein</value>
+  </data>
   <data name="Remove _expired" xml:space="preserve">
     <value>Verlopen _items verwijderen</value>
   </data>
@@ -6708,12 +6717,6 @@ Doorgaan?</value>
   <data name="Set TlsRptFromAddress in the [Settings] section of hMailServer.ini to a mailbox reports should be sent from. Leaving it empty is a valid choice - it just means the collected statistics are discarded and no reports are ever sent." xml:space="preserve">
     <value>Stel TlsRptFromAddress in de sectie [Settings] van hMailServer.ini in op een postvak waarvandaan rapporten moeten worden verstuurd. Het leeg laten is een geldige keuze - het betekent alleen dat de verzamelde statistieken worden weggegooid en er nooit rapporten worden verstuurd.</value>
   </data>
-  <data name="Set WebServicesHttpPort and/or WebServicesHttpsPort in hMailServer.ini so the URLs answer, then publish autoconfig.&lt;domain&gt; and autodiscover.&lt;domain&gt; DNS records for each mail domain, pointing at this server. These are address records, and this page checks TXT records only, so they cannot be confirmed from here." xml:space="preserve">
-    <value>Stel WebServicesHttpPort en/of WebServicesHttpsPort in hMailServer.ini in zodat de URL's antwoorden, en publiceer vervolgens voor elk maildomein DNS-records autoconfig.&lt;domain&gt; en autodiscover.&lt;domain&gt; die naar deze server wijzen. Dit zijn adresrecords, en deze pagina controleert alleen TXT-records, dus ze kunnen hiervandaan niet worden bevestigd.</value>
-  </data>
-  <data name="Set WebServicesHttpsPort in hMailServer.ini (RFC 8461 requires the policy over HTTPS), give the listener a certificate that covers mta-sts.&lt;domain&gt;, then for each domain publish an A/AAAA (or CNAME) record for mta-sts.&lt;domain&gt; pointing at this server and a TXT record at _mta-sts.&lt;domain&gt; (v=STSv1; id=...). This page checks the TXT record; the address record and the certificate's name coverage cannot be checked from here." xml:space="preserve">
-    <value>Stel WebServicesHttpsPort in hMailServer.ini in (RFC 8461 vereist het beleid over HTTPS), geef de listener een certificaat dat mta-sts.&lt;domain&gt; dekt, en publiceer vervolgens voor elk domein een A/AAAA-record (of CNAME) voor mta-sts.&lt;domain&gt; dat naar deze server wijst en een TXT-record op _mta-sts.&lt;domain&gt; (v=STSv1; id=...). Deze pagina controleert het TXT-record; het adresrecord en de naamdekking van het certificaat kunnen hiervandaan niet worden gecontroleerd.</value>
-  </data>
   <data name="Set a new server administration password." xml:space="preserve">
     <value>Stel een nieuw wachtwoord voor serverbeheer in.</value>
   </data>
@@ -6725,6 +6728,12 @@ Doorgaan?</value>
   </data>
   <data name="Set header value" xml:space="preserve">
     <value>Headerwaarde instellen</value>
+  </data>
+  <data name="Set the HTTP or HTTPS port on the Web services &amp; autoconfiguration page so the URLs answer, then publish autoconfig.&lt;domain&gt; and autodiscover.&lt;domain&gt; DNS records for each mail domain, pointing at this server. These are address records, and this page checks TXT records only, so they cannot be confirmed from here." xml:space="preserve">
+    <value>Stel de HTTP- of HTTPS-poort in op de pagina Webservices en autoconfiguratie in zodat de URL's antwoorden, en publiceer vervolgens voor elk maildomein DNS-records autoconfig.&lt;domain&gt; en autodiscover.&lt;domain&gt; die naar deze server wijzen. Dit zijn adresrecords, en deze pagina controleert alleen TXT-records, dus ze kunnen hiervandaan niet worden bevestigd.</value>
+  </data>
+  <data name="Set the HTTPS port on the Web services &amp; autoconfiguration page (RFC 8461 requires the policy over HTTPS), give the listener a certificate that covers mta-sts.&lt;domain&gt;, then for each domain publish an A/AAAA (or CNAME) record for mta-sts.&lt;domain&gt; pointing at this server and a TXT record at _mta-sts.&lt;domain&gt; (v=STSv1; id=...). This page checks the TXT record; the address record and the certificate's name coverage cannot be checked from here." xml:space="preserve">
+    <value>Stel de HTTPS-poort in op de pagina Webservices en autoconfiguratie in (RFC 8461 vereist het beleid over HTTPS), geef de listener een certificaat dat mta-sts.&lt;domain&gt; dekt, en publiceer vervolgens voor elk domein een A/AAAA-record (of CNAME) voor mta-sts.&lt;domain&gt; dat naar deze server wijst en een TXT-record op _mta-sts.&lt;domain&gt; (v=STSv1; id=...). Deze pagina controleert het TXT-record; het adresrecord en de naamdekking van het certificaat kunnen hiervandaan niet worden gecontroleerd.</value>
   </data>
   <data name="Set the SMTP relayer, and its credentials if the provider needs them." xml:space="preserve">
     <value>Stel de SMTP-relayserver in, en de referenties ervan als de provider die nodig heeft.</value>

--- a/hmailserver/source/Tools/ControlPanel/Resources/Strings.pl.resx
+++ b/hmailserver/source/Tools/ControlPanel/Resources/Strings.pl.resx
@@ -2917,8 +2917,8 @@ Poczta nie jest ruszana - indeks jest z niej wyprowadzany - ale dopóki odbudowa
   <data name="Enter a valid port number." xml:space="preserve">
     <value>Należy podać prawidłowy numer portu.</value>
   </data>
-  <data name="Enter an address and search. The trace records nothing at all unless MessageTraceEnabled is set in hMailServer.ini - it is off by default because it stores who corresponds with whom." xml:space="preserve">
-    <value>Wpisz adres i wyszukaj. Śledzenie nie zapisuje zupełnie niczego, dopóki w hMailServer.ini nie zostanie ustawione MessageTraceEnabled - domyślnie jest wyłączone, ponieważ przechowuje informacje o tym, kto z kim koresponduje.</value>
+  <data name="Enter an address and search. The trace records nothing at all until message tracing is switched on, on the Logging page - it is off by default because it stores who corresponds with whom." xml:space="preserve">
+    <value>Wpisz adres i wyszukaj. Śledzenie nie rejestruje niczego, dopóki śledzenie wiadomości nie zostanie włączone na stronie Rejestrowanie w dzienniku – domyślnie jest wyłączone, ponieważ zapisuje, kto z kim koresponduje.</value>
   </data>
   <data name="Enter part of a name and press Search, or search with an empty box to list all users." xml:space="preserve">
     <value>Wpisz część nazwy i naciśnij Szukaj albo wyszukaj z pustym polem, aby wypisać wszystkich użytkowników.</value>
@@ -3438,6 +3438,9 @@ Poczta nie jest ruszana - indeks jest z niej wyprowadzany - ale dopóki odbudowa
   </data>
   <data name="Host/Name:  {0}" xml:space="preserve">
     <value>Host/Nazwa:  {0}</value>
+  </data>
+  <data name="Hosted domain" xml:space="preserve">
+    <value>Domena hostowana</value>
   </data>
   <data name="Hours between checks (1 to 168)" xml:space="preserve">
     <value>Godziny między sprawdzeniami (1 do 168)</value>
@@ -4554,8 +4557,8 @@ Zweryfikowany instalator zostaje przekazany pomocnikowi aktualizacji: usługa je
   <data name="No encryption is available on this port. Inbound mail from other servers is normally unencrypted anyway, but this port also accepts AUTH, and a client using it sends its password in the clear." xml:space="preserve">
     <value>Na tym porcie nie jest dostępne żadne szyfrowanie. Poczta przychodząca z innych serwerów i tak zwykle nie jest szyfrowana, ale ten port przyjmuje także AUTH, a klient, który z niego korzysta, wysyła swoje hasło jawnym tekstem.</value>
   </data>
-  <data name="No events for that address. Either nothing has happened to it, or the trace was switched off at the time - it records only while MessageTraceEnabled is set." xml:space="preserve">
-    <value>Brak zdarzeń dla tego adresu. Albo nic się z nim nie działo, albo śledzenie było w tym czasie wyłączone - zapisuje ono tylko wtedy, gdy ustawione jest MessageTraceEnabled.</value>
+  <data name="No events for that address. Either nothing has happened to it, or the trace was switched off at the time - it records only while message tracing is on (Logging page)." xml:space="preserve">
+    <value>Brak zdarzeń dla tego adresu. Albo nic się z nim nie stało, albo śledzenie było wtedy wyłączone – rejestruje tylko wtedy, gdy śledzenie wiadomości jest włączone (strona Rejestrowanie w dzienniku).</value>
   </data>
   <data name="No events for that message." xml:space="preserve">
     <value>Brak zdarzeń dla tej wiadomości.</value>
@@ -4710,8 +4713,8 @@ Zweryfikowany instalator zostaje przekazany pomocnikowi aktualizacji: usługa je
   <data name="Not checked from here, honestly: verifying the PTR needs the server's PUBLIC IP address, which this panel cannot determine (behind NAT the machine does not know it either), and this page's checker reads TXT records only. Test from outside instead: nslookup &lt;your public IP&gt; shows the PTR; it should name the host above." xml:space="preserve">
     <value>Szczerze mówiąc, nie jest to stąd sprawdzane: weryfikacja rekordu PTR wymaga PUBLICZNEGO adresu IP serwera, którego ten panel nie potrafi ustalić (za NAT komputer też go nie zna), a mechanizm kontrolny tej strony odczytuje wyłącznie rekordy TXT. Należy zamiast tego przeprowadzić test z zewnątrz: nslookup &lt;your public IP&gt; pokazuje rekord PTR; powinien on wskazywać host podany powyżej.</value>
   </data>
-  <data name="Not checked yet (Check for updates, or UpdateCheckEnabled=1 in hMailServer.INI for a daily check)" xml:space="preserve">
-    <value>Jeszcze nie sprawdzono (Sprawdź aktualizacje albo UpdateCheckEnabled=1 w pliku hMailServer.INI dla codziennej kontroli)</value>
+  <data name="Not checked yet (Check for updates, or turn on the daily check under Updates on the API &amp; monitoring page)" xml:space="preserve">
+    <value>Jeszcze nie sprawdzono (Sprawdź aktualizacje lub włącz codzienne sprawdzanie w sekcji Aktualizacje na stronie API i monitorowanie)</value>
   </data>
   <data name="Not checked yet. Publish the record, allow time for propagation, then press &quot;Check DNS&quot;." xml:space="preserve">
     <value>Jeszcze nie sprawdzono. Należy opublikować rekord, odczekać na propagację, a następnie nacisnąć „Sprawdź DNS”.</value>
@@ -4758,11 +4761,14 @@ Zweryfikowany instalator zostaje przekazany pomocnikowi aktualizacji: usługa je
   <data name="Nothing here needs a decision: no mailbox is being skipped and none is being disabled." xml:space="preserve">
     <value>Nic tutaj nie wymaga decyzji: żadna skrzynka pocztowa nie jest pomijana ani wyłączana.</value>
   </data>
+  <data name="Nothing here yet - Add creates the first entry." xml:space="preserve">
+    <value>Na razie nic tu nie ma – Dodaj tworzy pierwszy wpis.</value>
+  </data>
   <data name="Nothing is ever marked as spam: marking needs a mark threshold above 0, and a 0 there means &quot;never&quot; rather than &quot;always&quot;. Messages reaching {0} are still refused." xml:space="preserve">
     <value>Nic nigdy nie jest oznaczane jako spam: oznaczanie wymaga progu oznaczania większego od 0, a 0 oznacza tam „nigdy”, a nie „zawsze”. Wiadomości osiągające {0} są nadal odrzucane.</value>
   </data>
-  <data name="Nothing is held. Quarantining is off unless QuarantineEnabled is set in hMailServer.ini - until then, spam over the delete threshold is refused during the SMTP conversation rather than stored." xml:space="preserve">
-    <value>Nic nie jest wstrzymywane. Kwarantanna jest wyłączona, dopóki w pliku hMailServer.ini nie zostanie ustawione QuarantineEnabled - do tego czasu spam powyżej progu usuwania jest odrzucany w trakcie rozmowy SMTP, a nie przechowywany.</value>
+  <data name="Nothing is held. Quarantining is switched off - turn it on under Anti-spam settings - and until it is on, spam over the delete threshold is refused during the SMTP conversation rather than stored." xml:space="preserve">
+    <value>Nic nie jest wstrzymane. Kwarantanna jest wyłączona – włącz ją w Ustawieniach antyspamowych – a dopóki jest wyłączona, spam powyżej progu usuwania jest odrzucany podczas sesji SMTP zamiast zapisywany.</value>
   </data>
   <data name="Nothing matched &quot;{0}&quot;. Try what you are trying to achieve (&quot;stop spam&quot;, &quot;let a device send mail&quot;), a page name, or an hMailServer.INI key." xml:space="preserve">
     <value>Nic nie pasuje do „{0}”. Warto spróbować opisać cel („zatrzymaj spam”, „pozwól urządzeniu wysyłać pocztę”), podać nazwę strony albo klucz z pliku hMailServer.INI.</value>
@@ -5749,6 +5755,9 @@ Warto to uruchomić, gdy klienty zgłaszają wiadomości pojawiające się pod n
   <data name="Remember this many previous passwords (0 = no history)" xml:space="preserve">
     <value>Zapamiętuj tyle poprzednich haseł (0 = brak historii)</value>
   </data>
+  <data name="Remote domain" xml:space="preserve">
+    <value>Domena zdalna</value>
+  </data>
   <data name="Remove _expired" xml:space="preserve">
     <value>Usuń _wygasłe</value>
   </data>
@@ -6708,12 +6717,6 @@ Kontynuować?</value>
   <data name="Set TlsRptFromAddress in the [Settings] section of hMailServer.ini to a mailbox reports should be sent from. Leaving it empty is a valid choice - it just means the collected statistics are discarded and no reports are ever sent." xml:space="preserve">
     <value>Ustaw TlsRptFromAddress w sekcji [Settings] pliku hMailServer.ini na skrzynkę pocztową, z której mają być wysyłane raporty. Pozostawienie pustej wartości jest poprawnym wyborem - oznacza po prostu, że zebrane statystyki są odrzucane i żadne raporty nigdy nie są wysyłane.</value>
   </data>
-  <data name="Set WebServicesHttpPort and/or WebServicesHttpsPort in hMailServer.ini so the URLs answer, then publish autoconfig.&lt;domain&gt; and autodiscover.&lt;domain&gt; DNS records for each mail domain, pointing at this server. These are address records, and this page checks TXT records only, so they cannot be confirmed from here." xml:space="preserve">
-    <value>Ustaw WebServicesHttpPort i/lub WebServicesHttpsPort w hMailServer.ini, aby adresy URL odpowiadały, a następnie opublikuj dla każdej domeny pocztowej rekordy DNS autoconfig.&lt;domain&gt; i autodiscover.&lt;domain&gt; wskazujące na ten serwer. Są to rekordy adresowe, a ta strona sprawdza wyłącznie rekordy TXT, więc nie da się ich stąd potwierdzić.</value>
-  </data>
-  <data name="Set WebServicesHttpsPort in hMailServer.ini (RFC 8461 requires the policy over HTTPS), give the listener a certificate that covers mta-sts.&lt;domain&gt;, then for each domain publish an A/AAAA (or CNAME) record for mta-sts.&lt;domain&gt; pointing at this server and a TXT record at _mta-sts.&lt;domain&gt; (v=STSv1; id=...). This page checks the TXT record; the address record and the certificate's name coverage cannot be checked from here." xml:space="preserve">
-    <value>Ustaw WebServicesHttpsPort w hMailServer.ini (RFC 8461 wymaga udostępniania polityki przez HTTPS), przypisz nasłuchowi certyfikat obejmujący mta-sts.&lt;domain&gt;, a następnie dla każdej domeny opublikuj rekord A/AAAA (lub CNAME) dla mta-sts.&lt;domain&gt; wskazujący na ten serwer oraz rekord TXT pod nazwą _mta-sts.&lt;domain&gt; (v=STSv1; id=...). Ta strona sprawdza rekord TXT; rekordu adresowego ani tego, czy certyfikat obejmuje tę nazwę, nie da się stąd sprawdzić.</value>
-  </data>
   <data name="Set a new server administration password." xml:space="preserve">
     <value>Ustaw nowe hasło administracji serwerem.</value>
   </data>
@@ -6725,6 +6728,12 @@ Kontynuować?</value>
   </data>
   <data name="Set header value" xml:space="preserve">
     <value>Ustaw wartość nagłówka</value>
+  </data>
+  <data name="Set the HTTP or HTTPS port on the Web services &amp; autoconfiguration page so the URLs answer, then publish autoconfig.&lt;domain&gt; and autodiscover.&lt;domain&gt; DNS records for each mail domain, pointing at this server. These are address records, and this page checks TXT records only, so they cannot be confirmed from here." xml:space="preserve">
+    <value>Ustaw port HTTP lub HTTPS na stronie Usługi webowe i autokonfiguracja, aby adresy URL odpowiadały, a następnie opublikuj dla każdej domeny pocztowej rekordy DNS autoconfig.&lt;domain&gt; i autodiscover.&lt;domain&gt; wskazujące na ten serwer. Są to rekordy adresowe, a ta strona sprawdza wyłącznie rekordy TXT, więc nie da się ich stąd potwierdzić.</value>
+  </data>
+  <data name="Set the HTTPS port on the Web services &amp; autoconfiguration page (RFC 8461 requires the policy over HTTPS), give the listener a certificate that covers mta-sts.&lt;domain&gt;, then for each domain publish an A/AAAA (or CNAME) record for mta-sts.&lt;domain&gt; pointing at this server and a TXT record at _mta-sts.&lt;domain&gt; (v=STSv1; id=...). This page checks the TXT record; the address record and the certificate's name coverage cannot be checked from here." xml:space="preserve">
+    <value>Ustaw port HTTPS na stronie Usługi webowe i autokonfiguracja (RFC 8461 wymaga udostępniania polityki przez HTTPS), przypisz nasłuchowi certyfikat obejmujący mta-sts.&lt;domain&gt;, a następnie dla każdej domeny opublikuj rekord A/AAAA (lub CNAME) dla mta-sts.&lt;domain&gt; wskazujący na ten serwer oraz rekord TXT pod nazwą _mta-sts.&lt;domain&gt; (v=STSv1; id=...). Ta strona sprawdza rekord TXT; rekordu adresowego ani tego, czy certyfikat obejmuje tę nazwę, nie da się stąd sprawdzić.</value>
   </data>
   <data name="Set the SMTP relayer, and its credentials if the provider needs them." xml:space="preserve">
     <value>Ustaw przekaźnik SMTP oraz jego poświadczenia, jeśli operator ich wymaga.</value>

--- a/hmailserver/source/Tools/ControlPanel/Resources/Strings.pt-BR.resx
+++ b/hmailserver/source/Tools/ControlPanel/Resources/Strings.pt-BR.resx
@@ -2917,8 +2917,8 @@ Nenhum e-mail é tocado - o índice é derivado deles - mas até a reconstruçã
   <data name="Enter a valid port number." xml:space="preserve">
     <value>Informe um número de porta válido.</value>
   </data>
-  <data name="Enter an address and search. The trace records nothing at all unless MessageTraceEnabled is set in hMailServer.ini - it is off by default because it stores who corresponds with whom." xml:space="preserve">
-    <value>Informe um endereço e busque. O rastreamento não registra absolutamente nada a menos que MessageTraceEnabled esteja definido em hMailServer.ini - vem desligado por padrão porque armazena quem se corresponde com quem.</value>
+  <data name="Enter an address and search. The trace records nothing at all until message tracing is switched on, on the Logging page - it is off by default because it stores who corresponds with whom." xml:space="preserve">
+    <value>Digite um endereço e pesquise. O rastreamento não registra nada até que o rastreamento de mensagens seja ativado na página Registro em log – está desativado por padrão porque armazena quem se corresponde com quem.</value>
   </data>
   <data name="Enter part of a name and press Search, or search with an empty box to list all users." xml:space="preserve">
     <value>Informe parte de um nome e pressione Buscar, ou busque com a caixa vazia para listar todos os usuários.</value>
@@ -3438,6 +3438,9 @@ Nenhum e-mail é tocado - o índice é derivado deles - mas até a reconstruçã
   </data>
   <data name="Host/Name:  {0}" xml:space="preserve">
     <value>Host/Nome:  {0}</value>
+  </data>
+  <data name="Hosted domain" xml:space="preserve">
+    <value>Domínio hospedado</value>
   </data>
   <data name="Hours between checks (1 to 168)" xml:space="preserve">
     <value>Horas entre verificações (1 a 168)</value>
@@ -4554,8 +4557,8 @@ O instalador verificado é entregue ao auxiliar de atualização: o serviço par
   <data name="No encryption is available on this port. Inbound mail from other servers is normally unencrypted anyway, but this port also accepts AUTH, and a client using it sends its password in the clear." xml:space="preserve">
     <value>Nenhuma criptografia está disponível nesta porta. E-mails de entrada de outros servidores normalmente já vêm sem criptografia, mas esta porta também aceita AUTH, e um cliente que a usa envia a senha dele em texto claro.</value>
   </data>
-  <data name="No events for that address. Either nothing has happened to it, or the trace was switched off at the time - it records only while MessageTraceEnabled is set." xml:space="preserve">
-    <value>Nenhum evento para esse endereço. Ou nada aconteceu com ele, ou o rastreamento estava desligado na ocasião - ele só grava enquanto MessageTraceEnabled estiver definido.</value>
+  <data name="No events for that address. Either nothing has happened to it, or the trace was switched off at the time - it records only while message tracing is on (Logging page)." xml:space="preserve">
+    <value>Nenhum evento para esse endereço. Ou nada aconteceu com ele, ou o rastreamento estava desativado na época – ele só registra enquanto o rastreamento de mensagens está ativado (página Registro em log).</value>
   </data>
   <data name="No events for that message." xml:space="preserve">
     <value>Nenhum evento para essa mensagem.</value>
@@ -4710,8 +4713,8 @@ O instalador verificado é entregue ao auxiliar de atualização: o serviço par
   <data name="Not checked from here, honestly: verifying the PTR needs the server's PUBLIC IP address, which this panel cannot determine (behind NAT the machine does not know it either), and this page's checker reads TXT records only. Test from outside instead: nslookup &lt;your public IP&gt; shows the PTR; it should name the host above." xml:space="preserve">
     <value>Sinceramente, não é verificado daqui: verificar o PTR exige o endereço IP PÚBLICO do servidor, que este painel não consegue determinar (atrás de NAT a máquina também não o conhece), e o verificador desta página lê apenas registros TXT. Em vez disso, teste de fora: nslookup &lt;your public IP&gt; mostra o PTR; ele deve nomear o host acima.</value>
   </data>
-  <data name="Not checked yet (Check for updates, or UpdateCheckEnabled=1 in hMailServer.INI for a daily check)" xml:space="preserve">
-    <value>Ainda não verificado (Verificar atualizações, ou UpdateCheckEnabled=1 no hMailServer.INI para uma verificação diária)</value>
+  <data name="Not checked yet (Check for updates, or turn on the daily check under Updates on the API &amp; monitoring page)" xml:space="preserve">
+    <value>Ainda não verificado (Verificar atualizações, ou ative a verificação diária em Atualizações na página API e monitoramento)</value>
   </data>
   <data name="Not checked yet. Publish the record, allow time for propagation, then press &quot;Check DNS&quot;." xml:space="preserve">
     <value>Ainda não verificado. Publique o registro, dê tempo para a propagação e então pressione "Verificar DNS".</value>
@@ -4758,11 +4761,14 @@ O instalador verificado é entregue ao auxiliar de atualização: o serviço par
   <data name="Nothing here needs a decision: no mailbox is being skipped and none is being disabled." xml:space="preserve">
     <value>Nada aqui exige uma decisão: nenhuma caixa está sendo pulada e nenhuma está sendo desativada.</value>
   </data>
+  <data name="Nothing here yet - Add creates the first entry." xml:space="preserve">
+    <value>Nada aqui ainda – Adicionar cria a primeira entrada.</value>
+  </data>
   <data name="Nothing is ever marked as spam: marking needs a mark threshold above 0, and a 0 there means &quot;never&quot; rather than &quot;always&quot;. Messages reaching {0} are still refused." xml:space="preserve">
     <value>Nada é jamais marcado como spam: a marcação exige um limiar de marcação acima de 0, e um 0 ali significa "nunca", não "sempre". Mensagens que alcançam {0} continuam sendo recusadas.</value>
   </data>
-  <data name="Nothing is held. Quarantining is off unless QuarantineEnabled is set in hMailServer.ini - until then, spam over the delete threshold is refused during the SMTP conversation rather than stored." xml:space="preserve">
-    <value>Nada é retido. A quarentena fica desligada a menos que QuarantineEnabled esteja definido no hMailServer.ini - até lá, spam acima do limiar de exclusão é recusado durante a conversa SMTP em vez de armazenado.</value>
+  <data name="Nothing is held. Quarantining is switched off - turn it on under Anti-spam settings - and until it is on, spam over the delete threshold is refused during the SMTP conversation rather than stored." xml:space="preserve">
+    <value>Nada está retido. A quarentena está desativada – ative-a em Configurações antispam – e, até que esteja ativada, o spam acima do limite de exclusão é recusado durante a conversa SMTP em vez de armazenado.</value>
   </data>
   <data name="Nothing matched &quot;{0}&quot;. Try what you are trying to achieve (&quot;stop spam&quot;, &quot;let a device send mail&quot;), a page name, or an hMailServer.INI key." xml:space="preserve">
     <value>Nada correspondeu a "{0}". Tente aquilo que você está tentando alcançar ("parar spam", "permitir que um dispositivo envie e-mails"), o nome de uma página, ou uma chave do hMailServer.INI.</value>
@@ -5749,6 +5755,9 @@ Execute isto se os clientes relatarem mensagens aparecendo com o UID errado, ou 
   <data name="Remember this many previous passwords (0 = no history)" xml:space="preserve">
     <value>Lembrar esta quantidade de senhas anteriores (0 = sem histórico)</value>
   </data>
+  <data name="Remote domain" xml:space="preserve">
+    <value>Domínio remoto</value>
+  </data>
   <data name="Remove _expired" xml:space="preserve">
     <value>_Remover os expirados</value>
   </data>
@@ -6708,12 +6717,6 @@ Continuar?</value>
   <data name="Set TlsRptFromAddress in the [Settings] section of hMailServer.ini to a mailbox reports should be sent from. Leaving it empty is a valid choice - it just means the collected statistics are discarded and no reports are ever sent." xml:space="preserve">
     <value>Defina TlsRptFromAddress na seção [Settings] do hMailServer.ini como a caixa a partir da qual os relatórios devem ser enviados. Deixá-lo vazio é uma escolha válida - significa apenas que as estatísticas coletadas são descartadas e nenhum relatório é enviado.</value>
   </data>
-  <data name="Set WebServicesHttpPort and/or WebServicesHttpsPort in hMailServer.ini so the URLs answer, then publish autoconfig.&lt;domain&gt; and autodiscover.&lt;domain&gt; DNS records for each mail domain, pointing at this server. These are address records, and this page checks TXT records only, so they cannot be confirmed from here." xml:space="preserve">
-    <value>Defina WebServicesHttpPort e/ou WebServicesHttpsPort em hMailServer.ini para que as URLs respondam, depois publique registros DNS autoconfig.&lt;domain&gt; e autodiscover.&lt;domain&gt; para cada domínio de e-mail, apontando para este servidor. São registros de endereço, e esta página verifica apenas registros TXT, então eles não podem ser confirmados daqui.</value>
-  </data>
-  <data name="Set WebServicesHttpsPort in hMailServer.ini (RFC 8461 requires the policy over HTTPS), give the listener a certificate that covers mta-sts.&lt;domain&gt;, then for each domain publish an A/AAAA (or CNAME) record for mta-sts.&lt;domain&gt; pointing at this server and a TXT record at _mta-sts.&lt;domain&gt; (v=STSv1; id=...). This page checks the TXT record; the address record and the certificate's name coverage cannot be checked from here." xml:space="preserve">
-    <value>Defina WebServicesHttpsPort em hMailServer.ini (a RFC 8461 exige a política por HTTPS), dê ao ouvinte um certificado que cubra mta-sts.&lt;domain&gt;, depois, para cada domínio, publique um registro A/AAAA (ou CNAME) para mta-sts.&lt;domain&gt; apontando para este servidor e um registro TXT em _mta-sts.&lt;domain&gt; (v=STSv1; id=...). Esta página verifica o registro TXT; o registro de endereço e a cobertura de nome do certificado não podem ser verificados daqui.</value>
-  </data>
   <data name="Set a new server administration password." xml:space="preserve">
     <value>Defina uma nova senha de administração do servidor.</value>
   </data>
@@ -6725,6 +6728,12 @@ Continuar?</value>
   </data>
   <data name="Set header value" xml:space="preserve">
     <value>Definir o valor do cabeçalho</value>
+  </data>
+  <data name="Set the HTTP or HTTPS port on the Web services &amp; autoconfiguration page so the URLs answer, then publish autoconfig.&lt;domain&gt; and autodiscover.&lt;domain&gt; DNS records for each mail domain, pointing at this server. These are address records, and this page checks TXT records only, so they cannot be confirmed from here." xml:space="preserve">
+    <value>Defina a porta HTTP ou HTTPS na página Serviços web e autoconfiguração para que as URLs respondam, depois publique registros DNS autoconfig.&lt;domain&gt; e autodiscover.&lt;domain&gt; para cada domínio de e-mail, apontando para este servidor. São registros de endereço, e esta página verifica apenas registros TXT, então eles não podem ser confirmados daqui.</value>
+  </data>
+  <data name="Set the HTTPS port on the Web services &amp; autoconfiguration page (RFC 8461 requires the policy over HTTPS), give the listener a certificate that covers mta-sts.&lt;domain&gt;, then for each domain publish an A/AAAA (or CNAME) record for mta-sts.&lt;domain&gt; pointing at this server and a TXT record at _mta-sts.&lt;domain&gt; (v=STSv1; id=...). This page checks the TXT record; the address record and the certificate's name coverage cannot be checked from here." xml:space="preserve">
+    <value>Defina a porta HTTPS na página Serviços web e autoconfiguração (a RFC 8461 exige a política por HTTPS), dê ao ouvinte um certificado que cubra mta-sts.&lt;domain&gt;, depois, para cada domínio, publique um registro A/AAAA (ou CNAME) para mta-sts.&lt;domain&gt; apontando para este servidor e um registro TXT em _mta-sts.&lt;domain&gt; (v=STSv1; id=...). Esta página verifica o registro TXT; o registro de endereço e a cobertura de nome do certificado não podem ser verificados daqui.</value>
   </data>
   <data name="Set the SMTP relayer, and its credentials if the provider needs them." xml:space="preserve">
     <value>Defina o relay SMTP e suas credenciais, se o provedor precisar delas.</value>

--- a/hmailserver/source/Tools/ControlPanel/Resources/Strings.resx
+++ b/hmailserver/source/Tools/ControlPanel/Resources/Strings.resx
@@ -2917,8 +2917,8 @@ No mail is touched - the index is derived from it - but until the rebuild catche
   <data name="Enter a valid port number." xml:space="preserve">
     <value>Enter a valid port number.</value>
   </data>
-  <data name="Enter an address and search. The trace records nothing at all unless MessageTraceEnabled is set in hMailServer.ini - it is off by default because it stores who corresponds with whom." xml:space="preserve">
-    <value>Enter an address and search. The trace records nothing at all unless MessageTraceEnabled is set in hMailServer.ini - it is off by default because it stores who corresponds with whom.</value>
+  <data name="Enter an address and search. The trace records nothing at all until message tracing is switched on, on the Logging page - it is off by default because it stores who corresponds with whom." xml:space="preserve">
+    <value>Enter an address and search. The trace records nothing at all until message tracing is switched on, on the Logging page - it is off by default because it stores who corresponds with whom.</value>
   </data>
   <data name="Enter part of a name and press Search, or search with an empty box to list all users." xml:space="preserve">
     <value>Enter part of a name and press Search, or search with an empty box to list all users.</value>
@@ -3438,6 +3438,9 @@ No mail is touched - the index is derived from it - but until the rebuild catche
   </data>
   <data name="Host/Name:  {0}" xml:space="preserve">
     <value>Host/Name:  {0}</value>
+  </data>
+  <data name="Hosted domain" xml:space="preserve">
+    <value>Hosted domain</value>
   </data>
   <data name="Hours between checks (1 to 168)" xml:space="preserve">
     <value>Hours between checks (1 to 168)</value>
@@ -4554,8 +4557,8 @@ The verified installer is handed to the update helper: the service stops, the ne
   <data name="No encryption is available on this port. Inbound mail from other servers is normally unencrypted anyway, but this port also accepts AUTH, and a client using it sends its password in the clear." xml:space="preserve">
     <value>No encryption is available on this port. Inbound mail from other servers is normally unencrypted anyway, but this port also accepts AUTH, and a client using it sends its password in the clear.</value>
   </data>
-  <data name="No events for that address. Either nothing has happened to it, or the trace was switched off at the time - it records only while MessageTraceEnabled is set." xml:space="preserve">
-    <value>No events for that address. Either nothing has happened to it, or the trace was switched off at the time - it records only while MessageTraceEnabled is set.</value>
+  <data name="No events for that address. Either nothing has happened to it, or the trace was switched off at the time - it records only while message tracing is on (Logging page)." xml:space="preserve">
+    <value>No events for that address. Either nothing has happened to it, or the trace was switched off at the time - it records only while message tracing is on (Logging page).</value>
   </data>
   <data name="No events for that message." xml:space="preserve">
     <value>No events for that message.</value>
@@ -4710,8 +4713,8 @@ The verified installer is handed to the update helper: the service stops, the ne
   <data name="Not checked from here, honestly: verifying the PTR needs the server's PUBLIC IP address, which this panel cannot determine (behind NAT the machine does not know it either), and this page's checker reads TXT records only. Test from outside instead: nslookup &lt;your public IP&gt; shows the PTR; it should name the host above." xml:space="preserve">
     <value>Not checked from here, honestly: verifying the PTR needs the server's PUBLIC IP address, which this panel cannot determine (behind NAT the machine does not know it either), and this page's checker reads TXT records only. Test from outside instead: nslookup &lt;your public IP&gt; shows the PTR; it should name the host above.</value>
   </data>
-  <data name="Not checked yet (Check for updates, or UpdateCheckEnabled=1 in hMailServer.INI for a daily check)" xml:space="preserve">
-    <value>Not checked yet (Check for updates, or UpdateCheckEnabled=1 in hMailServer.INI for a daily check)</value>
+  <data name="Not checked yet (Check for updates, or turn on the daily check under Updates on the API &amp; monitoring page)" xml:space="preserve">
+    <value>Not checked yet (Check for updates, or turn on the daily check under Updates on the API &amp; monitoring page)</value>
   </data>
   <data name="Not checked yet. Publish the record, allow time for propagation, then press &quot;Check DNS&quot;." xml:space="preserve">
     <value>Not checked yet. Publish the record, allow time for propagation, then press "Check DNS".</value>
@@ -4758,11 +4761,14 @@ The verified installer is handed to the update helper: the service stops, the ne
   <data name="Nothing here needs a decision: no mailbox is being skipped and none is being disabled." xml:space="preserve">
     <value>Nothing here needs a decision: no mailbox is being skipped and none is being disabled.</value>
   </data>
+  <data name="Nothing here yet - Add creates the first entry." xml:space="preserve">
+    <value>Nothing here yet - Add creates the first entry.</value>
+  </data>
   <data name="Nothing is ever marked as spam: marking needs a mark threshold above 0, and a 0 there means &quot;never&quot; rather than &quot;always&quot;. Messages reaching {0} are still refused." xml:space="preserve">
     <value>Nothing is ever marked as spam: marking needs a mark threshold above 0, and a 0 there means "never" rather than "always". Messages reaching {0} are still refused.</value>
   </data>
-  <data name="Nothing is held. Quarantining is off unless QuarantineEnabled is set in hMailServer.ini - until then, spam over the delete threshold is refused during the SMTP conversation rather than stored." xml:space="preserve">
-    <value>Nothing is held. Quarantining is off unless QuarantineEnabled is set in hMailServer.ini - until then, spam over the delete threshold is refused during the SMTP conversation rather than stored.</value>
+  <data name="Nothing is held. Quarantining is switched off - turn it on under Anti-spam settings - and until it is on, spam over the delete threshold is refused during the SMTP conversation rather than stored." xml:space="preserve">
+    <value>Nothing is held. Quarantining is switched off - turn it on under Anti-spam settings - and until it is on, spam over the delete threshold is refused during the SMTP conversation rather than stored.</value>
   </data>
   <data name="Nothing matched &quot;{0}&quot;. Try what you are trying to achieve (&quot;stop spam&quot;, &quot;let a device send mail&quot;), a page name, or an hMailServer.INI key." xml:space="preserve">
     <value>Nothing matched "{0}". Try what you are trying to achieve ("stop spam", "let a device send mail"), a page name, or an hMailServer.INI key.</value>
@@ -5749,6 +5755,9 @@ Run this if clients report messages appearing under the wrong UID, or after rest
   <data name="Remember this many previous passwords (0 = no history)" xml:space="preserve">
     <value>Remember this many previous passwords (0 = no history)</value>
   </data>
+  <data name="Remote domain" xml:space="preserve">
+    <value>Remote domain</value>
+  </data>
   <data name="Remove _expired" xml:space="preserve">
     <value>Remove _expired</value>
   </data>
@@ -6708,12 +6717,6 @@ Continue?</value>
   <data name="Set TlsRptFromAddress in the [Settings] section of hMailServer.ini to a mailbox reports should be sent from. Leaving it empty is a valid choice - it just means the collected statistics are discarded and no reports are ever sent." xml:space="preserve">
     <value>Set TlsRptFromAddress in the [Settings] section of hMailServer.ini to a mailbox reports should be sent from. Leaving it empty is a valid choice - it just means the collected statistics are discarded and no reports are ever sent.</value>
   </data>
-  <data name="Set WebServicesHttpPort and/or WebServicesHttpsPort in hMailServer.ini so the URLs answer, then publish autoconfig.&lt;domain&gt; and autodiscover.&lt;domain&gt; DNS records for each mail domain, pointing at this server. These are address records, and this page checks TXT records only, so they cannot be confirmed from here." xml:space="preserve">
-    <value>Set WebServicesHttpPort and/or WebServicesHttpsPort in hMailServer.ini so the URLs answer, then publish autoconfig.&lt;domain&gt; and autodiscover.&lt;domain&gt; DNS records for each mail domain, pointing at this server. These are address records, and this page checks TXT records only, so they cannot be confirmed from here.</value>
-  </data>
-  <data name="Set WebServicesHttpsPort in hMailServer.ini (RFC 8461 requires the policy over HTTPS), give the listener a certificate that covers mta-sts.&lt;domain&gt;, then for each domain publish an A/AAAA (or CNAME) record for mta-sts.&lt;domain&gt; pointing at this server and a TXT record at _mta-sts.&lt;domain&gt; (v=STSv1; id=...). This page checks the TXT record; the address record and the certificate's name coverage cannot be checked from here." xml:space="preserve">
-    <value>Set WebServicesHttpsPort in hMailServer.ini (RFC 8461 requires the policy over HTTPS), give the listener a certificate that covers mta-sts.&lt;domain&gt;, then for each domain publish an A/AAAA (or CNAME) record for mta-sts.&lt;domain&gt; pointing at this server and a TXT record at _mta-sts.&lt;domain&gt; (v=STSv1; id=...). This page checks the TXT record; the address record and the certificate's name coverage cannot be checked from here.</value>
-  </data>
   <data name="Set a new server administration password." xml:space="preserve">
     <value>Set a new server administration password.</value>
   </data>
@@ -6725,6 +6728,12 @@ Continue?</value>
   </data>
   <data name="Set header value" xml:space="preserve">
     <value>Set header value</value>
+  </data>
+  <data name="Set the HTTP or HTTPS port on the Web services &amp; autoconfiguration page so the URLs answer, then publish autoconfig.&lt;domain&gt; and autodiscover.&lt;domain&gt; DNS records for each mail domain, pointing at this server. These are address records, and this page checks TXT records only, so they cannot be confirmed from here." xml:space="preserve">
+    <value>Set the HTTP or HTTPS port on the Web services &amp; autoconfiguration page so the URLs answer, then publish autoconfig.&lt;domain&gt; and autodiscover.&lt;domain&gt; DNS records for each mail domain, pointing at this server. These are address records, and this page checks TXT records only, so they cannot be confirmed from here.</value>
+  </data>
+  <data name="Set the HTTPS port on the Web services &amp; autoconfiguration page (RFC 8461 requires the policy over HTTPS), give the listener a certificate that covers mta-sts.&lt;domain&gt;, then for each domain publish an A/AAAA (or CNAME) record for mta-sts.&lt;domain&gt; pointing at this server and a TXT record at _mta-sts.&lt;domain&gt; (v=STSv1; id=...). This page checks the TXT record; the address record and the certificate's name coverage cannot be checked from here." xml:space="preserve">
+    <value>Set the HTTPS port on the Web services &amp; autoconfiguration page (RFC 8461 requires the policy over HTTPS), give the listener a certificate that covers mta-sts.&lt;domain&gt;, then for each domain publish an A/AAAA (or CNAME) record for mta-sts.&lt;domain&gt; pointing at this server and a TXT record at _mta-sts.&lt;domain&gt; (v=STSv1; id=...). This page checks the TXT record; the address record and the certificate's name coverage cannot be checked from here.</value>
   </data>
   <data name="Set the SMTP relayer, and its credentials if the provider needs them." xml:space="preserve">
     <value>Set the SMTP relayer, and its credentials if the provider needs them.</value>

--- a/hmailserver/source/Tools/ControlPanel/Resources/Strings.ru.resx
+++ b/hmailserver/source/Tools/ControlPanel/Resources/Strings.ru.resx
@@ -2917,8 +2917,8 @@ Control Panel может читать файлы сообщений только
   <data name="Enter a valid port number." xml:space="preserve">
     <value>Введите корректный номер порта.</value>
   </data>
-  <data name="Enter an address and search. The trace records nothing at all unless MessageTraceEnabled is set in hMailServer.ini - it is off by default because it stores who corresponds with whom." xml:space="preserve">
-    <value>Введите адрес и выполните поиск. Трассировка не записывает вообще ничего, пока в hMailServer.ini не задан MessageTraceEnabled, — по умолчанию она выключена, поскольку хранит сведения о том, кто с кем переписывается.</value>
+  <data name="Enter an address and search. The trace records nothing at all until message tracing is switched on, on the Logging page - it is off by default because it stores who corresponds with whom." xml:space="preserve">
+    <value>Введите адрес и выполните поиск. Трассировка ничего не записывает, пока трассировка сообщений не будет включена на странице «Журналирование», – по умолчанию она выключена, потому что сохраняет, кто с кем переписывается.</value>
   </data>
   <data name="Enter part of a name and press Search, or search with an empty box to list all users." xml:space="preserve">
     <value>Введите часть имени и нажмите «Найти» либо выполните поиск с пустым полем, чтобы получить список всех пользователей.</value>
@@ -3438,6 +3438,9 @@ Control Panel может читать файлы сообщений только
   </data>
   <data name="Host/Name:  {0}" xml:space="preserve">
     <value>Узел/имя:  {0}</value>
+  </data>
+  <data name="Hosted domain" xml:space="preserve">
+    <value>Размещённый домен</value>
   </data>
   <data name="Hours between checks (1 to 168)" xml:space="preserve">
     <value>Часов между проверками (от 1 до 168)</value>
@@ -4554,8 +4557,8 @@ Control Panel может читать файлы сообщений только
   <data name="No encryption is available on this port. Inbound mail from other servers is normally unencrypted anyway, but this port also accepts AUTH, and a client using it sends its password in the clear." xml:space="preserve">
     <value>На этом порту шифрование недоступно. Входящая почта с других серверов и так обычно не шифруется, но этот порт принимает ещё и AUTH, и использующий его клиент отправляет свой пароль открытым текстом.</value>
   </data>
-  <data name="No events for that address. Either nothing has happened to it, or the trace was switched off at the time - it records only while MessageTraceEnabled is set." xml:space="preserve">
-    <value>Событий для этого адреса нет. Либо с ним ничего не происходило, либо трассировка в тот момент была выключена: она записывает только при заданном MessageTraceEnabled.</value>
+  <data name="No events for that address. Either nothing has happened to it, or the trace was switched off at the time - it records only while message tracing is on (Logging page)." xml:space="preserve">
+    <value>Событий для этого адреса нет. Либо с ним ничего не происходило, либо трассировка в то время была выключена – она записывает только пока трассировка сообщений включена (страница «Журналирование»).</value>
   </data>
   <data name="No events for that message." xml:space="preserve">
     <value>Событий для этого сообщения нет.</value>
@@ -4710,8 +4713,8 @@ Control Panel может читать файлы сообщений только
   <data name="Not checked from here, honestly: verifying the PTR needs the server's PUBLIC IP address, which this panel cannot determine (behind NAT the machine does not know it either), and this page's checker reads TXT records only. Test from outside instead: nslookup &lt;your public IP&gt; shows the PTR; it should name the host above." xml:space="preserve">
     <value>Отсюда, честно говоря, не проверяется: чтобы проверить PTR, нужен ПУБЛИЧНЫЙ IP-адрес сервера, который эта панель определить не может (за NAT его не знает и сам компьютер), а средство проверки на этой странице читает только записи TXT. Проверьте снаружи: nslookup &lt;your public IP&gt; показывает PTR; он должен называть узел, указанный выше.</value>
   </data>
-  <data name="Not checked yet (Check for updates, or UpdateCheckEnabled=1 in hMailServer.INI for a daily check)" xml:space="preserve">
-    <value>Ещё не проверено (нажмите «Проверить обновления» либо задайте UpdateCheckEnabled=1 в hMailServer.INI для ежедневной проверки)</value>
+  <data name="Not checked yet (Check for updates, or turn on the daily check under Updates on the API &amp; monitoring page)" xml:space="preserve">
+    <value>Ещё не проверялось (нажмите «Проверить обновления» или включите ежедневную проверку в разделе «Обновления» на странице «API и мониторинг»)</value>
   </data>
   <data name="Not checked yet. Publish the record, allow time for propagation, then press &quot;Check DNS&quot;." xml:space="preserve">
     <value>Ещё не проверено. Опубликуйте запись, дайте время на распространение, затем нажмите «Проверить DNS».</value>
@@ -4758,11 +4761,14 @@ Control Panel может читать файлы сообщений только
   <data name="Nothing here needs a decision: no mailbox is being skipped and none is being disabled." xml:space="preserve">
     <value>Здесь ничего решать не нужно: ни один почтовый ящик не пропускается и ни один не отключается.</value>
   </data>
+  <data name="Nothing here yet - Add creates the first entry." xml:space="preserve">
+    <value>Пока пусто – кнопка «Добавить» создаёт первую запись.</value>
+  </data>
   <data name="Nothing is ever marked as spam: marking needs a mark threshold above 0, and a 0 there means &quot;never&quot; rather than &quot;always&quot;. Messages reaching {0} are still refused." xml:space="preserve">
     <value>Ничто и никогда не помечается как спам: для пометки нужен порог пометки больше 0, а 0 здесь означает «никогда», а не «всегда». Сообщения, достигающие {0}, всё равно отклоняются.</value>
   </data>
-  <data name="Nothing is held. Quarantining is off unless QuarantineEnabled is set in hMailServer.ini - until then, spam over the delete threshold is refused during the SMTP conversation rather than stored." xml:space="preserve">
-    <value>Ничего не задерживается. Карантин выключен, пока в hMailServer.ini не задан QuarantineEnabled; до тех пор спам выше порога удаления отклоняется прямо в ходе разговора SMTP, а не сохраняется.</value>
+  <data name="Nothing is held. Quarantining is switched off - turn it on under Anti-spam settings - and until it is on, spam over the delete threshold is refused during the SMTP conversation rather than stored." xml:space="preserve">
+    <value>Ничего не задержано. Карантин выключен – включите его в разделе «Параметры антиспама», – а пока он выключен, спам выше порога удаления отклоняется во время сеанса SMTP, а не сохраняется.</value>
   </data>
   <data name="Nothing matched &quot;{0}&quot;. Try what you are trying to achieve (&quot;stop spam&quot;, &quot;let a device send mail&quot;), a page name, or an hMailServer.INI key." xml:space="preserve">
     <value>Ничто не совпало с «{0}». Попробуйте описать то, чего вы хотите добиться («остановить спам», «разрешить устройству отправлять почту»), либо имя страницы, либо ключ из hMailServer.INI.</value>
@@ -5749,6 +5755,9 @@ Control Panel может читать файлы сообщений только
   <data name="Remember this many previous passwords (0 = no history)" xml:space="preserve">
     <value>Запоминать столько предыдущих паролей (0 — без истории)</value>
   </data>
+  <data name="Remote domain" xml:space="preserve">
+    <value>Удалённый домен</value>
+  </data>
   <data name="Remove _expired" xml:space="preserve">
     <value>Удалить _просроченные</value>
   </data>
@@ -6708,12 +6717,6 @@ SMTP 25 и 587, POP3 110, IMAP 143 — без защиты подключени�
   <data name="Set TlsRptFromAddress in the [Settings] section of hMailServer.ini to a mailbox reports should be sent from. Leaving it empty is a valid choice - it just means the collected statistics are discarded and no reports are ever sent." xml:space="preserve">
     <value>Задайте TlsRptFromAddress в разделе [Settings] файла hMailServer.ini, указав почтовый ящик, от имени которого следует отправлять отчёты. Оставить его пустым — допустимый выбор: это просто означает, что собранная статистика отбрасывается и отчёты не отправляются никогда.</value>
   </data>
-  <data name="Set WebServicesHttpPort and/or WebServicesHttpsPort in hMailServer.ini so the URLs answer, then publish autoconfig.&lt;domain&gt; and autodiscover.&lt;domain&gt; DNS records for each mail domain, pointing at this server. These are address records, and this page checks TXT records only, so they cannot be confirmed from here." xml:space="preserve">
-    <value>Задайте в hMailServer.ini WebServicesHttpPort и (или) WebServicesHttpsPort, чтобы URL отвечали, а затем для каждого почтового домена опубликуйте записи DNS autoconfig.&lt;domain&gt; и autodiscover.&lt;domain&gt;, указывающие на этот сервер. Это адресные записи, а данная страница проверяет только записи TXT, поэтому подтвердить их отсюда невозможно.</value>
-  </data>
-  <data name="Set WebServicesHttpsPort in hMailServer.ini (RFC 8461 requires the policy over HTTPS), give the listener a certificate that covers mta-sts.&lt;domain&gt;, then for each domain publish an A/AAAA (or CNAME) record for mta-sts.&lt;domain&gt; pointing at this server and a TXT record at _mta-sts.&lt;domain&gt; (v=STSv1; id=...). This page checks the TXT record; the address record and the certificate's name coverage cannot be checked from here." xml:space="preserve">
-    <value>Задайте в hMailServer.ini WebServicesHttpsPort (RFC 8461 требует отдавать политику по HTTPS), назначьте прослушивателю сертификат, покрывающий mta-sts.&lt;domain&gt;, а затем для каждого домена опубликуйте запись A/AAAA (или CNAME) для mta-sts.&lt;domain&gt;, указывающую на этот сервер, и запись TXT по адресу _mta-sts.&lt;domain&gt; (v=STSv1; id=...). Эта страница проверяет запись TXT; адресную запись и покрытие имени сертификатом отсюда проверить нельзя.</value>
-  </data>
   <data name="Set a new server administration password." xml:space="preserve">
     <value>Задайте новый пароль администрирования сервера.</value>
   </data>
@@ -6725,6 +6728,12 @@ SMTP 25 и 587, POP3 110, IMAP 143 — без защиты подключени�
   </data>
   <data name="Set header value" xml:space="preserve">
     <value>Задать значение заголовка</value>
+  </data>
+  <data name="Set the HTTP or HTTPS port on the Web services &amp; autoconfiguration page so the URLs answer, then publish autoconfig.&lt;domain&gt; and autodiscover.&lt;domain&gt; DNS records for each mail domain, pointing at this server. These are address records, and this page checks TXT records only, so they cannot be confirmed from here." xml:space="preserve">
+    <value>Задайте порт HTTP или HTTPS на странице «Веб-службы и автоконфигурация» WebServicesHttpPort и (или) WebServicesHttpsPort, чтобы URL отвечали, а затем для каждого почтового домена опубликуйте записи DNS autoconfig.&lt;domain&gt; и autodiscover.&lt;domain&gt;, указывающие на этот сервер. Это адресные записи, а данная страница проверяет только записи TXT, поэтому подтвердить их отсюда невозможно.</value>
+  </data>
+  <data name="Set the HTTPS port on the Web services &amp; autoconfiguration page (RFC 8461 requires the policy over HTTPS), give the listener a certificate that covers mta-sts.&lt;domain&gt;, then for each domain publish an A/AAAA (or CNAME) record for mta-sts.&lt;domain&gt; pointing at this server and a TXT record at _mta-sts.&lt;domain&gt; (v=STSv1; id=...). This page checks the TXT record; the address record and the certificate's name coverage cannot be checked from here." xml:space="preserve">
+    <value>Задайте порт HTTPS на странице «Веб-службы и автоконфигурация» WebServicesHttpsPort (RFC 8461 требует отдавать политику по HTTPS), назначьте прослушивателю сертификат, покрывающий mta-sts.&lt;domain&gt;, а затем для каждого домена опубликуйте запись A/AAAA (или CNAME) для mta-sts.&lt;domain&gt;, указывающую на этот сервер, и запись TXT по адресу _mta-sts.&lt;domain&gt; (v=STSv1; id=...). Эта страница проверяет запись TXT; адресную запись и покрытие имени сертификатом отсюда проверить нельзя.</value>
   </data>
   <data name="Set the SMTP relayer, and its credentials if the provider needs them." xml:space="preserve">
     <value>Укажите ретранслятор SMTP и, если поставщик их требует, учётные данные к нему.</value>

--- a/hmailserver/source/Tools/ControlPanel/Resources/Strings.sv.resx
+++ b/hmailserver/source/Tools/ControlPanel/Resources/Strings.sv.resx
@@ -2917,8 +2917,8 @@ Ingen post rörs - indexet härleds från den - men tills ombyggnaden kommer ika
   <data name="Enter a valid port number." xml:space="preserve">
     <value>Ange ett giltigt portnummer.</value>
   </data>
-  <data name="Enter an address and search. The trace records nothing at all unless MessageTraceEnabled is set in hMailServer.ini - it is off by default because it stores who corresponds with whom." xml:space="preserve">
-    <value>Ange en adress och sök. Spårningen registrerar ingenting alls om inte MessageTraceEnabled är satt i hMailServer.ini - den är av som standard eftersom den lagrar vem som brevväxlar med vem.</value>
+  <data name="Enter an address and search. The trace records nothing at all until message tracing is switched on, on the Logging page - it is off by default because it stores who corresponds with whom." xml:space="preserve">
+    <value>Ange en adress och sök. Spårningen registrerar ingenting förrän meddelandespårning slås på på sidan Loggning – den är av som standard eftersom den lagrar vem som brevväxlar med vem.</value>
   </data>
   <data name="Enter part of a name and press Search, or search with an empty box to list all users." xml:space="preserve">
     <value>Ange en del av ett namn och tryck på Sök, eller sök med tom ruta för att lista alla användare.</value>
@@ -3438,6 +3438,9 @@ Ingen post rörs - indexet härleds från den - men tills ombyggnaden kommer ika
   </data>
   <data name="Host/Name:  {0}" xml:space="preserve">
     <value>Värd/Namn:  {0}</value>
+  </data>
+  <data name="Hosted domain" xml:space="preserve">
+    <value>Hostad domän</value>
   </data>
   <data name="Hours between checks (1 to 168)" xml:space="preserve">
     <value>Timmar mellan kontroller (1 till 168)</value>
@@ -4554,8 +4557,8 @@ Det verifierade installationsprogrammet lämnas över till uppdateringshjälpen:
   <data name="No encryption is available on this port. Inbound mail from other servers is normally unencrypted anyway, but this port also accepts AUTH, and a client using it sends its password in the clear." xml:space="preserve">
     <value>Ingen kryptering är tillgänglig på den här porten. Inkommande post från andra servrar är normalt okrypterad ändå, men den här porten godtar också AUTH, och en klient som använder den skickar sitt lösenord i klartext.</value>
   </data>
-  <data name="No events for that address. Either nothing has happened to it, or the trace was switched off at the time - it records only while MessageTraceEnabled is set." xml:space="preserve">
-    <value>Inga händelser för den adressen. Antingen har inget hänt med den, eller så var spårningen avstängd vid tillfället - den registrerar bara medan MessageTraceEnabled är satt.</value>
+  <data name="No events for that address. Either nothing has happened to it, or the trace was switched off at the time - it records only while message tracing is on (Logging page)." xml:space="preserve">
+    <value>Inga händelser för den adressen. Antingen har inget hänt med den, eller så var spårningen avstängd vid den tidpunkten – den registrerar bara medan meddelandespårning är på (sidan Loggning).</value>
   </data>
   <data name="No events for that message." xml:space="preserve">
     <value>Inga händelser för det meddelandet.</value>
@@ -4710,8 +4713,8 @@ Det verifierade installationsprogrammet lämnas över till uppdateringshjälpen:
   <data name="Not checked from here, honestly: verifying the PTR needs the server's PUBLIC IP address, which this panel cannot determine (behind NAT the machine does not know it either), and this page's checker reads TXT records only. Test from outside instead: nslookup &lt;your public IP&gt; shows the PTR; it should name the host above." xml:space="preserve">
     <value>Kontrolleras ärligt talat inte härifrån: att verifiera PTR-posten kräver serverns PUBLIKA IP-adress, som den här panelen inte kan avgöra (bakom NAT vet datorn den inte heller), och den här sidans kontroll läser bara TXT-poster. Testa från utsidan i stället: nslookup &lt;din publika IP&gt; visar PTR-posten; den ska namnge värden ovan.</value>
   </data>
-  <data name="Not checked yet (Check for updates, or UpdateCheckEnabled=1 in hMailServer.INI for a daily check)" xml:space="preserve">
-    <value>Inte kontrollerad ännu (Sök efter uppdateringar, eller UpdateCheckEnabled=1 i hMailServer.INI för en daglig kontroll)</value>
+  <data name="Not checked yet (Check for updates, or turn on the daily check under Updates on the API &amp; monitoring page)" xml:space="preserve">
+    <value>Inte kontrollerat ännu (Sök efter uppdateringar, eller slå på den dagliga kontrollen under Uppdateringar på sidan API &amp; övervakning)</value>
   </data>
   <data name="Not checked yet. Publish the record, allow time for propagation, then press &quot;Check DNS&quot;." xml:space="preserve">
     <value>Inte kontrollerad ännu. Publicera posten, ge tid för spridning, och tryck sedan på "Kontrollera DNS".</value>
@@ -4758,11 +4761,14 @@ Det verifierade installationsprogrammet lämnas över till uppdateringshjälpen:
   <data name="Nothing here needs a decision: no mailbox is being skipped and none is being disabled." xml:space="preserve">
     <value>Inget här kräver ett beslut: ingen brevlåda hoppas över och ingen inaktiveras.</value>
   </data>
+  <data name="Nothing here yet - Add creates the first entry." xml:space="preserve">
+    <value>Inget här ännu – Lägg till skapar den första posten.</value>
+  </data>
   <data name="Nothing is ever marked as spam: marking needs a mark threshold above 0, and a 0 there means &quot;never&quot; rather than &quot;always&quot;. Messages reaching {0} are still refused." xml:space="preserve">
     <value>Inget markeras någonsin som skräppost: markering kräver en markeringströskel över 0, och en 0 där betyder "aldrig" snarare än "alltid". Meddelanden som når {0} avvisas ändå.</value>
   </data>
-  <data name="Nothing is held. Quarantining is off unless QuarantineEnabled is set in hMailServer.ini - until then, spam over the delete threshold is refused during the SMTP conversation rather than stored." xml:space="preserve">
-    <value>Inget är kvarhållet. Karantän är av om inte QuarantineEnabled är satt i hMailServer.ini - fram till dess avvisas skräppost över borttagningströskeln under SMTP-konversationen i stället för att lagras.</value>
+  <data name="Nothing is held. Quarantining is switched off - turn it on under Anti-spam settings - and until it is on, spam over the delete threshold is refused during the SMTP conversation rather than stored." xml:space="preserve">
+    <value>Inget hålls kvar. Karantän är avstängd – slå på den under Skräppostinställningar – och tills den är på avvisas skräppost över raderingströskeln under SMTP-konversationen i stället för att lagras.</value>
   </data>
   <data name="Nothing matched &quot;{0}&quot;. Try what you are trying to achieve (&quot;stop spam&quot;, &quot;let a device send mail&quot;), a page name, or an hMailServer.INI key." xml:space="preserve">
     <value>Inget matchade "{0}". Prova det du försöker uppnå ("stoppa skräppost", "låt en enhet skicka post"), ett sidnamn, eller en hMailServer.INI-nyckel.</value>
@@ -5749,6 +5755,9 @@ Kör detta om klienter rapporterar meddelanden som dyker upp under fel UID, elle
   <data name="Remember this many previous passwords (0 = no history)" xml:space="preserve">
     <value>Kom ihåg så här många tidigare lösenord (0 = ingen historik)</value>
   </data>
+  <data name="Remote domain" xml:space="preserve">
+    <value>Fjärrdomän</value>
+  </data>
   <data name="Remove _expired" xml:space="preserve">
     <value>Ta bort _utgångna</value>
   </data>
@@ -6708,12 +6717,6 @@ Fortsätt?</value>
   <data name="Set TlsRptFromAddress in the [Settings] section of hMailServer.ini to a mailbox reports should be sent from. Leaving it empty is a valid choice - it just means the collected statistics are discarded and no reports are ever sent." xml:space="preserve">
     <value>Sätt TlsRptFromAddress i sektionen [Settings] i hMailServer.ini till en brevlåda rapporter ska skickas från. Att lämna den tom är ett giltigt val - det betyder bara att den insamlade statistiken kastas och inga rapporter någonsin skickas.</value>
   </data>
-  <data name="Set WebServicesHttpPort and/or WebServicesHttpsPort in hMailServer.ini so the URLs answer, then publish autoconfig.&lt;domain&gt; and autodiscover.&lt;domain&gt; DNS records for each mail domain, pointing at this server. These are address records, and this page checks TXT records only, so they cannot be confirmed from here." xml:space="preserve">
-    <value>Sätt WebServicesHttpPort och/eller WebServicesHttpsPort i hMailServer.ini så att URL:erna svarar, och publicera sedan DNS-posterna autoconfig.&lt;domain&gt; och autodiscover.&lt;domain&gt; för varje e-postdomän, pekande på den här servern. Det är adressposter, och den här sidan kontrollerar bara TXT-poster, så de kan inte bekräftas härifrån.</value>
-  </data>
-  <data name="Set WebServicesHttpsPort in hMailServer.ini (RFC 8461 requires the policy over HTTPS), give the listener a certificate that covers mta-sts.&lt;domain&gt;, then for each domain publish an A/AAAA (or CNAME) record for mta-sts.&lt;domain&gt; pointing at this server and a TXT record at _mta-sts.&lt;domain&gt; (v=STSv1; id=...). This page checks the TXT record; the address record and the certificate's name coverage cannot be checked from here." xml:space="preserve">
-    <value>Sätt WebServicesHttpsPort i hMailServer.ini (RFC 8461 kräver policyn över HTTPS), ge lyssnaren ett certifikat som täcker mta-sts.&lt;domain&gt;, och publicera sedan för varje domän en A-/AAAA-post (eller CNAME) för mta-sts.&lt;domain&gt; som pekar på den här servern och en TXT-post på _mta-sts.&lt;domain&gt; (v=STSv1; id=...). Den här sidan kontrollerar TXT-posten; adressposten och certifikatets namntäckning kan inte kontrolleras härifrån.</value>
-  </data>
   <data name="Set a new server administration password." xml:space="preserve">
     <value>Sätt ett nytt administrationslösenord för servern.</value>
   </data>
@@ -6725,6 +6728,12 @@ Fortsätt?</value>
   </data>
   <data name="Set header value" xml:space="preserve">
     <value>Sätt rubrikvärde</value>
+  </data>
+  <data name="Set the HTTP or HTTPS port on the Web services &amp; autoconfiguration page so the URLs answer, then publish autoconfig.&lt;domain&gt; and autodiscover.&lt;domain&gt; DNS records for each mail domain, pointing at this server. These are address records, and this page checks TXT records only, so they cannot be confirmed from here." xml:space="preserve">
+    <value>Ange HTTP- eller HTTPS-porten på sidan Webbtjänster &amp; automatisk konfiguration så att URL:erna svarar, och publicera sedan DNS-posterna autoconfig.&lt;domain&gt; och autodiscover.&lt;domain&gt; för varje e-postdomän, pekande på den här servern. Det är adressposter, och den här sidan kontrollerar bara TXT-poster, så de kan inte bekräftas härifrån.</value>
+  </data>
+  <data name="Set the HTTPS port on the Web services &amp; autoconfiguration page (RFC 8461 requires the policy over HTTPS), give the listener a certificate that covers mta-sts.&lt;domain&gt;, then for each domain publish an A/AAAA (or CNAME) record for mta-sts.&lt;domain&gt; pointing at this server and a TXT record at _mta-sts.&lt;domain&gt; (v=STSv1; id=...). This page checks the TXT record; the address record and the certificate's name coverage cannot be checked from here." xml:space="preserve">
+    <value>Ange HTTPS-porten på sidan Webbtjänster &amp; automatisk konfiguration (RFC 8461 kräver policyn över HTTPS), ge lyssnaren ett certifikat som täcker mta-sts.&lt;domain&gt;, och publicera sedan för varje domän en A-/AAAA-post (eller CNAME) för mta-sts.&lt;domain&gt; som pekar på den här servern och en TXT-post på _mta-sts.&lt;domain&gt; (v=STSv1; id=...). Den här sidan kontrollerar TXT-posten; adressposten och certifikatets namntäckning kan inte kontrolleras härifrån.</value>
   </data>
   <data name="Set the SMTP relayer, and its credentials if the provider needs them." xml:space="preserve">
     <value>Sätt SMTP-reläet, och dess inloggningsuppgifter om leverantören behöver dem.</value>

--- a/hmailserver/source/Tools/ControlPanel/Resources/Strings.tr.resx
+++ b/hmailserver/source/Tools/ControlPanel/Resources/Strings.tr.resx
@@ -2917,8 +2917,8 @@ Postaya dokunulmaz - indeks ondan türetilir - ama yeniden oluşturma yetişene 
   <data name="Enter a valid port number." xml:space="preserve">
     <value>Geçerli bir port numarası girin.</value>
   </data>
-  <data name="Enter an address and search. The trace records nothing at all unless MessageTraceEnabled is set in hMailServer.ini - it is off by default because it stores who corresponds with whom." xml:space="preserve">
-    <value>Bir adres girip arayın. hMailServer.ini içinde MessageTraceEnabled ayarlanmadıkça izleme hiçbir şey kaydetmez - kimin kiminle yazıştığını sakladığı için varsayılan olarak kapalıdır.</value>
+  <data name="Enter an address and search. The trace records nothing at all until message tracing is switched on, on the Logging page - it is off by default because it stores who corresponds with whom." xml:space="preserve">
+    <value>Bir adres girin ve arayın. İzleme, Günlükleme sayfasında ileti izleme açılana kadar hiçbir şey kaydetmez – kimin kiminle yazıştığını sakladığı için varsayılan olarak kapalıdır.</value>
   </data>
   <data name="Enter part of a name and press Search, or search with an empty box to list all users." xml:space="preserve">
     <value>Bir adın bir kısmını girip Ara'ya basın ya da tüm kullanıcıları listelemek için kutu boşken arayın.</value>
@@ -3438,6 +3438,9 @@ Postaya dokunulmaz - indeks ondan türetilir - ama yeniden oluşturma yetişene 
   </data>
   <data name="Host/Name:  {0}" xml:space="preserve">
     <value>Ana bilgisayar/Ad:  {0}</value>
+  </data>
+  <data name="Hosted domain" xml:space="preserve">
+    <value>Barındırılan etki alanı</value>
   </data>
   <data name="Hours between checks (1 to 168)" xml:space="preserve">
     <value>Denetimler arasındaki saat sayısı (1 ile 168 arası)</value>
@@ -4554,8 +4557,8 @@ Doğrulanan yükleyici güncelleştirme yardımcısına verilir: hizmet durur, y
   <data name="No encryption is available on this port. Inbound mail from other servers is normally unencrypted anyway, but this port also accepts AUTH, and a client using it sends its password in the clear." xml:space="preserve">
     <value>Bu portta şifreleme yok. Diğer sunuculardan gelen posta zaten olağan olarak şifresizdir, ama bu port AUTH de kabul eder ve onu kullanan bir istemci parolasını düz metin olarak gönderir.</value>
   </data>
-  <data name="No events for that address. Either nothing has happened to it, or the trace was switched off at the time - it records only while MessageTraceEnabled is set." xml:space="preserve">
-    <value>O adres için olay yok. Ya ona hiçbir şey olmadı ya da izleme o sırada kapalıydı - izleme yalnızca MessageTraceEnabled ayarlıyken kayıt tutar.</value>
+  <data name="No events for that address. Either nothing has happened to it, or the trace was switched off at the time - it records only while message tracing is on (Logging page)." xml:space="preserve">
+    <value>Bu adres için olay yok. Ya ona hiçbir şey olmadı ya da izleme o sırada kapalıydı – yalnızca ileti izleme açıkken kayıt yapar (Günlükleme sayfası).</value>
   </data>
   <data name="No events for that message." xml:space="preserve">
     <value>O ileti için olay yok.</value>
@@ -4710,8 +4713,8 @@ Doğrulanan yükleyici güncelleştirme yardımcısına verilir: hizmet durur, y
   <data name="Not checked from here, honestly: verifying the PTR needs the server's PUBLIC IP address, which this panel cannot determine (behind NAT the machine does not know it either), and this page's checker reads TXT records only. Test from outside instead: nslookup &lt;your public IP&gt; shows the PTR; it should name the host above." xml:space="preserve">
     <value>Buradan denetlenmedi, açıkçası: PTR'yi doğrulamak sunucunun GENEL IP adresini gerektirir ve bu panel onu belirleyemez (NAT arkasında makine de bilmez); bu sayfanın denetleyicisi ise yalnızca TXT kayıtlarını okur. Bunun yerine dışarıdan sınayın: nslookup &lt;your public IP&gt; PTR'yi gösterir; yukarıdaki ana bilgisayarı adlandırması gerekir.</value>
   </data>
-  <data name="Not checked yet (Check for updates, or UpdateCheckEnabled=1 in hMailServer.INI for a daily check)" xml:space="preserve">
-    <value>Henüz denetlenmedi (Güncelleştirmeleri denetle ya da günlük denetim için hMailServer.INI'de UpdateCheckEnabled=1)</value>
+  <data name="Not checked yet (Check for updates, or turn on the daily check under Updates on the API &amp; monitoring page)" xml:space="preserve">
+    <value>Henüz denetlenmedi (Güncelleştirmeleri denetleyin veya API ve izleme sayfasındaki Güncelleştirmeler altından günlük denetimi açın)</value>
   </data>
   <data name="Not checked yet. Publish the record, allow time for propagation, then press &quot;Check DNS&quot;." xml:space="preserve">
     <value>Henüz denetlenmedi. Kaydı yayımlayın, yayılması için zaman tanıyın, sonra "DNS'yi denetle"ye basın.</value>
@@ -4758,11 +4761,14 @@ Doğrulanan yükleyici güncelleştirme yardımcısına verilir: hizmet durur, y
   <data name="Nothing here needs a decision: no mailbox is being skipped and none is being disabled." xml:space="preserve">
     <value>Burada karar gerektiren bir şey yok: hiçbir posta kutusu atlanmıyor ve hiçbiri devre dışı bırakılmıyor.</value>
   </data>
+  <data name="Nothing here yet - Add creates the first entry." xml:space="preserve">
+    <value>Henüz burada bir şey yok – Ekle ilk girişi oluşturur.</value>
+  </data>
   <data name="Nothing is ever marked as spam: marking needs a mark threshold above 0, and a 0 there means &quot;never&quot; rather than &quot;always&quot;. Messages reaching {0} are still refused." xml:space="preserve">
     <value>Hiçbir şey hiçbir zaman spam olarak işaretlenmiyor: işaretleme 0'ın üzerinde bir işaretleme eşiği gerektirir ve oradaki 0 "her zaman" değil "hiçbir zaman" demektir. {0} puanına ulaşan iletiler yine reddedilir.</value>
   </data>
-  <data name="Nothing is held. Quarantining is off unless QuarantineEnabled is set in hMailServer.ini - until then, spam over the delete threshold is refused during the SMTP conversation rather than stored." xml:space="preserve">
-    <value>Hiçbir şey bekletilmiyor. hMailServer.ini içinde QuarantineEnabled ayarlanmadıkça karantina kapalıdır - o zamana kadar silme eşiğini aşan spam saklanmak yerine SMTP görüşmesi sırasında reddedilir.</value>
+  <data name="Nothing is held. Quarantining is switched off - turn it on under Anti-spam settings - and until it is on, spam over the delete threshold is refused during the SMTP conversation rather than stored." xml:space="preserve">
+    <value>Bekletilen bir şey yok. Karantina kapalı – Spam önleme ayarları altından açın – ve açılana kadar silme eşiğinin üzerindeki spam, depolanmak yerine SMTP oturumu sırasında reddedilir.</value>
   </data>
   <data name="Nothing matched &quot;{0}&quot;. Try what you are trying to achieve (&quot;stop spam&quot;, &quot;let a device send mail&quot;), a page name, or an hMailServer.INI key." xml:space="preserve">
     <value>"{0}" ile eşleşen bir şey yok. Yapmaya çalıştığınız şeyi ("spam'i durdur", "bir cihazın posta göndermesine izin ver"), bir sayfa adını ya da bir hMailServer.INI anahtarını deneyin.</value>
@@ -5749,6 +5755,9 @@ Her klasör için sayaç, o klasörün gerçekten tuttuğu en yüksek ileti UID'
   <data name="Remember this many previous passwords (0 = no history)" xml:space="preserve">
     <value>Bu kadar önceki parolayı hatırla (0 = geçmiş yok)</value>
   </data>
+  <data name="Remote domain" xml:space="preserve">
+    <value>Uzak etki alanı</value>
+  </data>
   <data name="Remove _expired" xml:space="preserve">
     <value>Süresi _dolanları kaldır</value>
   </data>
@@ -6708,12 +6717,6 @@ Devam edilsin mi?</value>
   <data name="Set TlsRptFromAddress in the [Settings] section of hMailServer.ini to a mailbox reports should be sent from. Leaving it empty is a valid choice - it just means the collected statistics are discarded and no reports are ever sent." xml:space="preserve">
     <value>hMailServer.ini'nin [Settings] bölümünde TlsRptFromAddress'i raporların gönderileceği bir posta kutusuna ayarlayın. Boş bırakmak geçerli bir seçimdir - yalnızca toplanan istatistiklerin atıldığı ve hiç rapor gönderilmediği anlamına gelir.</value>
   </data>
-  <data name="Set WebServicesHttpPort and/or WebServicesHttpsPort in hMailServer.ini so the URLs answer, then publish autoconfig.&lt;domain&gt; and autodiscover.&lt;domain&gt; DNS records for each mail domain, pointing at this server. These are address records, and this page checks TXT records only, so they cannot be confirmed from here." xml:space="preserve">
-    <value>URL'lerin yanıt vermesi için hMailServer.ini'de WebServicesHttpPort ve/veya WebServicesHttpsPort'u ayarlayın, ardından her posta etki alanı için bu sunucuya işaret eden autoconfig.&lt;domain&gt; ve autodiscover.&lt;domain&gt; DNS kayıtlarını yayımlayın. Bunlar adres kayıtlarıdır ve bu sayfa yalnızca TXT kayıtlarını denetler, bu yüzden buradan doğrulanamazlar.</value>
-  </data>
-  <data name="Set WebServicesHttpsPort in hMailServer.ini (RFC 8461 requires the policy over HTTPS), give the listener a certificate that covers mta-sts.&lt;domain&gt;, then for each domain publish an A/AAAA (or CNAME) record for mta-sts.&lt;domain&gt; pointing at this server and a TXT record at _mta-sts.&lt;domain&gt; (v=STSv1; id=...). This page checks the TXT record; the address record and the certificate's name coverage cannot be checked from here." xml:space="preserve">
-    <value>hMailServer.ini'de WebServicesHttpsPort'u ayarlayın (RFC 8461 ilkeyi HTTPS üzerinden gerektirir), dinleyiciye mta-sts.&lt;domain&gt; adını kapsayan bir sertifika verin, ardından her etki alanı için bu sunucuya işaret eden bir mta-sts.&lt;domain&gt; A/AAAA (veya CNAME) kaydı ve _mta-sts.&lt;domain&gt; adresinde bir TXT kaydı (v=STSv1; id=...) yayımlayın. Bu sayfa TXT kaydını denetler; adres kaydı ve sertifikanın ad kapsamı buradan denetlenemez.</value>
-  </data>
   <data name="Set a new server administration password." xml:space="preserve">
     <value>Yeni bir sunucu yönetim parolası ayarlayın.</value>
   </data>
@@ -6725,6 +6728,12 @@ Devam edilsin mi?</value>
   </data>
   <data name="Set header value" xml:space="preserve">
     <value>Başlık değerini ayarla</value>
+  </data>
+  <data name="Set the HTTP or HTTPS port on the Web services &amp; autoconfiguration page so the URLs answer, then publish autoconfig.&lt;domain&gt; and autodiscover.&lt;domain&gt; DNS records for each mail domain, pointing at this server. These are address records, and this page checks TXT records only, so they cannot be confirmed from here." xml:space="preserve">
+    <value>HTTP veya HTTPS bağlantı noktasını Web hizmetleri ve otomatik yapılandırma sayfasında ayarlayın'de WebServicesHttpPort ve/veya WebServicesHttpsPort'u ayarlayın, ardından her posta etki alanı için bu sunucuya işaret eden autoconfig.&lt;domain&gt; ve autodiscover.&lt;domain&gt; DNS kayıtlarını yayımlayın. Bunlar adres kayıtlarıdır ve bu sayfa yalnızca TXT kayıtlarını denetler, bu yüzden buradan doğrulanamazlar.</value>
+  </data>
+  <data name="Set the HTTPS port on the Web services &amp; autoconfiguration page (RFC 8461 requires the policy over HTTPS), give the listener a certificate that covers mta-sts.&lt;domain&gt;, then for each domain publish an A/AAAA (or CNAME) record for mta-sts.&lt;domain&gt; pointing at this server and a TXT record at _mta-sts.&lt;domain&gt; (v=STSv1; id=...). This page checks the TXT record; the address record and the certificate's name coverage cannot be checked from here." xml:space="preserve">
+    <value>HTTPS bağlantı noktasını Web hizmetleri ve otomatik yapılandırma sayfasında ayarlayın'de WebServicesHttpsPort'u ayarlayın (RFC 8461 ilkeyi HTTPS üzerinden gerektirir), dinleyiciye mta-sts.&lt;domain&gt; adını kapsayan bir sertifika verin, ardından her etki alanı için bu sunucuya işaret eden bir mta-sts.&lt;domain&gt; A/AAAA (veya CNAME) kaydı ve _mta-sts.&lt;domain&gt; adresinde bir TXT kaydı (v=STSv1; id=...) yayımlayın. Bu sayfa TXT kaydını denetler; adres kaydı ve sertifikanın ad kapsamı buradan denetlenemez.</value>
   </data>
   <data name="Set the SMTP relayer, and its credentials if the provider needs them." xml:space="preserve">
     <value>SMTP aktarıcısını ve sağlayıcı gerektiriyorsa kimlik bilgilerini ayarlayın.</value>

--- a/hmailserver/source/Tools/ControlPanel/Resources/Strings.uk.resx
+++ b/hmailserver/source/Tools/ControlPanel/Resources/Strings.uk.resx
@@ -2917,8 +2917,8 @@
   <data name="Enter a valid port number." xml:space="preserve">
     <value>Введіть дійсний номер порту.</value>
   </data>
-  <data name="Enter an address and search. The trace records nothing at all unless MessageTraceEnabled is set in hMailServer.ini - it is off by default because it stores who corresponds with whom." xml:space="preserve">
-    <value>Введіть адресу і шукайте. Трасування не записує взагалі нічого, доки MessageTraceEnabled не задано в hMailServer.ini - типово воно вимкнене, бо зберігає, хто з ким листується.</value>
+  <data name="Enter an address and search. The trace records nothing at all until message tracing is switched on, on the Logging page - it is off by default because it stores who corresponds with whom." xml:space="preserve">
+    <value>Введіть адресу та виконайте пошук. Трасування нічого не записує, доки трасування повідомлень не буде ввімкнено на сторінці «Журналювання», – типово воно вимкнене, бо зберігає, хто з ким листується.</value>
   </data>
   <data name="Enter part of a name and press Search, or search with an empty box to list all users." xml:space="preserve">
     <value>Введіть частину імені й натисніть «Пошук», або шукайте з порожнім полем, щоб перелічити всіх користувачів.</value>
@@ -3438,6 +3438,9 @@
   </data>
   <data name="Host/Name:  {0}" xml:space="preserve">
     <value>Вузол/Ім'я:  {0}</value>
+  </data>
+  <data name="Hosted domain" xml:space="preserve">
+    <value>Розміщений домен</value>
   </data>
   <data name="Hours between checks (1 to 168)" xml:space="preserve">
     <value>Годин між перевірками (від 1 до 168)</value>
@@ -4554,8 +4557,8 @@
   <data name="No encryption is available on this port. Inbound mail from other servers is normally unencrypted anyway, but this port also accepts AUTH, and a client using it sends its password in the clear." xml:space="preserve">
     <value>На цьому порту шифрування недоступне. Вхідна пошта з інших серверів зазвичай і так незашифрована, але цей порт також приймає AUTH, і клієнт, який ним користується, надсилає пароль відкритим текстом.</value>
   </data>
-  <data name="No events for that address. Either nothing has happened to it, or the trace was switched off at the time - it records only while MessageTraceEnabled is set." xml:space="preserve">
-    <value>Подій для цієї адреси немає. Або з нею нічого не відбувалося, або трасування в той час було вимкнено — воно записує лише тоді, коли задано MessageTraceEnabled.</value>
+  <data name="No events for that address. Either nothing has happened to it, or the trace was switched off at the time - it records only while message tracing is on (Logging page)." xml:space="preserve">
+    <value>Подій для цієї адреси немає. Або з нею нічого не відбувалося, або трасування тоді було вимкнене – воно записує лише доки трасування повідомлень увімкнене (сторінка «Журналювання»).</value>
   </data>
   <data name="No events for that message." xml:space="preserve">
     <value>Подій для цього повідомлення немає.</value>
@@ -4710,8 +4713,8 @@
   <data name="Not checked from here, honestly: verifying the PTR needs the server's PUBLIC IP address, which this panel cannot determine (behind NAT the machine does not know it either), and this page's checker reads TXT records only. Test from outside instead: nslookup &lt;your public IP&gt; shows the PTR; it should name the host above." xml:space="preserve">
     <value>Звідси не перевіряється, чесно кажучи: для перевірки PTR потрібна ПУБЛІЧНА IP-адреса сервера, яку ця панель не може визначити (за NAT комп’ютер і сам її не знає), а перевірник цієї сторінки читає лише TXT-записи. Перевірте натомість ззовні: nslookup &lt;your public IP&gt; показує PTR; він має називати вузол, наведений вище.</value>
   </data>
-  <data name="Not checked yet (Check for updates, or UpdateCheckEnabled=1 in hMailServer.INI for a daily check)" xml:space="preserve">
-    <value>Ще не перевірено («Перевірити наявність оновлень» або UpdateCheckEnabled=1 у hMailServer.INI для щоденної перевірки)</value>
+  <data name="Not checked yet (Check for updates, or turn on the daily check under Updates on the API &amp; monitoring page)" xml:space="preserve">
+    <value>Ще не перевірялося (натисніть «Перевірити оновлення» або ввімкніть щоденну перевірку в розділі «Оновлення» на сторінці «API та моніторинг»)</value>
   </data>
   <data name="Not checked yet. Publish the record, allow time for propagation, then press &quot;Check DNS&quot;." xml:space="preserve">
     <value>Ще не перевірено. Опублікуйте запис, дайте час на поширення, а потім натисніть «Перевірити DNS».</value>
@@ -4758,11 +4761,14 @@
   <data name="Nothing here needs a decision: no mailbox is being skipped and none is being disabled." xml:space="preserve">
     <value>Тут нічого не потребує рішення: жодну поштову скриньку не пропущено й жодну не вимикають.</value>
   </data>
+  <data name="Nothing here yet - Add creates the first entry." xml:space="preserve">
+    <value>Поки що порожньо – кнопка «Додати» створює перший запис.</value>
+  </data>
   <data name="Nothing is ever marked as spam: marking needs a mark threshold above 0, and a 0 there means &quot;never&quot; rather than &quot;always&quot;. Messages reaching {0} are still refused." xml:space="preserve">
     <value>Ніщо ніколи не позначається як спам: для позначення потрібен поріг позначення більший за 0, а 0 там означає «ніколи», а не «завжди». Повідомлення, що досягають {0}, усе одно відхиляються.</value>
   </data>
-  <data name="Nothing is held. Quarantining is off unless QuarantineEnabled is set in hMailServer.ini - until then, spam over the delete threshold is refused during the SMTP conversation rather than stored." xml:space="preserve">
-    <value>Ніщо не утримується. Карантин вимкнено, доки в hMailServer.ini не задано QuarantineEnabled — до того спам понад поріг видалення відхиляється під час сеансу SMTP, а не зберігається.</value>
+  <data name="Nothing is held. Quarantining is switched off - turn it on under Anti-spam settings - and until it is on, spam over the delete threshold is refused during the SMTP conversation rather than stored." xml:space="preserve">
+    <value>Нічого не затримано. Карантин вимкнено – увімкніть його в розділі «Параметри захисту від спаму», – а доки він вимкнений, спам вище порога видалення відхиляється під час сеансу SMTP, а не зберігається.</value>
   </data>
   <data name="Nothing matched &quot;{0}&quot;. Try what you are trying to achieve (&quot;stop spam&quot;, &quot;let a device send mail&quot;), a page name, or an hMailServer.INI key." xml:space="preserve">
     <value>За запитом «{0}» нічого не знайдено. Спробуйте описати, чого ви хочете досягти («зупинити спам», «дозволити пристрою надсилати пошту»), назву сторінки або ключ hMailServer.INI.</value>
@@ -5749,6 +5755,9 @@
   <data name="Remember this many previous passwords (0 = no history)" xml:space="preserve">
     <value>Пам’ятати стільки попередніх паролів (0 = без історії)</value>
   </data>
+  <data name="Remote domain" xml:space="preserve">
+    <value>Віддалений домен</value>
+  </data>
   <data name="Remove _expired" xml:space="preserve">
     <value>Вилучити _прострочені</value>
   </data>
@@ -6708,12 +6717,6 @@ SMTP 25 і 587, POP3 110, IMAP 143 — без захисту підключен�
   <data name="Set TlsRptFromAddress in the [Settings] section of hMailServer.ini to a mailbox reports should be sent from. Leaving it empty is a valid choice - it just means the collected statistics are discarded and no reports are ever sent." xml:space="preserve">
     <value>Задайте TlsRptFromAddress у розділі [Settings] файлу hMailServer.ini як поштову скриньку, з якої слід надсилати звіти. Залишити порожнім - припустимий вибір; це просто означає, що зібрана статистика відкидається і звіти ніколи не надсилаються.</value>
   </data>
-  <data name="Set WebServicesHttpPort and/or WebServicesHttpsPort in hMailServer.ini so the URLs answer, then publish autoconfig.&lt;domain&gt; and autodiscover.&lt;domain&gt; DNS records for each mail domain, pointing at this server. These are address records, and this page checks TXT records only, so they cannot be confirmed from here." xml:space="preserve">
-    <value>Задайте WebServicesHttpPort і/або WebServicesHttpsPort у hMailServer.ini, щоб URL-адреси відповідали, потім опублікуйте записи DNS autoconfig.&lt;domain&gt; і autodiscover.&lt;domain&gt; для кожного поштового домену, що вказують на цей сервер. Це адресні записи, а ця сторінка перевіряє лише записи TXT, тому підтвердити їх звідси неможливо.</value>
-  </data>
-  <data name="Set WebServicesHttpsPort in hMailServer.ini (RFC 8461 requires the policy over HTTPS), give the listener a certificate that covers mta-sts.&lt;domain&gt;, then for each domain publish an A/AAAA (or CNAME) record for mta-sts.&lt;domain&gt; pointing at this server and a TXT record at _mta-sts.&lt;domain&gt; (v=STSv1; id=...). This page checks the TXT record; the address record and the certificate's name coverage cannot be checked from here." xml:space="preserve">
-    <value>Задайте WebServicesHttpsPort у hMailServer.ini (RFC 8461 вимагає політику через HTTPS), дайте слухачу сертифікат, що покриває mta-sts.&lt;domain&gt;, потім для кожного домену опублікуйте запис A/AAAA (або CNAME) для mta-sts.&lt;domain&gt;, що вказує на цей сервер, і запис TXT на _mta-sts.&lt;domain&gt; (v=STSv1; id=...). Ця сторінка перевіряє запис TXT; адресний запис і покриття імені сертифікатом звідси перевірити неможливо.</value>
-  </data>
   <data name="Set a new server administration password." xml:space="preserve">
     <value>Задайте новий пароль адміністрування сервера.</value>
   </data>
@@ -6725,6 +6728,12 @@ SMTP 25 і 587, POP3 110, IMAP 143 — без захисту підключен�
   </data>
   <data name="Set header value" xml:space="preserve">
     <value>Установити значення заголовка</value>
+  </data>
+  <data name="Set the HTTP or HTTPS port on the Web services &amp; autoconfiguration page so the URLs answer, then publish autoconfig.&lt;domain&gt; and autodiscover.&lt;domain&gt; DNS records for each mail domain, pointing at this server. These are address records, and this page checks TXT records only, so they cannot be confirmed from here." xml:space="preserve">
+    <value>Задайте порт HTTP або HTTPS на сторінці «Вебслужби та автоконфігурація», щоб URL-адреси відповідали, потім опублікуйте записи DNS autoconfig.&lt;domain&gt; і autodiscover.&lt;domain&gt; для кожного поштового домену, що вказують на цей сервер. Це адресні записи, а ця сторінка перевіряє лише записи TXT, тому підтвердити їх звідси неможливо.</value>
+  </data>
+  <data name="Set the HTTPS port on the Web services &amp; autoconfiguration page (RFC 8461 requires the policy over HTTPS), give the listener a certificate that covers mta-sts.&lt;domain&gt;, then for each domain publish an A/AAAA (or CNAME) record for mta-sts.&lt;domain&gt; pointing at this server and a TXT record at _mta-sts.&lt;domain&gt; (v=STSv1; id=...). This page checks the TXT record; the address record and the certificate's name coverage cannot be checked from here." xml:space="preserve">
+    <value>Задайте порт HTTPS на сторінці «Вебслужби та автоконфігурація» (RFC 8461 вимагає політику через HTTPS), дайте слухачу сертифікат, що покриває mta-sts.&lt;domain&gt;, потім для кожного домену опублікуйте запис A/AAAA (або CNAME) для mta-sts.&lt;domain&gt;, що вказує на цей сервер, і запис TXT на _mta-sts.&lt;domain&gt; (v=STSv1; id=...). Ця сторінка перевіряє запис TXT; адресний запис і покриття імені сертифікатом звідси перевірити неможливо.</value>
   </data>
   <data name="Set the SMTP relayer, and its credentials if the provider needs them." xml:space="preserve">
     <value>Задайте ретранслятор SMTP і його облікові дані, якщо провайдер їх вимагає.</value>

--- a/hmailserver/source/Tools/ControlPanel/Resources/Strings.zh-Hans.resx
+++ b/hmailserver/source/Tools/ControlPanel/Resources/Strings.zh-Hans.resx
@@ -2917,8 +2917,8 @@
   <data name="Enter a valid port number." xml:space="preserve">
     <value>请输入有效的端口号。</value>
   </data>
-  <data name="Enter an address and search. The trace records nothing at all unless MessageTraceEnabled is set in hMailServer.ini - it is off by default because it stores who corresponds with whom." xml:space="preserve">
-    <value>输入地址并搜索。除非在 hMailServer.ini 中设置了 MessageTraceEnabled，否则跟踪不会记录任何内容 - 它默认关闭，因为它会存储谁与谁通信。</value>
+  <data name="Enter an address and search. The trace records nothing at all until message tracing is switched on, on the Logging page - it is off by default because it stores who corresponds with whom." xml:space="preserve">
+    <value>输入地址并搜索。在“日志记录”页面开启邮件跟踪之前，跟踪不会记录任何内容 - 它默认关闭，因为它会存储谁与谁通信。</value>
   </data>
   <data name="Enter part of a name and press Search, or search with an empty box to list all users." xml:space="preserve">
     <value>输入名称的一部分并按“搜索”，或者用空白框搜索以列出所有用户。</value>
@@ -3438,6 +3438,9 @@
   </data>
   <data name="Host/Name:  {0}" xml:space="preserve">
     <value>主机/名称：  {0}</value>
+  </data>
+  <data name="Hosted domain" xml:space="preserve">
+    <value>托管的域</value>
   </data>
   <data name="Hours between checks (1 to 168)" xml:space="preserve">
     <value>两次检查之间的小时数（1 到 168）</value>
@@ -4554,8 +4557,8 @@
   <data name="No encryption is available on this port. Inbound mail from other servers is normally unencrypted anyway, but this port also accepts AUTH, and a client using it sends its password in the clear." xml:space="preserve">
     <value>此端口上没有可用的加密。来自其他服务器的入站邮件本来通常就不加密，但此端口也接受 AUTH，使用它的客户端会以明文发送密码。</value>
   </data>
-  <data name="No events for that address. Either nothing has happened to it, or the trace was switched off at the time - it records only while MessageTraceEnabled is set." xml:space="preserve">
-    <value>该地址没有任何事件。要么它没有发生过任何事情，要么当时跟踪已关闭 - 只有在设置了 MessageTraceEnabled 时才会记录。</value>
+  <data name="No events for that address. Either nothing has happened to it, or the trace was switched off at the time - it records only while message tracing is on (Logging page)." xml:space="preserve">
+    <value>该地址没有事件。要么它没有发生任何事情，要么当时跟踪已关闭 - 它只在邮件跟踪开启时记录（“日志记录”页面）。</value>
   </data>
   <data name="No events for that message." xml:space="preserve">
     <value>该邮件没有任何事件。</value>
@@ -4710,8 +4713,8 @@
   <data name="Not checked from here, honestly: verifying the PTR needs the server's PUBLIC IP address, which this panel cannot determine (behind NAT the machine does not know it either), and this page's checker reads TXT records only. Test from outside instead: nslookup &lt;your public IP&gt; shows the PTR; it should name the host above." xml:space="preserve">
     <value>坦率地说，此处未做检查：验证 PTR 需要服务器的公网 IP 地址，而此面板无法确定它（在 NAT 之后机器自己也不知道），而且本页的检查器只读取 TXT 记录。请改为从外部测试：nslookup &lt;your public IP&gt; 会显示 PTR；它应当指向上面的主机名。</value>
   </data>
-  <data name="Not checked yet (Check for updates, or UpdateCheckEnabled=1 in hMailServer.INI for a daily check)" xml:space="preserve">
-    <value>尚未检查（“检查更新”，或在 hMailServer.INI 中设置 UpdateCheckEnabled=1 以每日检查）</value>
+  <data name="Not checked yet (Check for updates, or turn on the daily check under Updates on the API &amp; monitoring page)" xml:space="preserve">
+    <value>尚未检查（请检查更新，或在“API 与监控”页面的“更新”下开启每日检查）</value>
   </data>
   <data name="Not checked yet. Publish the record, allow time for propagation, then press &quot;Check DNS&quot;." xml:space="preserve">
     <value>尚未检查。请发布记录，留出传播时间，然后按“检查 DNS”。</value>
@@ -4758,11 +4761,14 @@
   <data name="Nothing here needs a decision: no mailbox is being skipped and none is being disabled." xml:space="preserve">
     <value>此处不需要做任何决定：没有邮箱被跳过，也没有邮箱被禁用。</value>
   </data>
+  <data name="Nothing here yet - Add creates the first entry." xml:space="preserve">
+    <value>这里还没有任何内容 - “添加”会创建第一个条目。</value>
+  </data>
   <data name="Nothing is ever marked as spam: marking needs a mark threshold above 0, and a 0 there means &quot;never&quot; rather than &quot;always&quot;. Messages reaching {0} are still refused." xml:space="preserve">
     <value>永远不会有邮件被标记为垃圾邮件：标记需要一个大于 0 的标记阈值，而 0 表示“从不”而不是“总是”。达到 {0} 的邮件仍会被拒绝。</value>
   </data>
-  <data name="Nothing is held. Quarantining is off unless QuarantineEnabled is set in hMailServer.ini - until then, spam over the delete threshold is refused during the SMTP conversation rather than stored." xml:space="preserve">
-    <value>没有任何邮件被暂挂。除非在 hMailServer.ini 中设置了 QuarantineEnabled，否则隔离是关闭的 - 在那之前，超过删除阈值的垃圾邮件会在 SMTP 会话期间被拒绝，而不是被存储。</value>
+  <data name="Nothing is held. Quarantining is switched off - turn it on under Anti-spam settings - and until it is on, spam over the delete threshold is refused during the SMTP conversation rather than stored." xml:space="preserve">
+    <value>没有被扣留的邮件。隔离已关闭 - 请在“反垃圾邮件设置”中开启 - 在开启之前，超过删除阈值的垃圾邮件会在 SMTP 会话中被拒绝，而不会被存储。</value>
   </data>
   <data name="Nothing matched &quot;{0}&quot;. Try what you are trying to achieve (&quot;stop spam&quot;, &quot;let a device send mail&quot;), a page name, or an hMailServer.INI key." xml:space="preserve">
     <value>没有与 "{0}" 匹配的内容。请尝试输入您想达成的目标（“阻止垃圾邮件”、“允许设备发送邮件”）、页面名称或 hMailServer.INI 键名。</value>
@@ -5749,6 +5755,9 @@
   <data name="Remember this many previous passwords (0 = no history)" xml:space="preserve">
     <value>记住这么多个历史密码（0 = 不保留历史）</value>
   </data>
+  <data name="Remote domain" xml:space="preserve">
+    <value>远程域</value>
+  </data>
   <data name="Remove _expired" xml:space="preserve">
     <value>移除已过期项(_E)</value>
   </data>
@@ -6708,12 +6717,6 @@ SMTP 25 和 587、POP3 110、IMAP 143 - 均不带连接安全。TLS 端口和自
   <data name="Set TlsRptFromAddress in the [Settings] section of hMailServer.ini to a mailbox reports should be sent from. Leaving it empty is a valid choice - it just means the collected statistics are discarded and no reports are ever sent." xml:space="preserve">
     <value>在 hMailServer.ini 的 [Settings] 节中把 TlsRptFromAddress 设为用来发送报告的邮箱。留空也是有效的选择 - 它只是意味着收集的统计信息被丢弃，永远不发送报告。</value>
   </data>
-  <data name="Set WebServicesHttpPort and/or WebServicesHttpsPort in hMailServer.ini so the URLs answer, then publish autoconfig.&lt;domain&gt; and autodiscover.&lt;domain&gt; DNS records for each mail domain, pointing at this server. These are address records, and this page checks TXT records only, so they cannot be confirmed from here." xml:space="preserve">
-    <value>在 hMailServer.ini 中设置 WebServicesHttpPort 和/或 WebServicesHttpsPort 以便这些 URL 能够应答，然后为每个邮件域发布指向本服务器的 autoconfig.&lt;domain&gt; 和 autodiscover.&lt;domain&gt; DNS 记录。这些是地址记录，而本页只检查 TXT 记录，因此无法从此处确认。</value>
-  </data>
-  <data name="Set WebServicesHttpsPort in hMailServer.ini (RFC 8461 requires the policy over HTTPS), give the listener a certificate that covers mta-sts.&lt;domain&gt;, then for each domain publish an A/AAAA (or CNAME) record for mta-sts.&lt;domain&gt; pointing at this server and a TXT record at _mta-sts.&lt;domain&gt; (v=STSv1; id=...). This page checks the TXT record; the address record and the certificate's name coverage cannot be checked from here." xml:space="preserve">
-    <value>在 hMailServer.ini 中设置 WebServicesHttpsPort (RFC 8461 要求通过 HTTPS 提供策略)，为监听器配置一个覆盖 mta-sts.&lt;domain&gt; 的证书，然后为每个域发布一条指向本服务器的 mta-sts.&lt;domain&gt; A/AAAA (或 CNAME) 记录，以及在 _mta-sts.&lt;domain&gt; 处的一条 TXT 记录 (v=STSv1; id=...)。本页检查 TXT 记录；地址记录和证书的名称覆盖范围无法从此处检查。</value>
-  </data>
   <data name="Set a new server administration password." xml:space="preserve">
     <value>设置新的服务器管理密码。</value>
   </data>
@@ -6725,6 +6728,12 @@ SMTP 25 和 587、POP3 110、IMAP 143 - 均不带连接安全。TLS 端口和自
   </data>
   <data name="Set header value" xml:space="preserve">
     <value>设置标头值</value>
+  </data>
+  <data name="Set the HTTP or HTTPS port on the Web services &amp; autoconfiguration page so the URLs answer, then publish autoconfig.&lt;domain&gt; and autodiscover.&lt;domain&gt; DNS records for each mail domain, pointing at this server. These are address records, and this page checks TXT records only, so they cannot be confirmed from here." xml:space="preserve">
+    <value>在“Web 服务和自动配置”页面设置 HTTP 或 HTTPS 端口以使 URL 能够响应，然后为每个邮件域发布指向此服务器的 autoconfig.&lt;domain&gt; 和 autodiscover.&lt;domain&gt; DNS 记录。这些是地址记录，而此页面只检查 TXT 记录，因此无法从此处确认。</value>
+  </data>
+  <data name="Set the HTTPS port on the Web services &amp; autoconfiguration page (RFC 8461 requires the policy over HTTPS), give the listener a certificate that covers mta-sts.&lt;domain&gt;, then for each domain publish an A/AAAA (or CNAME) record for mta-sts.&lt;domain&gt; pointing at this server and a TXT record at _mta-sts.&lt;domain&gt; (v=STSv1; id=...). This page checks the TXT record; the address record and the certificate's name coverage cannot be checked from here." xml:space="preserve">
+    <value>在“Web 服务和自动配置”页面设置 HTTPS 端口（RFC 8461 要求通过 HTTPS 提供策略），为侦听器提供覆盖 mta-sts.&lt;domain&gt; 的证书，然后为每个域发布指向此服务器的 mta-sts.&lt;domain&gt; 的 A/AAAA（或 CNAME）记录，以及 _mta-sts.&lt;domain&gt; 的 TXT 记录（v=STSv1; id=...）。此页面检查 TXT 记录；地址记录和证书的名称覆盖范围无法从此处检查。</value>
   </data>
   <data name="Set the SMTP relayer, and its credentials if the provider needs them." xml:space="preserve">
     <value>设置 SMTP 中继，以及提供商需要时的凭据。</value>

--- a/hmailserver/source/Tools/ControlPanel/Services/ExternalSetupChecks.cs
+++ b/hmailserver/source/Tools/ControlPanel/Services/ExternalSetupChecks.cs
@@ -859,7 +859,7 @@ namespace hMailServer.ControlPanel.Services
          {
             Title = L("MTA-STS policy hosting - HTTPS listener plus two DNS entries per domain"),
             Purpose = L("Tells sending servers they must use TLS when delivering to your domains, closing the downgrade hole in opportunistic TLS."),
-            Action = L("Set WebServicesHttpsPort in hMailServer.ini (RFC 8461 requires the policy over HTTPS), give the listener a certificate that covers mta-sts.<domain>, then for each domain publish an A/AAAA (or CNAME) record for mta-sts.<domain> pointing at this server and a TXT record at _mta-sts.<domain> (v=STSv1; id=...). This page checks the TXT record; the address record and the certificate's name coverage cannot be checked from here."),
+            Action = L("Set the HTTPS port on the Web services & autoconfiguration page (RFC 8461 requires the policy over HTTPS), give the listener a certificate that covers mta-sts.<domain>, then for each domain publish an A/AAAA (or CNAME) record for mta-sts.<domain> pointing at this server and a TXT record at _mta-sts.<domain> (v=STSv1; id=...). This page checks the TXT record; the address record and the certificate's name coverage cannot be checked from here."),
             Page = "webservices"
          };
 
@@ -1413,7 +1413,7 @@ namespace hMailServer.ControlPanel.Services
          {
             Title = L("Client autoconfiguration - a listener plus the DNS names clients probe"),
             Purpose = L("Lets Outlook, Thunderbird and mobile clients set themselves up from an e-mail address alone, by fetching this server's configuration URLs."),
-            Action = L("Set WebServicesHttpPort and/or WebServicesHttpsPort in hMailServer.ini so the URLs answer, then publish autoconfig.<domain> and autodiscover.<domain> DNS records for each mail domain, pointing at this server. These are address records, and this page checks TXT records only, so they cannot be confirmed from here."),
+            Action = L("Set the HTTP or HTTPS port on the Web services & autoconfiguration page so the URLs answer, then publish autoconfig.<domain> and autodiscover.<domain> DNS records for each mail domain, pointing at this server. These are address records, and this page checks TXT records only, so they cannot be confirmed from here."),
             Page = "webservices"
          };
 

--- a/hmailserver/source/Tools/ControlPanel/Services/SelectionGate.cs
+++ b/hmailserver/source/Tools/ControlPanel/Services/SelectionGate.cs
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 Christopher Holloway / Progressive Robot Ltd and the hMailServer contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using System.ComponentModel;
+using System.Windows;
+using System.Windows.Controls.Primitives;
+
+namespace hMailServer.ControlPanel.Services
+{
+   /// <summary>
+   /// A button that acts on the selected row is enabled only while there is one.
+   /// Every list page had these buttons live all the time - Delete, Edit,
+   /// Properties, Release, Deliver now - and a click with nothing selected either
+   /// did nothing or wrote "Select a row first" into a status line the eye is not
+   /// on. A disabled button says the same thing before the click, where the eye
+   /// is. One call per page, after the list and its buttons exist:
+   /// <c>SelectionGate.Bind(grid, editButton, deleteButton)</c>.
+   ///
+   /// The gate watches the selector's SelectedItem through its dependency property,
+   /// not only SelectionChanged, because replacing ItemsSource clears the selection
+   /// and a Reload does exactly that on every page.
+   /// </summary>
+   public static class SelectionGate
+   {
+      public static void Bind(Selector list, params UIElement[] targets)
+      {
+         if (list == null || targets == null || targets.Length == 0)
+            return;
+
+         void Apply()
+         {
+            bool any = list.SelectedItem != null;
+            foreach (UIElement target in targets)
+            {
+               if (target != null)
+                  target.IsEnabled = any;
+            }
+         }
+
+         DependencyPropertyDescriptor
+            .FromProperty(Selector.SelectedItemProperty, list.GetType())
+            .AddValueChanged(list, (_, _) => Apply());
+         list.SelectionChanged += (_, _) => Apply();
+         Apply();
+      }
+   }
+}

--- a/hmailserver/source/Tools/ControlPanel/Views/CollectionEditorView.cs
+++ b/hmailserver/source/Tools/ControlPanel/Views/CollectionEditorView.cs
@@ -161,14 +161,23 @@ namespace hMailServer.ControlPanel.Views
          Grid.SetColumn(actions, 1);
          if (spec_.CanAdd)
             actions.Children.Add(MakeButton(L("_Add"), ControlAppearance.Primary, SymbolRegular.Add24, (_, _) => OpenDialog(null)));
-         actions.Children.Add(MakeButton(L("_Edit"), ControlAppearance.Secondary, SymbolRegular.Edit24, (_, _) => EditSelected()));
+         var edit = MakeButton(L("_Edit"), ControlAppearance.Secondary, SymbolRegular.Edit24, (_, _) => EditSelected());
+         actions.Children.Add(edit);
+         Wpf.Ui.Controls.Button del = null;
          if (spec_.CanDelete)
          {
-            var del = MakeButton(L("_Delete"), ControlAppearance.Secondary, SymbolRegular.Delete24, (_, _) => DeleteSelected());
+            del = MakeButton(L("_Delete"), ControlAppearance.Secondary, SymbolRegular.Delete24, (_, _) => DeleteSelected());
             del.Foreground = Services.ThemeTokens.Danger;
             actions.Children.Add(del);
          }
          actions.Children.Add(MakeButton(L("_Refresh"), ControlAppearance.Secondary, SymbolRegular.ArrowSync24, (_, _) => Reload()));
+         // Edit and Delete act on the selected row, so they are enabled only
+         // while there is one; with nothing selected they used to answer a click
+         // with "Select a row first." in the status line.
+         if (del != null)
+            Services.SelectionGate.Bind(grid_, edit, del);
+         else
+            Services.SelectionGate.Bind(grid_, edit);
          toolbar.Children.Add(actions);
          Grid.SetRow(toolbar, 1);
          root.Children.Add(toolbar);
@@ -260,7 +269,10 @@ namespace hMailServer.ControlPanel.Views
                rows_.Add(row);
                ServerSession.Release(item);
             }
-            status_.Text = L("Loaded from server.");
+            // An empty list is a state to name, not a blank to stare at.
+            status_.Text = rows_.Count == 0 && spec_.CanAdd
+               ? L("Nothing here yet - Add creates the first entry.")
+               : L("Loaded from server.");
          }
          catch (Exception ex) when (!ExceptionPolicy.IsFatal(ex))
          {

--- a/hmailserver/source/Tools/ControlPanel/Views/MessageTraceView.cs
+++ b/hmailserver/source/Tools/ControlPanel/Views/MessageTraceView.cs
@@ -74,7 +74,7 @@ namespace hMailServer.ControlPanel.Views
       public MessageTraceView()
       {
          Build();
-         status_.Text = L("Enter an address and search. The trace records nothing at all unless MessageTraceEnabled is set in hMailServer.ini - it is off by default because it stores who corresponds with whom.");
+         status_.Text = L("Enter an address and search. The trace records nothing at all until message tracing is switched on, on the Logging page - it is off by default because it stores who corresponds with whom.");
       }
 
       private dynamic OpenTrace()
@@ -156,7 +156,7 @@ namespace hMailServer.ControlPanel.Views
             try
             {
                trace.Search(address_.Text.Trim());
-               Fill(trace, L("No events for that address. Either nothing has happened to it, or the trace was switched off at the time - it records only while MessageTraceEnabled is set."));
+               Fill(trace, L("No events for that address. Either nothing has happened to it, or the trace was switched off at the time - it records only while message tracing is on (Logging page)."));
             }
             finally
             {
@@ -259,7 +259,9 @@ namespace hMailServer.ControlPanel.Views
          address_.KeyDown += (_, e) => { if (e.Key == System.Windows.Input.Key.Enter) Search(); };
          toolbar.Children.Add(address_);
          toolbar.Children.Add(MakeButton(L("_Search"), Wpf.Ui.Controls.ControlAppearance.Primary, (_, _) => Search()));
-         toolbar.Children.Add(MakeButton(L("_Follow this message"), Wpf.Ui.Controls.ControlAppearance.Secondary, (_, _) => FollowSelected()));
+         var follow = MakeButton(L("_Follow this message"), Wpf.Ui.Controls.ControlAppearance.Secondary, (_, _) => FollowSelected());
+         toolbar.Children.Add(follow);
+         hMailServer.ControlPanel.Services.SelectionGate.Bind(list_, follow);
          toolbar.Children.Add(MakeButton(L("_Remove expired"), Wpf.Ui.Controls.ControlAppearance.Secondary, (_, _) => SweepExpired()));
          root.Children.Add(toolbar);
 

--- a/hmailserver/source/Tools/ControlPanel/Views/PasswordField.cs
+++ b/hmailserver/source/Tools/ControlPanel/Views/PasswordField.cs
@@ -31,6 +31,15 @@ namespace hMailServer.ControlPanel.Views
    {
       private int depth_;
 
+      public PasswordField()
+      {
+         // An implicit style is keyed by the exact type, so a derived control
+         // does not receive the one WPF-UI defines for PasswordBox and rendered
+         // as a bare WPF PasswordBox - a white box on the dark theme, on the
+         // Domains page and the sign-in card. Ask for the base type's style.
+         SetResourceReference(StyleProperty, typeof(Wpf.Ui.Controls.PasswordBox));
+      }
+
       protected override void OnTextChanged(TextChangedEventArgs e)
       {
          depth_++;

--- a/hmailserver/source/Tools/ControlPanel/Views/PublicFoldersView.cs
+++ b/hmailserver/source/Tools/ControlPanel/Views/PublicFoldersView.cs
@@ -51,8 +51,11 @@ namespace hMailServer.ControlPanel.Views
          var toolbar = new StackPanel { Orientation = Orientation.Horizontal, HorizontalAlignment = HorizontalAlignment.Right, Margin = new Thickness(0, 0, 0, 12) };
          Grid.SetRow(toolbar, 1);
          toolbar.Children.Add(MakeButton(L("_Add folder"), Wpf.Ui.Controls.ControlAppearance.Primary, (_, _) => AddFolder()));
-         toolbar.Children.Add(MakeButton(L("_Permissions"), Wpf.Ui.Controls.ControlAppearance.Secondary, (_, _) => EditPermissions()));
-         toolbar.Children.Add(MakeButton(L("_Delete"), Wpf.Ui.Controls.ControlAppearance.Danger, (_, _) => DeleteFolder()));
+         var permissions = MakeButton(L("_Permissions"), Wpf.Ui.Controls.ControlAppearance.Secondary, (_, _) => EditPermissions());
+         toolbar.Children.Add(permissions);
+         var delete = MakeButton(L("_Delete"), Wpf.Ui.Controls.ControlAppearance.Danger, (_, _) => DeleteFolder());
+         toolbar.Children.Add(delete);
+         hMailServer.ControlPanel.Services.SelectionGate.Bind(list_, permissions, delete);
          toolbar.Children.Add(MakeButton(L("_Refresh"), Wpf.Ui.Controls.ControlAppearance.Secondary, (_, _) => Reload()));
          root.Children.Add(toolbar);
 

--- a/hmailserver/source/Tools/ControlPanel/Views/QuarantineView.cs
+++ b/hmailserver/source/Tools/ControlPanel/Views/QuarantineView.cs
@@ -144,7 +144,7 @@ namespace hMailServer.ControlPanel.Views
 
                if (total == 0)
                {
-                  status_.Text = L("Nothing is held. Quarantining is off unless QuarantineEnabled is set in hMailServer.ini - until then, spam over the delete threshold is refused during the SMTP conversation rather than stored.");
+                  status_.Text = L("Nothing is held. Quarantining is switched off - turn it on under Anti-spam settings - and until it is on, spam over the delete threshold is refused during the SMTP conversation rather than stored.");
                }
                else if (listed < total)
                {
@@ -390,8 +390,11 @@ namespace hMailServer.ControlPanel.Views
          root.Children.Add(hint);
 
          var toolbar = new StackPanel { Orientation = Orientation.Horizontal, Margin = new Thickness(0, 0, 0, 10) };
-         toolbar.Children.Add(MakeButton(L("_Release"), Wpf.Ui.Controls.ControlAppearance.Primary, (_, _) => ReleaseSelected()));
-         toolbar.Children.Add(MakeButton(L("_Delete"), Wpf.Ui.Controls.ControlAppearance.Danger, (_, _) => DeleteSelected()));
+         var release = MakeButton(L("_Release"), Wpf.Ui.Controls.ControlAppearance.Primary, (_, _) => ReleaseSelected());
+         toolbar.Children.Add(release);
+         var delete = MakeButton(L("_Delete"), Wpf.Ui.Controls.ControlAppearance.Danger, (_, _) => DeleteSelected());
+         toolbar.Children.Add(delete);
+         hMailServer.ControlPanel.Services.SelectionGate.Bind(list_, release, delete);
          toolbar.Children.Add(MakeButton(L("Remove _expired"), Wpf.Ui.Controls.ControlAppearance.Secondary, (_, _) => SweepExpired()));
          toolbar.Children.Add(MakeButton(L("Re_fresh"), Wpf.Ui.Controls.ControlAppearance.Secondary, (_, _) => Reload()));
          root.Children.Add(toolbar);

--- a/hmailserver/source/Tools/ControlPanel/Views/QueueView.xaml
+++ b/hmailserver/source/Tools/ControlPanel/Views/QueueView.xaml
@@ -25,13 +25,13 @@
                 </ui:TextBox>
             </StackPanel>
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Top">
-                <ui:Button Content="{loc:L '_View source'}" Click="View_Click" Margin="0,0,8,0">
+                <ui:Button x:Name="ViewButton" Content="{loc:L '_View source'}" Click="View_Click" Margin="0,0,8,0">
                     <ui:Button.Icon><ui:SymbolIcon Symbol="DocumentText24" /></ui:Button.Icon>
                 </ui:Button>
-                <ui:Button Content="{loc:L '_Deliver now'}" Appearance="Primary" Click="Retry_Click" Margin="0,0,8,0">
+                <ui:Button x:Name="RetryButton" Content="{loc:L '_Deliver now'}" Appearance="Primary" Click="Retry_Click" Margin="0,0,8,0">
                     <ui:Button.Icon><ui:SymbolIcon Symbol="Send24" /></ui:Button.Icon>
                 </ui:Button>
-                <ui:Button Content="{loc:L '_Remove'}" Appearance="Danger" Click="Remove_Click" Margin="0,0,8,0">
+                <ui:Button x:Name="RemoveButton" Content="{loc:L '_Remove'}" Appearance="Danger" Click="Remove_Click" Margin="0,0,8,0">
                     <ui:Button.Icon><ui:SymbolIcon Symbol="Delete24" /></ui:Button.Icon>
                 </ui:Button>
                 <ui:Button Content="{loc:L 'Re_fresh'}" Click="Refresh_Click">

--- a/hmailserver/source/Tools/ControlPanel/Views/QueueView.xaml.cs
+++ b/hmailserver/source/Tools/ControlPanel/Views/QueueView.xaml.cs
@@ -28,6 +28,8 @@ namespace hMailServer.ControlPanel.Views
       public QueueView()
       {
          InitializeComponent();
+         // The three act on the selected message; enabled only while one is selected.
+         hMailServer.ControlPanel.Services.SelectionGate.Bind(QueueGrid, ViewButton, RetryButton, RemoveButton);
       }
 
       public void OnEnter() => Reload();

--- a/hmailserver/source/Tools/ControlPanel/Views/RoutesView.xaml
+++ b/hmailserver/source/Tools/ControlPanel/Views/RoutesView.xaml
@@ -62,8 +62,8 @@
                     <ui:TextBox x:Name="NewHost" Grid.Column="1" PlaceholderText="{loc:L 'Target SMTP host'}" Margin="0,0,8,0" />
                     <ui:TextBox x:Name="NewPort" Grid.Column="2" PlaceholderText="{loc:L 'Port'}" Text="25" Margin="0,0,8,0" />
                     <ui:Button Grid.Column="3" Content="{loc:L '_Add'}" Appearance="Primary" Click="Add_Click" Margin="0,0,8,0" />
-                    <ui:Button Grid.Column="4" Content="{loc:L '_Properties'}" Click="Edit_Click" Margin="0,0,8,0" />
-                    <ui:Button Grid.Column="5" Content="{loc:L '_Delete selected'}" Appearance="Danger" Click="Delete_Click" />
+                    <ui:Button x:Name="PropertiesButton" Grid.Column="4" Content="{loc:L '_Properties'}" Click="Edit_Click" Margin="0,0,8,0" />
+                    <ui:Button x:Name="DeleteButton" Grid.Column="5" Content="{loc:L '_Delete selected'}" Appearance="Danger" Click="Delete_Click" />
                 </Grid>
             </StackPanel>
         </Border>

--- a/hmailserver/source/Tools/ControlPanel/Views/RoutesView.xaml.cs
+++ b/hmailserver/source/Tools/ControlPanel/Views/RoutesView.xaml.cs
@@ -25,6 +25,7 @@ namespace hMailServer.ControlPanel.Views
       public RoutesView()
       {
          InitializeComponent();
+         hMailServer.ControlPanel.Services.SelectionGate.Bind(RouteGrid, PropertiesButton, DeleteButton);
       }
 
       public void OnEnter() => Reload();

--- a/hmailserver/source/Tools/ControlPanel/Views/RulesView.xaml
+++ b/hmailserver/source/Tools/ControlPanel/Views/RulesView.xaml
@@ -41,10 +41,10 @@
         </Border>
 
         <StackPanel Grid.Row="2" Orientation="Horizontal" Margin="0,12,0,12">
-            <ui:Button Content="{loc:L 'Move _up'}" Click="MoveUp_Click" Margin="0,0,8,0" />
-            <ui:Button Content="{loc:L 'Move _down'}" Click="MoveDown_Click" Margin="0,0,8,0" />
-            <ui:Button Content="{loc:L 'Ena_ble / disable'}" Click="Toggle_Click" Margin="0,0,8,0" />
-            <ui:Button Content="{loc:L 'De_lete rule'}" Appearance="Danger" Click="Delete_Click" Margin="0,0,24,0" />
+            <ui:Button x:Name="MoveUpButton" Content="{loc:L 'Move _up'}" Click="MoveUp_Click" Margin="0,0,8,0" />
+            <ui:Button x:Name="MoveDownButton" Content="{loc:L 'Move _down'}" Click="MoveDown_Click" Margin="0,0,8,0" />
+            <ui:Button x:Name="ToggleButton" Content="{loc:L 'Ena_ble / disable'}" Click="Toggle_Click" Margin="0,0,8,0" />
+            <ui:Button x:Name="DeleteRuleButton" Content="{loc:L 'De_lete rule'}" Appearance="Danger" Click="Delete_Click" Margin="0,0,24,0" />
             <ui:TextBox x:Name="NewRuleName" PlaceholderText="{loc:L 'New rule name'}" AutomationProperties.Name="{loc:L 'New rule name'}" Width="180" Margin="0,0,8,0" />
             <ui:Button Content="{loc:L '_Add rule'}" Appearance="Primary" Click="AddRule_Click" />
         </StackPanel>
@@ -65,7 +65,7 @@
                     </Grid.RowDefinitions>
                     <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
                         <TextBlock Text="{loc:L 'IF'}" FontWeight="SemiBold" FontSize="14" VerticalAlignment="Center" Margin="0,0,12,0" />
-                        <ComboBox x:Name="MatchMode" FontSize="12" Width="180"
+                        <ComboBox x:Name="MatchMode" FontSize="12" MinWidth="230"
                                   SelectionChanged="MatchMode_SelectionChanged" />
                     </StackPanel>
                     <DataGrid Grid.Row="1" x:Name="CriteriaGrid" AutoGenerateColumns="False" IsReadOnly="True"
@@ -78,8 +78,8 @@
                     </DataGrid>
                     <StackPanel Grid.Row="2" Orientation="Horizontal" Margin="0,8,0,0">
                         <ui:Button Content="{loc:L 'Add _criterion…'}" Appearance="Primary" Click="AddCriterion_Click" Margin="0,0,8,0" />
-                        <ui:Button Content="{loc:L '_Edit criterion…'}" Click="EditCriterion_Click" Margin="0,0,8,0" />
-                        <ui:Button Content="{loc:L '_Remove criterion'}" Appearance="Danger" Click="RemoveCriterion_Click" />
+                        <ui:Button x:Name="EditCriterionButton" Content="{loc:L '_Edit criterion…'}" Click="EditCriterion_Click" Margin="0,0,8,0" />
+                        <ui:Button x:Name="RemoveCriterionButton" Content="{loc:L '_Remove criterion'}" Appearance="Danger" Click="RemoveCriterion_Click" />
                     </StackPanel>
                 </Grid>
             </Border>
@@ -101,13 +101,16 @@
                             <DataGridTextColumn Binding="{Binding Description}" Width="*" />
                         </DataGrid.Columns>
                     </DataGrid>
-                    <StackPanel Grid.Row="2" Orientation="Horizontal" Margin="0,8,0,0">
-                        <ui:Button Content="{loc:L 'Add ac_tion…'}" Appearance="Primary" Click="AddAction_Click" Margin="0,0,8,0" />
-                        <ui:Button Content="{loc:L 'Ed_it action…'}" Click="EditAction_Click" Margin="0,0,8,0" />
-                        <ui:Button Content="{loc:L 'Re_move action'}" Appearance="Danger" Click="RemoveAction_Click" Margin="0,0,8,0" />
-                        <ui:Button Content="U_p" Click="ActionUp_Click" Margin="0,0,8,0" />
-                        <ui:Button Content="{loc:L 'Dow_n'}" Click="ActionDown_Click" />
-                    </StackPanel>
+                    <!-- A WrapPanel, not a StackPanel: five buttons do not fit one row of
+                         the half-width card at 1920 wide, and a StackPanel clips the last
+                         one rather than wrapping it. -->
+                    <WrapPanel Grid.Row="2" Orientation="Horizontal" Margin="0,8,0,0">
+                        <ui:Button Content="{loc:L 'Add ac_tion…'}" Appearance="Primary" Click="AddAction_Click" Margin="0,0,8,8" />
+                        <ui:Button x:Name="EditActionButton" Content="{loc:L 'Ed_it action…'}" Click="EditAction_Click" Margin="0,0,8,8" />
+                        <ui:Button x:Name="RemoveActionButton" Content="{loc:L 'Re_move action'}" Appearance="Danger" Click="RemoveAction_Click" Margin="0,0,8,8" />
+                        <ui:Button x:Name="ActionUpButton" Content="U_p" Click="ActionUp_Click" Margin="0,0,8,8" />
+                        <ui:Button x:Name="ActionDownButton" Content="{loc:L 'Dow_n'}" Click="ActionDown_Click" Margin="0,0,8,8" />
+                    </WrapPanel>
                 </Grid>
             </Border>
         </Grid>

--- a/hmailserver/source/Tools/ControlPanel/Views/RulesView.xaml.cs
+++ b/hmailserver/source/Tools/ControlPanel/Views/RulesView.xaml.cs
@@ -49,6 +49,10 @@ namespace hMailServer.ControlPanel.Views
       public RulesView()
       {
          InitializeComponent();
+         // Every button here acts on a selected rule, criterion or action.
+         hMailServer.ControlPanel.Services.SelectionGate.Bind(RuleGrid, MoveUpButton, MoveDownButton, ToggleButton, DeleteRuleButton);
+         hMailServer.ControlPanel.Services.SelectionGate.Bind(CriteriaGrid, EditCriterionButton, RemoveCriterionButton);
+         hMailServer.ControlPanel.Services.SelectionGate.Bind(ActionsGrid, EditActionButton, RemoveActionButton, ActionUpButton, ActionDownButton);
 
          suppressMatchMode_ = true;
          MatchMode.Items.Add(L("Match ALL criteria (AND)"));

--- a/hmailserver/source/Tools/ControlPanel/Views/ServerSettingsView.xaml.cs
+++ b/hmailserver/source/Tools/ControlPanel/Views/ServerSettingsView.xaml.cs
@@ -2735,6 +2735,12 @@ namespace hMailServer.ControlPanel.Views
          if (SettingsTabs.Items.Count > 0)
             SettingsTabs.SelectedIndex = 0;
 
+         // A page with one tab is a page, not a tab: the strip with a single
+         // underlined header is hidden. Collapsing the item hides its header
+         // only; the TabControl still presents the selected item's content.
+         if (SettingsTabs.Items.Count == 1 && SettingsTabs.Items[0] is TabItem only)
+            only.Visibility = Visibility.Collapsed;
+
          StatusText.Text = failedReads_ == 0
             ? L("Values read from the server.")
             : F("{0} setting(s) could not be read — {1}", failedReads_, diag_);

--- a/hmailserver/source/Tools/ControlPanel/Views/SslCertificatesView.xaml
+++ b/hmailserver/source/Tools/ControlPanel/Views/SslCertificatesView.xaml
@@ -114,7 +114,7 @@
                                AutomationProperties.Name="{loc:L 'Browse for the private key file'}" />
                     <ui:Button Grid.Column="5" Content="{loc:L '_Add'}" Appearance="Primary" Click="Add_Click" Margin="0,0,8,0"
                                AutomationProperties.Name="{loc:L 'Add the certificate'}" />
-                    <ui:Button Grid.Column="6" Content="{loc:L '_Delete selected'}" Appearance="Danger" Click="Delete_Click"
+                    <ui:Button x:Name="DeleteButton" Grid.Column="6" Content="{loc:L '_Delete selected'}" Appearance="Danger" Click="Delete_Click"
                                AutomationProperties.Name="{loc:L 'Delete the selected certificate'}" />
                 </Grid>
                 <StackPanel Orientation="Horizontal" Margin="0,8,0,0">

--- a/hmailserver/source/Tools/ControlPanel/Views/SslCertificatesView.xaml.cs
+++ b/hmailserver/source/Tools/ControlPanel/Views/SslCertificatesView.xaml.cs
@@ -91,6 +91,7 @@ namespace hMailServer.ControlPanel.Views
       public SslCertificatesView()
       {
          InitializeComponent();
+         hMailServer.ControlPanel.Services.SelectionGate.Bind(CertGrid, DeleteButton);
       }
 
       public void OnEnter() => Reload();

--- a/hmailserver/source/Tools/ControlPanel/Views/StalledMailView.cs
+++ b/hmailserver/source/Tools/ControlPanel/Views/StalledMailView.cs
@@ -29,6 +29,11 @@ namespace hMailServer.ControlPanel.Views
       private const string GuideUrl =
          "https://github.com/Progressiverobot/hmailserver/blob/master/hmailserver/docs/DiagnosingStalledMail.md";
 
+      // The two buttons of the debug-logging card: the one that would change
+      // nothing is disabled, so the state reads off the buttons as well as the line.
+      private Wpf.Ui.Controls.Button debugOn_;
+      private Wpf.Ui.Controls.Button debugOff_;
+
       private readonly TextBlock loggingStatus_ = new()
       {
          FontSize = Typography.Caption,
@@ -102,7 +107,7 @@ namespace hMailServer.ControlPanel.Views
          var content = (StackPanel)card.Child;
 
          var row = new StackPanel { Orientation = Orientation.Horizontal };
-         var enable = new Wpf.Ui.Controls.Button
+         var enable = debugOn_ = new Wpf.Ui.Controls.Button
          {
             Content = L("_Turn on debug logging now"),
             Appearance = Wpf.Ui.Controls.ControlAppearance.Primary,
@@ -112,7 +117,7 @@ namespace hMailServer.ControlPanel.Views
          enable.Click += (s, e) => SetDebugLogging(true);
          row.Children.Add(enable);
 
-         var disable = new Wpf.Ui.Controls.Button { Content = L("Turn it _off again"), Margin = new Thickness(0, 4, 8, 0) };
+         var disable = debugOff_ = new Wpf.Ui.Controls.Button { Content = L("Turn it _off again"), Margin = new Thickness(0, 4, 8, 0) };
          AutomationProperties.SetName(disable, L("Turn debug logging off again"));
          disable.Click += (s, e) => SetDebugLogging(false);
          row.Children.Add(disable);
@@ -248,6 +253,10 @@ namespace hMailServer.ControlPanel.Views
                : debug
                   ? L("Debug logging is ON. The stage timings and the DNS lines are being written; turn it off again when you have what you need.")
                   : L("Debug logging is off. Application logging still records any stage that takes ten seconds or more.");
+            if (debugOn_ != null)
+               debugOn_.IsEnabled = !(enabled && debug);
+            if (debugOff_ != null)
+               debugOff_.IsEnabled = enabled && debug;
          }
          catch (Exception ex) when (!ExceptionPolicy.IsFatal(ex))
          {

--- a/hmailserver/source/Tools/ControlPanel/Views/StatusView.xaml.cs
+++ b/hmailserver/source/Tools/ControlPanel/Views/StatusView.xaml.cs
@@ -293,7 +293,7 @@ namespace hMailServer.ControlPanel.Views
             case 3: return outcome + F("{0} is downloaded and verified", version) + when + L("; Install update applies it");
             case 4: return outcome + F("Installing {0}: the service will stop and start", version);
             case 5: return outcome + F("The last update step failed: {0}", error);
-            default: return outcome + L("Not checked yet (Check for updates, or UpdateCheckEnabled=1 in hMailServer.INI for a daily check)");
+            default: return outcome + L("Not checked yet (Check for updates, or turn on the daily check under Updates on the API & monitoring page)");
          }
       }
 

--- a/hmailserver/source/Tools/ControlPanel/Views/TcpIpPortsView.xaml
+++ b/hmailserver/source/Tools/ControlPanel/Views/TcpIpPortsView.xaml
@@ -108,8 +108,8 @@
                         <ComboBoxItem Content="{loc:L 'STARTTLS (required)'}" />
                     </ComboBox>
                     <ui:Button Grid.Column="4" Content="{loc:L '_Add'}" Appearance="Primary" Click="Add_Click" Margin="0,0,8,0" />
-                    <ui:Button Grid.Column="5" Content="{loc:L '_Properties'}" Click="Edit_Click" Margin="0,0,8,0" />
-                    <ui:Button Grid.Column="6" Content="{loc:L '_Delete selected'}" Appearance="Secondary"
+                    <ui:Button x:Name="PropertiesButton" Grid.Column="5" Content="{loc:L '_Properties'}" Click="Edit_Click" Margin="0,0,8,0" />
+                    <ui:Button x:Name="DeleteButton" Grid.Column="6" Content="{loc:L '_Delete selected'}" Appearance="Secondary"
                                Foreground="{DynamicResource AppDangerBrush}" Click="Delete_Click" Margin="0,0,8,0" />
                     <ui:Button Grid.Column="7" Content="{loc:L '_Restore defaults'}" Click="RestoreDefaults_Click"
                                ToolTip="{loc:L 'Replaces every port with the standard set: SMTP 25 and 587, POP3 110, IMAP 143, all without connection security.'}" />

--- a/hmailserver/source/Tools/ControlPanel/Views/TcpIpPortsView.xaml.cs
+++ b/hmailserver/source/Tools/ControlPanel/Views/TcpIpPortsView.xaml.cs
@@ -37,6 +37,7 @@ namespace hMailServer.ControlPanel.Views
       public TcpIpPortsView()
       {
          InitializeComponent();
+         hMailServer.ControlPanel.Services.SelectionGate.Bind(PortGrid, PropertiesButton, DeleteButton);
       }
 
       public void OnEnter() => Reload();

--- a/hmailserver/source/Tools/ControlPanel/Views/UtilityViews.cs
+++ b/hmailserver/source/Tools/ControlPanel/Views/UtilityViews.cs
@@ -443,8 +443,16 @@ namespace hMailServer.ControlPanel.Views
          TextWrapping = TextWrapping.Wrap,
          Margin = new Thickness(0, 0, 0, 10)
       };
-      private readonly ListView consistencyList_ = new()
+      // A DataGrid rather than a ListView with a GridView: the application's
+      // implicit DataGrid styles theme it, and nothing themes a GridView, whose
+      // white header and system-hyperlink text were unreadable on the dark theme.
+      private readonly DataGrid consistencyList_ = new()
       {
+         AutoGenerateColumns = false,
+         IsReadOnly = true,
+         HeadersVisibility = DataGridHeadersVisibility.Column,
+         GridLinesVisibility = DataGridGridLinesVisibility.None,
+         SelectionMode = DataGridSelectionMode.Single,
          BorderThickness = new Thickness(0),
          Background = System.Windows.Media.Brushes.Transparent,
          // A badly damaged store can list thousands of messages; cap the section
@@ -489,11 +497,16 @@ namespace hMailServer.ControlPanel.Views
          inputRow.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
          inputRow.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
          localDomain_.Margin = new Thickness(0, 0, 8, 0);
-         inputRow.Children.Add(localDomain_);
+         // Two unlabelled boxes read as one question; a caption over each says
+         // which domain is which. The captions double as the accessible names.
+         System.Windows.Automation.AutomationProperties.SetName(localDomain_, L("Hosted domain"));
+         System.Windows.Automation.AutomationProperties.SetName(testDomain_, L("Remote domain"));
+         inputRow.Children.Add(Captioned(L("Hosted domain"), localDomain_));
          testDomain_.Margin = new Thickness(0, 0, 8, 0);
          Grid.SetColumn(testDomain_, 1);
-         inputRow.Children.Add(testDomain_);
-         var actions = new StackPanel { Orientation = Orientation.Horizontal };
+         inputRow.Children.Add(Captioned(L("Remote domain"), testDomain_));
+         // Bottom-aligned, level with the two captioned inputs' boxes.
+         var actions = new StackPanel { Orientation = Orientation.Horizontal, VerticalAlignment = VerticalAlignment.Bottom };
          var run = new Wpf.Ui.Controls.Button { Content = L("_Run diagnostics"), Appearance = Wpf.Ui.Controls.ControlAppearance.Primary };
          run.Click += async (s, e) => await Run();
          actions.Children.Add(run);
@@ -550,30 +563,43 @@ namespace hMailServer.ControlPanel.Views
          Grid.SetRow(consistencyStatus_, 1);
          section.Children.Add(consistencyStatus_);
 
-         var columns = new GridView();
-         columns.Columns.Add(new GridViewColumn
+         consistencyList_.Columns.Add(new DataGridTextColumn
          {
             Header = L("Message ID"),
-            DisplayMemberBinding = new System.Windows.Data.Binding(nameof(Services.MessageStoreConsistencyEntry.MessageId)),
+            Binding = new System.Windows.Data.Binding(nameof(Services.MessageStoreConsistencyEntry.MessageId)),
             Width = 110
          });
-         columns.Columns.Add(new GridViewColumn
+         consistencyList_.Columns.Add(new DataGridTextColumn
          {
             Header = L("Account"),
-            DisplayMemberBinding = new System.Windows.Data.Binding(nameof(Services.MessageStoreConsistencyEntry.Account)),
+            Binding = new System.Windows.Data.Binding(nameof(Services.MessageStoreConsistencyEntry.Account)),
             Width = 220
          });
-         columns.Columns.Add(new GridViewColumn
+         consistencyList_.Columns.Add(new DataGridTextColumn
          {
             Header = L("Expected file"),
-            DisplayMemberBinding = new System.Windows.Data.Binding(nameof(Services.MessageStoreConsistencyEntry.ExpectedPath)),
-            Width = 480
+            Binding = new System.Windows.Data.Binding(nameof(Services.MessageStoreConsistencyEntry.ExpectedPath)),
+            Width = new DataGridLength(1, DataGridLengthUnitType.Star)
          });
-         consistencyList_.View = columns;
          Grid.SetRow(consistencyList_, 2);
          section.Children.Add(consistencyList_);
 
          return section;
+      }
+
+      /// <summary>A small caption above an input, in the secondary text colour.</summary>
+      private static StackPanel Captioned(string caption, FrameworkElement input)
+      {
+         var label = new TextBlock { Text = caption, FontSize = Typography.Caption, Margin = new Thickness(0, 0, 0, 4) };
+         label.SetResourceReference(TextBlock.ForegroundProperty, "TextFillColorSecondaryBrush");
+         // The panel takes the input's place in its grid: its column, and its margin.
+         var panel = new StackPanel { Margin = input.Margin };
+         Grid.SetColumn(panel, Grid.GetColumn(input));
+         Grid.SetRow(panel, Grid.GetRow(input));
+         input.Margin = new Thickness(0);
+         panel.Children.Add(label);
+         panel.Children.Add(input);
+         return panel;
       }
 
       public void OnEnter()


### PR DESCRIPTION
## Summary

A visual pass over every page of the Control Panel - all fifty-five captured as screenshots and read - and the defects it found, fixed.

**Buttons that act on a selection are enabled only while there is one.** On every list page the row actions were live all the time - Delete, Edit, Properties, Release, Deliver now, Follow this message, Move up, Remove action - and a click with nothing selected either did nothing or wrote "Select a row first" into a status line the eye is not on. `Services/SelectionGate.cs` binds a set of buttons to a list's selection in one call, watching the selected item through its dependency property so a reload that clears the selection is seen too. Applied in the generic collection editor (SURBL, DNS blacklists, white lists, blocked senders, greylisting, blocked attachments, groups, and every other page it builds), the delivery queue, message trace, rules (the rule, criterion and action buttons), public folders, routes, quarantine, TCP/IP ports and certificates. IP ranges and scripts already did this.

**Look defects, each visible in the pictures and invisible to a build:**

- The new-account password box on the Domains page rendered as a white box on the dark theme. `PasswordField` derives from WPF-UI's `PasswordBox`, and an implicit style is keyed by the exact type, so the derived control got the bare WPF look everywhere it is used. It now asks for the base type's style.
- The message-store consistency table on the Diagnostics page had a white header and navy text on a dark background: a `ListView` with a `GridView`, which nothing themes. It is a `DataGrid` now, which the application's implicit styles theme, with the last column filling the width.
- The rules page's action buttons overflowed their half-width card and clipped "Down" to "Dov"; the row wraps. The match-mode combo box was too narrow for "Match ALL criteria (AND)"; it has a minimum width that fits.
- A settings page with one tab (Logging, Auto-ban, and others) showed a tab strip with a single underlined header. The header is hidden when there is one.
- On the stalled-mail page, "Turn on debug logging now" stayed the primary button while the line under it said debug logging was already on. The button that would change nothing is disabled.
- The two inputs on the Diagnostics page had no captions once they held values; each has one now (Hosted domain, Remote domain), which also names them for a screen reader.

**Text that pointed at the INI file when the setting is on a page.** Six captions told an administrator to set `QuarantineEnabled`, `MessageTraceEnabled`, `UpdateCheckEnabled` or `WebServicesHttpsPort` in `hMailServer.ini`; every one of those is a setting on a Control Panel page (Anti-spam settings, Logging, API & monitoring under Updates, Web services & autoconfiguration), and the captions name the page now. An empty collection also says "Nothing here yet - Add creates the first entry." instead of only "Loaded from server.".

**Localisation.** Nine captions are new or changed; all seventeen catalogues carry them, with the page names taken from each catalogue's own translations of those pages. The two long External setup captions were spliced: the clause naming the file was replaced and each language's existing translation of the rest kept. `check-localisation.py` and `check-catalogues.py` pass; `Strings.resx` was regenerated by the checker.

**What the sweep also established.** Of the 234 `[Settings]` keys the server reads from `hMailServer.ini`, every one is on a Control Panel page or in its search index except the two fault-injection keys meant for tests (`SimulateDatabaseFailureFor`, `SimulateSpoolWriteFailure`). The INI values themselves have lived in the database since 14 August (the `IniSettingStore` three-way merge the roadmap records), so "every setting in the database and in the Control Panel" is the state of the tree, not a gap.

**Proof.** The Control Panel builds with warnings as errors; its 681 unit tests pass; the affected pages were captured again from this build and read: rule, criterion and action buttons dimmed with nothing selected, the password box themed, the consistency table readable, the action row wrapped, the Logging page without a tab strip, the stalled-mail button disabled while debug logging is on, the Groups page's Edit and Delete dimmed.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring / internal
- [ ] Documentation
- [ ] Build / installer

## Checklist

- [x] Builds warning-free (`/WX`) with `build/build.ps1` - the Control Panel builds with `-warnaserror`
- [x] Regression suite passes with no failures - no server code changes; the Control Panel's 681 tests pass
- [ ] New behavior covered by regression tests - the fixes are visual; the screenshots are the test
- [x] SQL uses parameterised queries only - no SQL
- [x] DB schema changes include scripts for MySQL, MS SQL and PostgreSQL in `source/DBScripts/` - no schema change
- [x] New settings exposed via COM API or `hMailServer.INI` pattern as appropriate - no new settings
