### PR TITLE
Linux: three file streams open a narrow path, so RestApiFiles.cpp and RestApiScheduled.cpp compile again

### DIFF
--- a/hmailserver/source/Server/Common/Util/RestApiFiles.cpp
+++ b/hmailserver/source/Server/Common/Util/RestApiFiles.cpp
@@ -649,7 +649,13 @@ namespace HM
 
       const String path = PathOf(row.token);
       {
+         // A narrow path on POSIX: libstdc++'s streams take no wide one.
+#ifdef HM_PLATFORM_POSIX
+         const AnsiString narrowPath(path);
+         std::ofstream out(narrowPath.c_str(), std::ios::binary | std::ios::app);
+#else
          std::ofstream out(path.c_str(), std::ios::binary | std::ios::app);
+#endif
          if (!out)
             return BuildResponse_(500, "{\"error\":\"the file could not be written\"}");
          out.write(body.c_str(), body.GetLength());
@@ -784,7 +790,12 @@ namespace HM
          return BuildResponse_(405, "{\"error\":\"GET fetches the file\"}");
       }
 
+#ifdef HM_PLATFORM_POSIX
+      const AnsiString narrowPath(PathOf(token));
+      std::ifstream in(narrowPath.c_str(), std::ios::binary);
+#else
       std::ifstream in(PathOf(token).c_str(), std::ios::binary);
+#endif
       if (!in)
          return Page(404, "No such file", "<h1>No such file</h1><p>There is no file at this address, or it has been removed.</p>");
       std::string bytes((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());

--- a/hmailserver/source/Server/Common/Util/RestApiScheduled.cpp
+++ b/hmailserver/source/Server/Common/Util/RestApiScheduled.cpp
@@ -136,7 +136,12 @@ namespace HM
 
       bool ReadWholeFile(const String &fileName, AnsiString &bytes)
       {
+#ifdef HM_PLATFORM_POSIX
+         const AnsiString narrowPath(fileName);
+         std::ifstream in(narrowPath.c_str(), std::ios::binary);
+#else
          std::ifstream in(fileName.c_str(), std::ios::binary);
+#endif
          if (!in)
             return false;
          std::string contents((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());


### PR DESCRIPTION
The Linux census on master fails on RestApiFiles.cpp (652, 787) and RestApiScheduled.cpp (139): std::ofstream/ifstream built from a wide path, which libstdc++ has no constructor for. Each now opens a narrow path under HM_PLATFORM_POSIX, the pattern the tree already uses (RestApiServer.cpp). No change on Windows. Merged once the census on the lab VM confirms the three units compile.