### PR TITLE
The Linux build workflow runs behind Harden-Runner in audit mode and pins its database service images by digest

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -61,6 +61,10 @@ jobs:
     name: the Linux version stamps agree with Version.h
     runs-on: ubuntu-latest
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Check the version stamps
@@ -93,6 +97,10 @@ jobs:
             package: true
 
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Reproducibility, the half CMakeLists.txt cannot do on its own: every tool
@@ -301,6 +309,10 @@ jobs:
     name: cross-compile for aarch64
     runs-on: ubuntu-latest
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install the cross toolchain
@@ -357,7 +369,7 @@ jobs:
     timeout-minutes: 20
     services:
       postgres:
-        image: postgres:16
+        image: postgres:16@sha256:f1c3376c26f2609ab9f29f71f824103fe2fcd8ee0346485cb6122a4f93df6f94
         env:
           POSTGRES_USER: hmailserver
           POSTGRES_PASSWORD: hmtest
@@ -374,6 +386,10 @@ jobs:
       REST_PORT: '8046'
       ADMIN_PASSWORD: testar
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Fetch the x86-64 packages
@@ -599,7 +615,7 @@ jobs:
     timeout-minutes: 60
     services:
       postgres:
-        image: postgres:16
+        image: postgres:16@sha256:f1c3376c26f2609ab9f29f71f824103fe2fcd8ee0346485cb6122a4f93df6f94
         env:
           POSTGRES_USER: hmailserver
           POSTGRES_PASSWORD: hmtest
@@ -630,6 +646,10 @@ jobs:
       HMTEST_SERVER_INI: ${{ github.workspace }}/hmtest-tree/program/hMailServer.ini
       PGPASSWORD: hmtest
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # What the binary loads (ldd names them: Boost thread, chrono, filesystem and
@@ -800,7 +820,7 @@ jobs:
         backend: [pgsql, mysql]
     services:
       postgres:
-        image: postgres:16
+        image: postgres:16@sha256:f1c3376c26f2609ab9f29f71f824103fe2fcd8ee0346485cb6122a4f93df6f94
         env:
           POSTGRES_USER: hmailserver
           POSTGRES_PASSWORD: hmtest
@@ -813,7 +833,7 @@ jobs:
           --health-timeout 5s
           --health-retries 12
       mariadb:
-        image: mariadb:11
+        image: mariadb:11@sha256:2d2f4095530294735a857cfe22bb101e19b0849b416911c796ec4aa81b164a62
         env:
           MARIADB_ROOT_PASSWORD: hmtest
         ports:
@@ -824,6 +844,10 @@ jobs:
           --health-timeout 5s
           --health-retries 12
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install the libraries the server loads, and both clients
@@ -870,6 +894,10 @@ jobs:
       contents: read
       packages: write
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Fetch the amd64 packages the build job made
@@ -1015,6 +1043,10 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
+        with:
+          egress-policy: audit
       - name: Fetch every architecture's packages
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:


### PR DESCRIPTION
Harden-Runner (step-security/harden-runner v2.21.1, pinned to its commit) becomes the first step of all eight jobs of linux-build.yml, in audit mode, and the postgres:16 and mariadb:11 service images are pinned to their current digests. With the actions already pinned and the token already read-only, this is the rest of what StepSecurity's secure-workflow review lists for the workflow. Audit mode records outbound connections and blocks nothing, so the policy can be tightened from evidence later.