### PR TITLE
The C++ CodeQL job places the Windows type libraries before it builds, and the one Code Quality finding since the Control Panel polish is fixed

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -241,6 +241,14 @@ jobs:
       # skip every up-to-date file and the analysis failed with "No source code
       # was seen during the build".) build.ps1 disables the pre- and post-build
       # events, so nothing here stops or starts a service.
+      # The ADO 2.8 type library the server #imports is Windows' own file, not in git
+      # (the manifest's "system" kind): placed from the runner's own Windows by the
+      # same script the server build runs, or stdafx.h's #import fails with C1083.
+      - name: Place the system type libraries the server compiles against
+        run: |
+          powershell.exe -NoProfile -ExecutionPolicy Bypass -File build\get-installer-binaries.ps1 -SystemOnly
+          if ($LASTEXITCODE -ne 0) { throw "get-installer-binaries.ps1 -SystemOnly failed with exit code $LASTEXITCODE" }
+
       - name: Build server under CodeQL tracing
         shell: pwsh
         run: |

--- a/hmailserver/source/Tools/ControlPanel/Services/SelectionGate.cs
+++ b/hmailserver/source/Tools/ControlPanel/Services/SelectionGate.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 using System.ComponentModel;
+using System.Linq;
 using System.Windows;
 using System.Windows.Controls.Primitives;
 
@@ -30,11 +31,8 @@ namespace hMailServer.ControlPanel.Services
          void Apply()
          {
             bool any = list.SelectedItem != null;
-            foreach (UIElement target in targets)
-            {
-               if (target != null)
-                  target.IsEnabled = any;
-            }
+            foreach (UIElement target in targets.Where(t => t != null))
+               target.IsEnabled = any;
          }
 
          DependencyPropertyDescriptor


### PR DESCRIPTION
## Summary

Two things the first master run after #202 showed. The C++ CodeQL job builds the server on a Windows runner and did not place the ADO type libraries that left git in #202, so `stdafx.h` failed with C1083 and the C/C++ analysis on master was recorded as unsuccessful; it now runs `build/get-installer-binaries.ps1 -SystemOnly` before the traced build, as the server build does. And the one Code Quality finding since #199 - a `foreach` in `SelectionGate` that skipped nulls inside the loop - filters with `.Where(...)`.

**Proof.** A `workflow_dispatch` of codeql.yml on this branch (the C/C++ job does not run on pull requests) - see the run linked in the comments once it completes.

## Type of change

- [x] Bug fix

## Checklist

- [x] Builds warning-free - the Control Panel builds with `-warnaserror`
- [x] No server or test code changes
