### PR TITLE
Boost is linked statically and Boost.Regex is header-only, so the .deb and the .rpm stop depending on the builder's Boost and ICU sonames and install on the next Ubuntu release, which the packaging run now checks in a container

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -343,11 +343,12 @@ jobs:
   #
   # The .rpm gets the same file assertions inside a Fedora container. It is installed
   # with --nodeps deliberately: the package is built on Ubuntu, so its automatic
-  # requires name Ubuntu's sonames (libboost_thread.so.1.83.0 and its kin) which no
-  # Fedora will ever satisfy. What this proves is the payload and the scriptlets, which
-  # is what CPack decides; whether an RPM distribution's own Boost matches is a question
-  # for a build done on that distribution, and the PKGBUILD makes the same point for
-  # Arch by building from source.
+  # requires name Ubuntu's sonames - libldap-2.5.so.0 where Fedora has libldap.so.2 -
+  # which no Fedora will ever satisfy (Boost is no longer among them: it is linked
+  # statically, see CMakeLists.txt). What this proves is the payload and the
+  # scriptlets, which is what CPack decides; whether an RPM distribution's own
+  # libraries match is a question for a build done on that distribution, and the
+  # PKGBUILD makes the same point for Arch by building from source.
   package-install:
     name: the packaged server installs, starts and serves the Deck
     needs: [ build, stamps ]
@@ -388,6 +389,20 @@ jobs:
           sudo apt-get install -y postgresql-client curl
           sudo apt-get install -y ./packages/hmailserver_*_amd64.deb
           /usr/bin/hmailserver --version
+
+      # The same .deb on the NEXT Ubuntu release, in a container. Boost is linked
+      # statically so that a package built on one release installs on the next;
+      # this is where that claim is checked on every run, against the release the
+      # 6.3.1 package was refused by. The dependencies that remain are printed so
+      # a new soname in the list is seen in the log before a user sees it.
+      - name: The .deb installs on Ubuntu 26.04 too
+        run: |
+          set -euo pipefail
+          deb=$(ls packages/hmailserver_*_amd64.deb)
+          echo "Depends: $(dpkg-deb -f "$deb" Depends)"
+          docker run --rm -v "$PWD/packages:/packages:ro" \
+            ubuntu:26.04@sha256:513c074113a871b51a8d16ab445c88779d6452d937a164fb5cc479f32668a41d \
+            bash -c 'set -e; apt-get update -qq >/dev/null; DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends /packages/hmailserver_*_amd64.deb >/tmp/install.log 2>&1 || { tail -20 /tmp/install.log; exit 1; }; /usr/bin/hmailserver --version'
 
       # The packaged configuration is EDITED, not replaced, so what starts below is
       # the file the package installs with three sections filled in - which is what an

--- a/hmailserver/source/Server/CMakeLists.txt
+++ b/hmailserver/source/Server/CMakeLists.txt
@@ -190,6 +190,18 @@ find_package(ZLIB REQUIRED)
 # the server calls. Against 1.90 it links without being named, which is how the
 # first CI build came to fail at the link step on a runner and not on the
 # machine the port was written on.
+# Boost is linked STATICALLY. A Boost library's soname carries its version
+# (libboost_thread.so.1.83.0), so a package built against the Boost of one
+# distribution release installs on that release and no other: the 6.3.1 .deb,
+# built on Ubuntu 24.04, was refused by Ubuntu 26.04 for five Boost sonames and
+# nothing else (11 September 2026). With the archives linked in, dpkg-shlibdeps
+# and rpmbuild's find-requires see no Boost at all and the package depends on
+# what every release ships under a stable soname: libssl3, libpq5, libldap2,
+# libstdc++6. The -dev packages carry the archives on Debian, Ubuntu and Fedora;
+# the AppImage is unaffected (it bundled the shared libraries and now has none
+# to bundle). Boost.Regex's static archive pulls ICU in only where ICU is
+# called, which this code does not, so no libicu soname appears either.
+set(Boost_USE_STATIC_LIBS ON)
 find_package(Boost 1.83 REQUIRED COMPONENTS thread chrono filesystem regex)
 
 # libpq. PGConnection.h and PGRecordset.h include <libpq-fe.h> by that bare name,

--- a/hmailserver/source/Server/CMakeLists.txt
+++ b/hmailserver/source/Server/CMakeLists.txt
@@ -199,10 +199,16 @@ find_package(ZLIB REQUIRED)
 # what every release ships under a stable soname: libssl3, libpq5, libldap2,
 # libstdc++6. The -dev packages carry the archives on Debian, Ubuntu and Fedora;
 # the AppImage is unaffected (it bundled the shared libraries and now has none
