### PR TITLE
Two maintainers: Zain Ul Abidin joins Christopher Holloway in GOVERNANCE.md

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,57 +2,58 @@
 #
 # READ THIS BEFORE TURNING ON "Require review from Code Owners".
 #
-# This file on its own changes nothing. It only has an effect once branch
-# protection on master enables "Require a pull request before merging" and
-# "Require review from Code Owners". Until then GitHub uses it to *request*
-# reviews automatically, which is harmless and mildly useful.
+# This file on its own blocks nothing: GitHub uses it to *request* reviews
+# automatically, which is harmless and mildly useful. It gates merging only
+# once the master ruleset enables "Require review from Code Owners".
 #
 # The catch, stated plainly: GitHub will not let you approve your own pull
-# request. While @chrisholloway5 is the only owner listed here, enabling
-# "Require review from Code Owners" makes every pull request he opens
-# unmergeable except by an admin bypass. That is not a hypothetical - it is
-# the single most common way a solo maintainer locks themselves out of their
-# own default branch. Add a second owner with *write* access before turning
-# that setting on, or accept that the rule is satisfied only by bypass.
+# request. With one owner, enabling "Require review from Code Owners" makes
+# every pull request that owner opens unmergeable except by someone on the
+# ruleset's bypass list - the single most common way a solo maintainer locks
+# themselves out of their own default branch. There are two owners now, both
+# with write access, so each can approve the other's pull requests. Keep it
+# that way: every pattern below names both, because a pattern naming one owner
+# puts that owner's own changes to those paths back behind a bypass. A user
+# without write access is not assigned as a code owner at all, so removing
+# someone's write access means removing them here in the same change - and, if
+# code-owner review is required by then, adding a replacement owner with write
+# access in that change too.
 #
-# Ownership order matters: the LAST matching pattern wins, unlike .gitignore.
+# Ownership order matters: the LAST matching pattern wins, as in .gitignore,
+# so a later, narrower pattern replaces the owners of an earlier one rather
+# than adding to them. (Unlike .gitignore, `!` negation does not work here.)
 
-# Default owner for everything in the repository.
-*                                   @chrisholloway5
+# Default owners for everything in the repository.
+*                                   @chrisholloway5 @Zainulabidin90
 
 # Supply chain and CI. A change here can alter what ships or what is trusted
 # without touching a line of server code, so it deserves the same scrutiny as
 # the protocol handlers.
-/.github/                           @chrisholloway5
-/.github/workflows/                 @chrisholloway5
-/.github/CODEOWNERS                 @chrisholloway5
-/.github/SECURITY.md                @chrisholloway5
-/hmailserver/docs/ThirdPartyBinaries.md   @chrisholloway5
-/hmailserver/docs/third-party-binaries.json @chrisholloway5
+/.github/                           @chrisholloway5 @Zainulabidin90
+/.github/workflows/                 @chrisholloway5 @Zainulabidin90
+/.github/CODEOWNERS                 @chrisholloway5 @Zainulabidin90
+/.github/SECURITY.md                @chrisholloway5 @Zainulabidin90
+/hmailserver/docs/ThirdPartyBinaries.md   @chrisholloway5 @Zainulabidin90
+/hmailserver/docs/third-party-binaries.json @chrisholloway5 @Zainulabidin90
 
-# Committed third-party binaries. Nobody can review a DLL in a diff, so the
-# review that matters is of the provenance record that accompanies it.
-/libraries/                         @chrisholloway5
-/hmailserver/installation/          @chrisholloway5
-/hmailserver/source/Tools/Interop/  @chrisholloway5
+# Where the third-party executables and libraries used to be committed. Since
+# 11 September 2026 the build fetches, gathers or copies them instead
+# (build/get-installer-binaries.ps1 and hmailserver/docs/third-party-binaries.json,
+# both owned in this file); these paths still hold the installer scripts and
+# library build scripts that use them.
+/libraries/                         @chrisholloway5 @Zainulabidin90
+/hmailserver/installation/          @chrisholloway5 @Zainulabidin90
+/hmailserver/source/Tools/Interop/  @chrisholloway5 @Zainulabidin90
 
 # Security-relevant server code: TLS, certificate and DANE verification, and
 # the crypto helpers that the security policy names as in scope. (Paths here
 # are checked against the tree - CODEOWNERS silently ignores a pattern that
 # matches nothing, so a typo costs you the rule with no warning.)
