### PR TITLE
Attest a release published before the .sigstore.json twin and the provenance existed

### DIFF
--- a/.github/workflows/attest-release.yml
+++ b/.github/workflows/attest-release.yml
@@ -1,0 +1,233 @@
+# Copyright (c) 2026 Christopher Holloway / Progressive Robot Ltd and the hMailServer contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# Attest a release that is already published: give every asset a signature
+# under the name OpenSSF Scorecard's Signed-Releases check recognises
+# (.sigstore.json) and attach SLSA provenance for the assets as they are
+# attached. Nothing an installation in the field depends on is touched: an
+# asset that already carries a .cosign.bundle keeps it, byte for byte, and
+# its twin is a copy of it; only an asset with no bundle at all - the
+# build-inputs release, whose binaries every build fetches - is signed here,
+# keylessly, by this workflow's identity, the same way "Sign release
+# artefacts" signs a new release.
+#
+# Why it exists: the twin and the provenance were added to the signing
+# workflow after 6.3.1 shipped, and Scorecard judges the five latest
+# releases, so the four before it and the build-inputs release scored as
+# unsigned. This is the one-off that brings them up to what every release
+# from here on gets on the day it is cut. Run by hand only (workflow_dispatch
+# needs write access), once per tag.
+#
+# Verify a twin exactly as a bundle (they are the same bytes):
+#   cosign verify-blob \
+#     --bundle <asset>.sigstore.json \
+#     --certificate-identity-regexp '^https://github\.com/Progressiverobot/hmailserver/' \
+#     --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+#     <asset>
+# and the provenance with slsa-verifier, as the last job below does.
+
+name: Attest an existing release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag of the published release to attest (e.g. v6.3.1, or build-inputs-1).'
+        type: string
+        required: true
+
+permissions: {}
+
+concurrency:
+  group: attest-release-${{ inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  sign:
+    name: Twin the signatures, sign what has none
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+    outputs:
+      hashes: ${{ steps.attached.outputs.hashes }}
+      tag: ${{ inputs.tag }}
+    steps:
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v3.10.1
+
+      - name: The release exists and is published
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          draft=$(gh release view "$TAG" --json isDraft --jq .isDraft)
+          if [ "$draft" != "false" ]; then
+            echo "::error::${TAG} is a draft; a draft is attested by the signing workflow when it is published."
+            exit 1
+          fi
+
+      - name: Download the assets, and the bundles they already carry
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          mkdir -p assets
+          gh release download "$TAG" --dir assets --pattern '*' --clobber
+          # Provenance and twins are remade below; a .cosign.bundle is kept.
+          rm -f assets/*.sigstore.json assets/*.intoto.jsonl
+          echo "As attached:"
+          ls -la assets
+
+      - name: Twin every bundle; sign every asset that has none
+        id: signing
+        env:
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          twinned=0
+          signed=0
+          for file in assets/*; do
+            [ -f "$file" ] || continue
+            case "$(basename "$file")" in *.cosign.bundle|*.sigstore.json|*.intoto.jsonl|*.sig|*.pem) continue ;; esac
+            if [ -f "${file}.cosign.bundle" ]; then
+              # Verified before it is twinned: a bundle that does not verify
+              # against its file must not be copied under a second name.
+              cosign verify-blob \
+                --bundle "${file}.cosign.bundle" \
+                --certificate-identity-regexp "^https://github\.com/${REPO}/" \
+                --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+                "$file"
+              cp "${file}.cosign.bundle" "${file}.sigstore.json"
+              twinned=$((twinned + 1))
+              echo "twinned $(basename "$file")"
+            else
+              echo "::group::Signing $(basename "$file")"
+              cosign sign-blob --yes \
+                --bundle "${file}.cosign.bundle" \
+                "$file"
+              cp "${file}.cosign.bundle" "${file}.sigstore.json"
+              signed=$((signed + 1))
+              echo "::endgroup::"
+            fi
+          done
+          if [ $((twinned + signed)) -eq 0 ]; then
+            echo "::error::No assets on this release."
+            exit 1
+          fi
+          echo "twinned=${twinned}" >> "$GITHUB_OUTPUT"
+          echo "signed=${signed}" >> "$GITHUB_OUTPUT"
+          echo "Twinned ${twinned} bundle(s); signed ${signed} asset(s) that had none."
+
+      - name: Attach the twins, and the bundles that are new
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          gh release upload "$TAG" assets/*.cosign.bundle assets/*.sigstore.json --clobber
+
+      - name: Verify the release as attached, and list what the provenance attests
+        id: attached
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          rm -rf published
+          mkdir -p published
+          gh release download "$TAG" --dir published --pattern '*' --clobber
+          subjects=()
+          for file in published/*; do
+            [ -f "$file" ] || continue
+            case "$(basename "$file")" in *.cosign.bundle|*.sigstore.json|*.intoto.jsonl|*.sig|*.pem) continue ;; esac
+            [ -f "${file}.cosign.bundle" ] || { echo "::error::$(basename "$file") has no bundle as attached."; exit 1; }
+            cmp -s "${file}.cosign.bundle" "${file}.sigstore.json" || { echo "::error::$(basename "$file"): the twin is not the bundle."; exit 1; }
+            cosign verify-blob \
+              --bundle "${file}.sigstore.json" \
+              --certificate-identity-regexp "^https://github\.com/${REPO}/" \
+              --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+              "$file"
+            subjects+=("$file")
+          done
+          [ "${#subjects[@]}" -gt 0 ] || { echo "::error::nothing to attest."; exit 1; }
+          hashes=$(cd published && sha256sum "${subjects[@]#published/}" | base64 -w0)
+          echo "hashes=${hashes}" >> "$GITHUB_OUTPUT"
+          echo "Verified ${#subjects[@]} asset(s) as attached."
+
+  provenance:
+    needs: sign
+    permissions:
+      actions: read
+      id-token: write
+      contents: write
+    # Referenced by tag on purpose: the generator refuses a hash reference
+    # and slsa-verifier checks the builder's tag (its README). Scorecard's
+    # pinned-dependencies check counts this one line against the project.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+    with:
+      base64-subjects: ${{ needs.sign.outputs.hashes }}
+      provenance-name: hmailserver-${{ needs.sign.outputs.tag }}.intoto.jsonl
+
+  attach-provenance:
+    name: Attach and verify the provenance
+    needs: [sign, provenance]
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: write
+    steps:
+      - name: Fetch the provenance the generator made
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ needs.provenance.outputs.provenance-name }}
+          path: provenance
+
+      - name: Attach it to the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ needs.sign.outputs.tag }}
+          NAME: ${{ needs.provenance.outputs.provenance-name }}
+        run: |
+          set -euo pipefail
+          [ -s "provenance/${NAME}" ] || { echo "::error::the generator's artifact holds no ${NAME}."; exit 1; }
+          gh release upload "$TAG" "provenance/${NAME}" --clobber
+
+      - uses: slsa-framework/slsa-verifier/actions/installer@ea584f4502babc6f60d9bc799dbbb13c1caa9ee6 # v2.7.1
+
+      - name: Verify the provenance as attached, against the assets as attached
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ needs.sign.outputs.tag }}
+          NAME: ${{ needs.provenance.outputs.provenance-name }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          rm -rf published
+          mkdir -p published
+          gh release download "$TAG" --dir published --pattern '*' --clobber
+          cmp -s "provenance/${NAME}" "published/${NAME}" || { echo "::error::${NAME} as attached is not the file the generator made."; exit 1; }
+          subjects=()
+          for file in published/*; do
+            [ -f "$file" ] || continue
+            case "$(basename "$file")" in *.cosign.bundle|*.sigstore.json|*.intoto.jsonl|*.sig|*.pem) continue ;; esac
+            subjects+=("$file")
+          done
+          slsa-verifier verify-artifact "${subjects[@]}" \
+            --provenance-path "published/${NAME}" \
+            --source-uri "github.com/${REPO}" \
+            --source-branch "${REF_NAME}"
+          echo "Provenance verified for ${#subjects[@]} asset(s) of ${TAG}."

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -290,6 +290,16 @@ already cost a release cycle or nearly shipped a defect.
     before publication, because nothing can be added afterwards. 6.2.22-pre4 was
     published straight away and ended up with an installer and no SBOM at all.
 
+    **A release published before the twin and the provenance existed** - 6.3.1
+    and earlier, and the `build-inputs-1` release every build fetches from - is
+    brought up to the same state by `attest-release.yml`, run by hand with the
+    tag: every `.cosign.bundle` it finds is verified and copied to its
+    `.sigstore.json` twin, an asset with no bundle at all is signed keylessly by
+    that workflow's own identity, and the SLSA provenance is generated and
+    attached for the assets as they are attached. The bundles an installation in
+    the field verifies are never replaced. OpenSSF Scorecard judges the five
+    latest releases, so run it once for each of those that predates the twins.
+
     **The two `gh workflow run` lines are required, not belt-and-braces.** Saving a
     draft does not start a workflow: GitHub does not deliver `release` events for
     draft releases, which was measured here rather than assumed - creating the pre5


### PR DESCRIPTION
A new workflow, run by hand with a tag, that brings an already-published release up to what every release gets on the day it is cut since the twins and the provenance were added to the signing workflow (after 6.3.1): every `.cosign.bundle` it finds is verified against its file and copied to its `.sigstore.json` twin; an asset with no bundle at all (only `build-inputs-1`, whose binaries every build fetches) is signed keylessly by the workflow's identity; and SLSA provenance is generated by the generic generator and attached, then verified with slsa-verifier against the assets as attached. Nothing an installation in the field verifies is replaced - an existing bundle is never re-signed.

Why: OpenSSF Scorecard's Signed-Releases check judges the five latest releases and recognises only `.asc/.minisig/.sig/.sign/.sigstore/.sigstore.json` for signatures and `.intoto.jsonl` for provenance, so v6.3.1, v6.3.0, v6.2.28, v6.2.27 and build-inputs-1 score as unsigned today (the check is at 0). Once this has run for each, they carry what the next release will.

RELEASE.md says when to run it. Workflow + one paragraph of RELEASE.md; no server code.