-# to bundle). Boost.Regex's static archive pulls ICU in only where ICU is
-# called, which this code does not, so no libicu soname appears either.
+# to bundle).
+#
+# Boost.Regex is not linked at all: it has been header-only since 1.76, and
+# Debian's compiled archive is built with ICU support, so linking it statically
+# drags in libicu - whose soname also changes with every release (libicu74 on
+# Ubuntu 24.04, libicu76 on 26.04). The first static-Boost package proved that:
+# no Boost in its Depends, and libicu74 still there. The headers alone give
+# the same boost::regex, and nothing here includes boost/regex/icu.hpp.
 set(Boost_USE_STATIC_LIBS ON)
-find_package(Boost 1.83 REQUIRED COMPONENTS thread chrono filesystem regex)
+find_package(Boost 1.83 REQUIRED COMPONENTS thread chrono filesystem)
 
 # libpq. PGConnection.h and PGRecordset.h include <libpq-fe.h> by that bare name,
 # the way the Windows project reaches it through an include directory, and Debian
@@ -293,7 +299,6 @@ target_link_libraries(hmailserver_core PUBLIC
    Boost::thread
    Boost::chrono
    Boost::filesystem
-   Boost::regex
    ${CMAKE_DL_LIBS})
 
 # ---------------------------------------------------------------- the service


### PR DESCRIPTION
## Summary

Boost is linked statically on Linux, so the `.deb` and the `.rpm` stop depending on the builder's Boost sonames and install on the next distribution release.

A Boost library's soname carries its version (`libboost_thread.so.1.83.0`), so a package built against one release's Boost installs on that release and no other. The 6.3.1 `.deb`, built on Ubuntu 24.04, was refused by Ubuntu 26.04 for five Boost sonames and nothing else (found setting up the lab VM on 11 September; the roadmap row records it). With the archives linked in, `dpkg-shlibdeps` and `find-requires` see no Boost at all, and the package depends on what every release ships under a stable soname: `libssl3`, `libpq5`, `libldap2`, `libstdc++6`. The `-dev` packages carry the archives on Debian, Ubuntu and Fedora, so nothing changes in what CI installs; the AppImage bundled the shared Boost libraries and now has none to bundle. Boost.Regex is not linked at all: it has been header-only since 1.76, and Debian's compiled archive is built with ICU support, so linking it statically drags `libicu` in, whose soname also changes with every release.

The `package-install` job gains a step that installs the `.deb` on Ubuntu 26.04 in a container (pinned by digest) and runs `hmailserver --version` there, on every packaging run, and prints the package's `Depends` line first so a new soname is seen in the log before a user sees it. The comment on the Fedora `--nodeps` install now names what remains (`libldap-2.5.so.0`, where Fedora has `libldap.so.2`).

**Proof.** Packaging run 34572717666 of this branch, dispatched with `package=true`: the amd64 `.deb` declares `Depends: libc6 (>= 2.38), libgcc-s1 (>= 3.0), libldap2 (>= 2.6.2), libpq5, libssl3t64 (>= 3.0.0), libstdc++6 (>= 13.1), zlib1g (>= 1:1.1.4)` - no Boost and no ICU; it installed on the runner's Ubuntu 24.04 and, in a container, on Ubuntu 26.04, and `hmailserver --version` answered `hMailServer 6.3.1 build 40` on both; the aarch64 build linked the same way. The first run, 34568068610, showed what static linking alone gives: every Boost soname gone from `Depends` and `libicu74` still there, because Debian's Boost.Regex archive is built with ICU support; Boost.Regex has been header-only since 1.76 and is no longer linked at all, which is what the second run proves.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring / internal
- [ ] Documentation
- [x] Build / installer

## Checklist

- [x] Builds warning-free (`/WX`) with `build/build.ps1` - the Windows build is untouched; the Linux build is the CMake change and the packaging run above
- [x] Regression suite passes with no failures - no server or test code changes; the Linux regression suite of the packaging run above ran against the statically linked server
- [ ] New behavior covered by regression tests - the 26.04 install step is the test
- [x] SQL uses parameterised queries only - no SQL
- [x] DB schema changes include scripts for MySQL, MS SQL and PostgreSQL in `source/DBScripts/` - no schema change
- [x] New settings exposed via COM API or `hMailServer.INI` pattern as appropriate - no new settings