-/hmailserver/source/Server/Common/TCPIP/        @chrisholloway5
-/hmailserver/source/Server/Common/Util/Crypt.cpp @chrisholloway5
-/hmailserver/source/Server/Common/Util/Crypt.h  @chrisholloway5
-/hmailserver/source/Server/Common/LDAP/         @chrisholloway5
+/hmailserver/source/Server/Common/TCPIP/        @chrisholloway5 @Zainulabidin90
+/hmailserver/source/Server/Common/Util/Crypt.cpp @chrisholloway5 @Zainulabidin90
+/hmailserver/source/Server/Common/Util/Crypt.h  @chrisholloway5 @Zainulabidin90
+/hmailserver/source/Server/Common/LDAP/         @chrisholloway5 @Zainulabidin90
 
 # Release and signing.
-/RELEASE.md                         @chrisholloway5
-/build/                             @chrisholloway5
-
-# --- Add a second reviewer here ----------------------------------------------
-# Uncomment and replace once a second person holds write access on this
-# repository. A code owner with only read access cannot supply an approval
-# that satisfies branch protection, so granting write is part of the change,
-# not an optional extra.
-#
-# *                                 @chrisholloway5 @second-maintainer
+/RELEASE.md                         @chrisholloway5 @Zainulabidin90
+/build/                             @chrisholloway5 @Zainulabidin90

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -62,7 +62,7 @@ requests, discussions, code review and commit messages.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the maintainer, [@chrisholloway5](https://github.com/chrisholloway5)
+reported to [@chrisholloway5](https://github.com/chrisholloway5)
 (Christopher Holloway / Progressive Robot Ltd). Reports can be sent privately
 through GitHub. All complaints will be reviewed and investigated promptly and
 fairly.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -29,7 +29,9 @@ technical detail — and we will open an advisory and invite you to it.
 | Initial assessment: reproduced or more information requested | 10 working days |
 | Fix released for a confirmed vulnerability | 90 days from the acknowledgement |
 
-This is a small project — a single maintainer, not a staffed security team.
+This is a small project, not a staffed security team: it has two maintainers,
+and one of them currently receives private reports (see
+[GOVERNANCE.md](https://github.com/Progressiverobot/hmailserver/blob/master/GOVERNANCE.md#maintainers)).
 Those are the targets we hold ourselves to, not a contractual commitment. If a
 deadline is going to slip, you will be told before it slips rather than after.
 
@@ -71,21 +73,26 @@ report about them will be closed with a pointer back here:
 - Vulnerabilities in a third-party dependency with no path from hMailServer
   to the affected code. Report those upstream; tell us as well if we ship a
   vulnerable version, and see
-  [ThirdPartyBinaries.md](../hmailserver/docs/ThirdPartyBinaries.md) for what
+  [ThirdPartyBinaries.md](https://github.com/Progressiverobot/hmailserver/blob/master/hmailserver/docs/ThirdPartyBinaries.md) for what
   we ship and where it came from.
 
 ## Supply chain
 
 Every release ships an SBOM (SPDX and CycloneDX) covering both the .NET and
-the native dependencies. Third-party binaries committed to this repository are
-inventoried, checksummed and verified on every build — see
-[hmailserver/docs/ThirdPartyBinaries.md](../hmailserver/docs/ThirdPartyBinaries.md).
+the native dependencies. The third-party executables and libraries the build
+uses are no longer committed to this repository. They are inventoried in
+[hmailserver/docs/ThirdPartyBinaries.md](https://github.com/Progressiverobot/hmailserver/blob/master/hmailserver/docs/ThirdPartyBinaries.md):
+those fetched from the project's `build-inputs-<n>` releases are checked against a
+recorded SHA-256 whenever `build/get-installer-binaries.ps1` places them, the
+MSVC runtime is checked by version, and the ADO type libraries, which are
+Windows' own files, are checked only for presence, with their hash reported.
 
 Two things on a release can be verified independently of GitHub:
 
 - **The release tag** (from `v6.2.23-alpha2` on) is an annotated tag signed
-  with the maintainer's SSH key. The allow list is in the repository, so a
-  clone can check it without trusting anything else:
+  with a maintainer's SSH key listed in `.github/allowed_signers`. That allow
+  list is in the repository, so a clone can check it without trusting
+  anything else:
 
   ```
   git -c gpg.ssh.allowedSignersFile=.github/allowed_signers verify-tag v6.2.23-alpha2
@@ -104,4 +111,5 @@ Two things on a release can be verified independently of GitHub:
   ```
 
 Neither replaces Authenticode: Windows SmartScreen and the UAC prompt do not
-read either signature, and the installer is not Authenticode-signed today.
+read either signature. Since 6.3.1 the Windows installer is also
+Authenticode-signed; the Linux packages are not.

--- a/ASSURANCE-CASE.md
+++ b/ASSURANCE-CASE.md
@@ -339,9 +339,13 @@ credible.
   variance of the suite. The executable grew by about 97 KB of guard tables.
   CFG is a mitigation, not a boundary: a defect that overwrites data rather
   than a pointer is unaffected.
-- **Bus factor is 1.** A single maintainer performs security triage and
-  releases. See [GOVERNANCE.md](GOVERNANCE.md) — a slow security response is a
-  realistic failure mode.
+- **Bus factor is still effectively 1.** Since September 2026 the project has
+  two maintainers, both at Progressive Robot Ltd, but until the second has
+  access to private vulnerability reports and a key in
+  `.github/allowed_signers`, security triage and release tagging rest on one
+  person, and so far only one person has a record of changes to the codebase —
+  see [GOVERNANCE.md](GOVERNANCE.md#continuity). A slow security response
+  remains a realistic failure mode.
 - **Administrators are inside the boundary.** Anyone who can administer the
   server can run code on it. Operators must treat administrative credentials
   as equivalent to host credentials.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -10,25 +10,27 @@ aspirational structure.
 The short version
 -----------------
 
-This is a **single-maintainer project** stewarded by Progressive Robot Ltd.
-Christopher Holloway is the maintainer and currently holds every role below.
-Decisions are made by the maintainer, in the open, on the issue tracker.
+This project has **two maintainers**, Christopher Holloway and Zain Ul Abidin,
+and is stewarded by Progressive Robot Ltd. Decisions are made by the
+maintainers, in the open, on the issue tracker.
 
-That is a real constraint rather than an embarrassment, and it is stated
-plainly here for the same reason it is stated in
+Both maintainers work for Progressive Robot Ltd, and until this change this
+document named Christopher Holloway as the project's only maintainer.
+That is stated plainly here for the same reason the project's size is stated in
 [SECURITY.md](.github/SECURITY.md): people relying on a mail server are
-entitled to know how much of it rests on one person. The
-[Continuity](#continuity) section below says what is and is not currently
-true about that.
+entitled to know how much of it rests on how few people, and on which
+organisation. The [Continuity](#continuity) section below says what is and is
+not currently true about that.
 
 Roles and responsibilities
 --------------------------
 
-### Maintainer
+### Maintainers
 
-**Currently: Christopher Holloway ([@chrisholloway5](https://github.com/chrisholloway5)).**
+**Currently: Christopher Holloway ([@chrisholloway5](https://github.com/chrisholloway5))
+and Zain Ul Abidin ([@Zainulabidin90](https://github.com/Zainulabidin90)).**
 
-The maintainer is accountable for the project. In practice this means:
+The maintainers are accountable for the project. In practice this means:
 
 - **Accepting changes.** Reviewing and merging pull requests, and deciding
   what does and does not belong in the fork.
@@ -43,8 +45,38 @@ The maintainer is accountable for the project. In practice this means:
 - **Infrastructure.** Holding and protecting the credentials listed under
   [Critical assets](#critical-assets).
 
-The maintainer holds admin rights on the GitHub repository and the signing
-and release path.
+Who holds which today:
+
+| Duty | Christopher Holloway | Zain Ul Abidin |
+|---|:-:|:-:|
+| Accepting changes | Yes | Yes |
+| Releasing | Yes | Not yet ¹ |
+| Security response | Yes | Not yet ² |
+| Direction | Yes | Yes |
+| Infrastructure | Yes | No |
+
+Christopher Holloway holds admin rights on the GitHub repository and the
+signing and release path. Zain Ul Abidin holds write access to the
+repository, which is enough to review and merge pull requests and to run the
+release workflows. Two of the duties above need more than write access, and
+neither is in place yet:
+
+1. **Releasing** needs Zain Ul Abidin's SSH signing key in
+   [.github/allowed_signers](.github/allowed_signers): the signing workflow
+   refuses a tag that does not verify against that file. A release also needs
+   a machine set up to run [RELEASE.md](RELEASE.md) steps 4 to 11 — the
+   regression suite, the fuzz runs and the installer build. Until both are in
+   place, releases are tagged by Christopher Holloway.
+2. **Security response** needs repository admin or the organisation's
+   security manager role. Reports arrive through GitHub's private
+   vulnerability reporting: GitHub notifies repository admins and security
+   managers of a new report and lets them, and organisation owners, see every
+   advisory, while anyone else sees a report only once added to it as a
+   collaborator, and cannot publish it. Until one of the roles is granted, Zain
+   Ul Abidin sees a report only if Christopher Holloway adds Zain Ul Abidin to
+   it, so security response rests on Christopher Holloway in practice. (The
+   security manager role is organisation-wide: it also gives read access to
+   every Progressiverobot repository.)
 
 ### Contributor
 
@@ -68,25 +100,52 @@ Reporters are credited for security findings unless they ask not to be.
 How decisions are made
 ----------------------
 
-**Ordinary changes.** The maintainer decides, and the reasoning is recorded
-where the decision happens — in the pull request, in the issue, or in the
-release notes. The project's habit is to write down *why* rather than just
-*what*; the release notes are the clearest example of this and are the
-intended place to look for the reasoning behind a behavioural change.
+**Ordinary changes.** Either maintainer decides on a contributor's pull
+request; a maintainer's own pull request also needs the other's approval (see
+Review). The reasoning is recorded where the decision happens — in the pull
+request, in the issue, or in the release notes. The project's habit is to
+write down *why* rather than just *what*; the release notes are the clearest
+example of this and are the intended place to look for the reasoning behind a
+behavioural change.
 
-**Disagreements.** Raise them on the issue in question. The maintainer will
+**Review.** A pull request authored by one maintainer, or opened by an agent
+on one maintainer's behalf, is approved by the other before it is merged. The
+master ruleset enforces this: a merge needs an approving review from someone
+other than the last person to push, so a reviewer suggests changes rather than
+pushing to the author's branch. A pull request Copilot opens under its own
+identity, rather than for one maintainer, needs both maintainers' approval: the
+ruleset adds one approval for those. The rule binds both maintainers: while
+either is unavailable, the other's own pull requests, release pull requests
+included, wait too. When waiting would hold up something urgent — a security
+fix inside its disclosure window, or a broken build on master — only an
+administrator on the ruleset's bypass list can merge first; Zain Ul Abidin's
+write access carries no bypass. A change merged that way is reviewed
+afterwards, and its pull request says that it was merged before review, and
+why. Reviews are recorded on the pull request rather than anywhere private,
+because that record is what shows that a second person has read the change.
+
+**Disagreements.** Raise them on the issue in question. A maintainer will
 respond with a reason, not just a verdict. A closed issue is not a closed
 conversation — reopening it with new information (especially a reproduction)
-is welcome, and has changed outcomes before.
+is welcome, and has changed outcomes before. If the maintainers disagree, both
+positions are written on the issue and Christopher Holloway decides, recording
+the reason there. When that decision is to merge a pull request the other
+maintainer has not approved, the other maintainer approves it and records the
+disagreement in the review.
 
 **Scope.** Whether something belongs in the fork is decided against one
 question: does it serve people running this as a mail server in production?
 Compatibility with existing hMailServer deployments is a standing constraint,
 not a preference — an upgrade must preserve configuration and mail.
 
-**Security.** Security decisions are the maintainer's alone, and are made
-under the disclosure timetable in [SECURITY.md](.github/SECURITY.md) rather
-than by consensus.
+**Security.** Security decisions are made under the disclosure timetable in
+[SECURITY.md](.github/SECURITY.md), not by consensus. They are the
+maintainers' to make, and either maintainer may decide alone when waiting for
+the other would miss that timetable. Until the second note under
+[Maintainers](#maintainers) is resolved, only Christopher Holloway is notified
+of a report and can publish an advisory, so in practice those decisions are
+Christopher Holloway's; and a fix authored by Zain Ul Abidin always needs
+Christopher Holloway's approval to merge (see Review).
 
 Becoming a maintainer
 ---------------------
@@ -99,6 +158,11 @@ the release and security duties above rather than only the coding.
 If you want to help at that level, say so on an issue. The project would
 benefit from it — see [Continuity](#continuity).
 
+The second maintainer did not come by that route. Zain Ul Abidin was
+appointed in September 2026 from within Progressive Robot Ltd, before building
+a track record in this repository; that record is being built through the
+review rule under [How decisions are made](#how-decisions-are-made).
+
 Critical assets
 ---------------
 
@@ -107,8 +171,8 @@ so that a successor knows what to look for:
 
 | Asset | What it is for |
 |---|---|
-| GitHub repository admin | Accepting changes, managing issues, publishing releases |
-| Release signing path | Sigstore cosign keyless signing of release assets (no long-lived private key is held) |
+| GitHub repository admin | Repository settings and rulesets, including who may bypass them, secrets and variables, private vulnerability reports and security advisories, and granting access |
+| Release signing path | Sigstore cosign keyless signing of release assets, and the SSH keys listed in `.github/allowed_signers` that sign release tags (one today, Christopher Holloway's) |
 | Code-signing material | Signing the Windows installer |
 | Build environment recipe | Visual Studio 2026 / v145 plus the external libraries under `hMailServerLibs` |
 | Test environment recipe | The database, ClamAV, SpamAssassin and INI configuration the full regression suite needs |
@@ -118,41 +182,69 @@ committed to this repository and documented — in
 [README.md](README.md), [ARCHITECTURE.md](ARCHITECTURE.md),
 [RELEASE.md](RELEASE.md), the scripts under `build/`, and the workflows under
 `.github/workflows/`. Deliberately, nothing about producing a release depends
-on knowledge that exists only in the maintainer's head.
+on knowledge that exists only in one maintainer's head.
 
-Note that release signing is **keyless** (Sigstore, via GitHub OIDC). There is
-no private signing key to inherit or to lose, which removes the single most
-common continuity failure for a small project.
+Note that release-asset signing is **keyless** (Sigstore, via GitHub OIDC), so
+there is no private key behind it to inherit or to lose, which removes the
+single most common continuity failure for a small project. Release *tags* are
+signed with a maintainer's own SSH key, which must be listed in
+[.github/allowed_signers](.github/allowed_signers) — today only Christopher
+Holloway's is; a lost key is replaced by adding a new one there, not inherited.
 
 Continuity
 ----------
 
-**Current status: the knowledge bus factor is 1; access continuity is
-arranged.** One person does the work today — but the credentials and legal
-rights needed to continue the project do not die with them. The maintainer
-keeps the critical credentials in a managed arrangement that a trusted person
-can reach if the maintainer is confirmed unavailable, together with the legal
-authority to use them, so the project could create and close issues, accept
-changes and publish a release within days rather than being locked out.
+**Current status: two maintainers, both at Progressive Robot Ltd; access
+continuity is arranged; the record of knowing the codebase is still one
+person's.** Christopher Holloway keeps the critical credentials in a managed
+arrangement that a trusted person can reach if Christopher Holloway is
+confirmed unavailable, together with the legal authority to use them, so the
+project could create and close issues, accept changes and publish a release
+within days rather than being locked out. A second maintainer with write
+access means a contributor's pull request can be reviewed and merged without
+that arrangement. Zain Ul Abidin's own pull requests cannot: the master
+ruleset requires an approval from someone other than the last person to push,
+and GitHub does not let authors approve their own pull requests, so while
+Christopher Holloway is unavailable, those pull requests wait on the
+arrangement too.
 
-What remains true is that no second person currently *knows* the codebase the
-way the maintainer does — that is the bus-factor gap recorded honestly above
-and in the badge entry. The mitigations in place for it:
+What remains true, stated as plainly as the single-maintainer position was:
+
+- **The record is one person's.** Every commit on master made by a person
+  before 11 September 2026 was authored by Christopher Holloway, and none of
+  Christopher Holloway's pull requests had been approved by anyone else, so
+  the repository does not yet show a second person who knows the codebase.
+  That changes only as both maintainers review and write changes here; the
+  review rule under [How decisions are made](#how-decisions-are-made) is what
+  builds that record.
+- **Administration rests on one person.** Only Christopher Holloway holds
+  repository admin and the credentials under
+  [Critical assets](#critical-assets); while Christopher Holloway is
+  unavailable, settings, rulesets, access and security advisories wait on the
+  arrangement above.
+- **Two of the duties need more than write access.** Releasing needs a second
+  tag-signing key and a release machine, and security response needs access to
+  private reports; see the notes under [Maintainers](#maintainers).
+- **One organisation.** Both maintainers work for Progressive Robot Ltd, so
+  the project still depends on one organisation; only a maintainer from
+  outside it would remove that dependence.
+
+The mitigations that were in place for a single maintainer still hold:
 
 - Every build, test and release step is scripted and committed, so the work is
   reproducible by someone else without tacit knowledge.
-- Release signing requires no inherited private key.
+- Release-asset signing requires no inherited private key, and a tag-signing
+  key is replaced rather than inherited.
 - The repository is public, and the licence (AGPLv3) permits anyone to
   continue the work — a fork is always available as a last resort, which is
   precisely how this project itself came to exist.
 
-Closing the gap properly requires a second person with repository admin and
-release rights. The project is open to that; see
+The project is open to further maintainers, and particularly to one from
+outside Progressive Robot Ltd; see
 [Becoming a maintainer](#becoming-a-maintainer).
 
 Changing this document
 ----------------------
 
 Propose changes the same way as any other change: open a pull request. The
-maintainer decides, and, as everywhere else in this project, will give a
-reason.
+maintainers decide, and, as everywhere else in this project, give a reason.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -186,15 +186,17 @@ already cost a release cycle or nearly shipped a defect.
    and it must be green **before** the release is published.
 12. **Commit** (as chrisholloway5, no co-author trailers - history has been
     rewritten once to remove them, and will be again). `master` is protected:
-    changes arrive by pull request, force-pushes and deletions are refused, and
-    the maintainer's bypass exists for emergencies, not for the release flow.
-    So push the working branch, open the PR and merge it with a rebase so the
-    history stays linear and the commits keep their own messages:
+    changes arrive by pull request with an approving review from someone other
+    than the last person to push, force-pushes and deletions are refused, and
+    an administrator's bypass exists for emergencies, not for the release flow.
+    So push the working branch, open the PR, have the other maintainer approve
+    it, and merge it with a rebase so the history stays linear and the commits
+    keep their own messages:
 
     ```
     git push origin server-fixes-wave
     gh pr create --base master --head server-fixes-wave --fill
-    gh pr merge --rebase            # self-merge is allowed; no reviewer is required
+    gh pr merge --rebase            # after the other maintainer's approval (GOVERNANCE.md, Review)
     git pull --ff-only origin master
     ```
 
@@ -321,9 +323,9 @@ Authenticode
 
 Every release asset is signed with cosign, keylessly, and that signature is what
 somebody who deliberately checks can verify. It is not what Windows reads.
-SmartScreen and the UAC prompt read **Authenticode**, and until the installer
-carries one they show an unknown publisher - so the two are complementary and
-this one is still owed.
+SmartScreen and the UAC prompt read **Authenticode**, which the Windows
+installer has carried since 6.3.1 (before that they showed an unknown
+publisher) - so the two are complementary.
 
 **Be clear what it buys, because it is not what everybody assumes.** Signing does
 not remove the SmartScreen warning. Microsoft's own comparison puts a signed


### PR DESCRIPTION
## Summary

- **GOVERNANCE.md** names a second maintainer, Zain Ul Abidin (@Zainulabidin90), beside Christopher Holloway, with a table of who holds which duty today:
  - Both share accepting changes and direction.
  - Releasing and security response are "Not yet" for the second maintainer, with what each needs.
  - Christopher Holloway keeps infrastructure.

  It describes the review the master ruleset now enforces and keeps what is still true: every commit on master made by a person before 11 September 2026 is Christopher Holloway's, administration and the critical credentials rest on one person, and both maintainers work for Progressive Robot Ltd.
- **.github/CODEOWNERS** names both maintainers on every pattern. The last matching pattern wins, so a pattern naming one owner would put that owner's own changes to those paths back behind a bypass once code-owner review is required. The header now describes the ruleset rather than branch protection.
- **.github/SECURITY.md**:
  - says one of the two maintainers currently receives private reports;
  - describes how third-party binaries are checked now that none is committed;
  - links GOVERNANCE.md and ThirdPartyBinaries.md by absolute URL, because relative links from `.github/` break on the repository's Security policy page;
  - records that the 6.3.1 installer is Authenticode-signed.
- **ASSURANCE-CASE.md** keeps the bus factor at effectively 1, with the reason.
- **RELEASE.md**:
  - Step 12 no longer says self-merge needs no reviewer; the ruleset has refused that since 11 September 2026.
  - The Authenticode section no longer calls the signature "still owed".
- **.github/CODE_OF_CONDUCT.md** names its contact without calling them "the maintainer".

## Decisions for @chrisholloway5

Under the current GOVERNANCE.md ("The maintainer decides"), all of this is Christopher Holloway's decision. These parts are new policy, not description:

1. The appointment itself and its scope: accepting changes and direction now, releasing and security response once the steps below are done.
2. Ordinary changes: either maintainer decides on a contributor's pull request, and a maintainer's own pull request needs the other's approval.
3. The review rule, including pull requests an agent opens on a maintainer's behalf. The rule binds both maintainers, so each one's own pull requests, releases included, wait while the other is unavailable. Merging first in an emergency is left to an administrator on the ruleset's bypass list.
4. When the maintainers disagree, Christopher Holloway decides and records the reason. When that decision is to merge a pull request the other maintainer has not approved, the other maintainer approves it and records the disagreement in the review.
5. Security decisions are the maintainers', and either may decide alone when waiting would miss the disclosure timetable.
6. Changes to GOVERNANCE.md are the maintainers' decision.
7. CODEOWNERS: both maintainers on every pattern, and losing write access means removal from it in the same change.
8. The sentence in *Becoming a maintainer* about how the second maintainer was appointed: confirm it is accurate.
9. Left unchanged: RELEASE.md step 12 still says "Commit (as chrisholloway5 …)". Decide whether it should name the maintainer cutting the release.
10. Left unchanged: the Code of Conduct has one contact. Decide whether to add @Zainulabidin90, so a report about one maintainer can go to the other. GitHub's private content reports reach only repository admins, so a second contact would also need a private channel of their own, such as an email address.
11. Continuity now invites further maintainers "particularly … from outside Progressive Robot Ltd". That replaces "Closing the gap properly requires a second person with repository admin and release rights".

## Still needed outside this PR

- [ ] Repository admin, or the organisation's security manager role, for @Zainulabidin90. SECURITY.md routes every report through private vulnerability reporting, and GitHub notifies only admins and security managers of a new report. The security manager role is organisation-wide: it also gives read access to every Progressiverobot repository.
- [ ] @Zainulabidin90's SSH signing key in `.github/allowed_signers`, and a machine that can run RELEASE.md steps 4 to 11.
- [x] Already in place: since 11 September 2026 the master ruleset requires one approving review from someone other than the last person to push, and @Zainulabidin90 has no bypass.
- [ ] Revisit the OpenSSF badge's `bus_factor` answer only once the items above are done and the second maintainer has a record of reviews and commits here, citing `GOVERNANCE.md#continuity`.

## Named follow-ups, not in this PR

- `hmailserver/docs/RegulatoryScope.md` rests on "maintained by one individual, not a company or foundation", which this change makes false. Its own review trigger 3 (maintenance moving to a company) needs evaluating.
- `README.md` line 9 names one maintainer, and line 785 says the provisioning recipe is "kept with the maintainer's internal notes".
- Workflow comments that still describe one maintainer or an unsigned installer:
  - `scorecard.yml:10`;
  - `upstream-watch.yml:12,63`;
  - `dco.yml:15-18`, since maintainers no longer merge their own pull requests;
  - `sign-release.yml:18-19,24-26`;
  - `ci.yml:11`, `server-build.yml:7` and `installer-smoke.yml:6-7`.
- `SECURITY.md`'s Supported Versions table lists only 6.2.x, although 6.3.0 and 6.3.1 are released.
- `Roadmap.md`:
  - the `bus_factor`, `contributors_unassociated` and `two_person_review` rows, and the "ceiling" paragraph;
  - the Scorecard and organisation-2FA housekeeping rows;
  - the live badge percentages.

  This goes in a separate pull request after #206, #207, #213 and #214, which all change the contents table's totals.

## Notes

- The commit is signed off for the DCO check. It also carries a Co-Authored-By trailer, which RELEASE.md step 12 excludes from release commits; say if it should come off here too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
