### PR TITLE
The regression suite can drive a console server: HM_CONSOLE_SERVER=1 skips what needs a service restart

### DIFF
--- a/hmailserver/test/RegressionTests/Shared/TestSetup.cs
+++ b/hmailserver/test/RegressionTests/Shared/TestSetup.cs
@@ -62,8 +62,26 @@ namespace RegressionTests.Shared
       ///    [Parallelizable], so NUnit runs one fixture at a time whatever the worker count
       ///    says. If that ever changes, this becomes unsafe and every caller with it.
       /// </summary>
+      /// <summary>
+      /// True when the server under test is a console server - hMailServer.exe /Debug,
+      /// launched by a coverage tool with the service stopped - which HM_CONSOLE_SERVER=1
+      /// in the environment says. Such a server answers COM and the protocols like the
+      /// service, but no service command can restart it, so the fixtures and tests that
+      /// need a restart are skipped, with the reason, rather than left to stop a server
+      /// that will not come back (the coverage run of 13 September 2026: the first
+      /// restart-needing fixture ended the measurement for everything after it).
+      /// </summary>
+      public static bool ConsoleServer =>
+         Environment.GetEnvironmentVariable("HM_CONSOLE_SERVER") == "1";
+
       public void RestartServiceAndReacquire()
       {
+         if (ConsoleServer)
+         {
+            Assert.Ignore("Needs a service restart, and the server under test is a console server " +
+                          "(HM_CONSOLE_SERVER=1), which no service command can restart.");
+         }
+
          RunServiceCommand("stop");
 
          // Wait for the OLD process to actually exit before starting the new one.


### PR DESCRIPTION
The regression suite can drive a console server.

**Why.** Native coverage is measured by running `hMailServer.exe /Debug` under OpenCppCoverage with the service stopped and pointing the suite at it (wave 14 made the console server reachable over COM). The first such run, on 13 September 2026, measured nothing: the suite's `TestSetup.RestartServiceAndReacquire` stops and starts the *service* between fixtures and waits for every `hMailServer.exe` to disappear, so the first fixture needing a restart stopped a server no service command could bring back, and everything after it ran against nothing.

**What changes.** `TestSetup.ConsoleServer` is true when `HM_CONSOLE_SERVER=1` is in the environment; under it, `RestartServiceAndReacquire` ignores the fixture or test with the reason ("Needs a service restart, and the server under test is a console server ... which no service command can restart"). Nothing changes without the variable. The fixtures that restart the server - the DKIM and DMARC ones, FilterHook, Quarantine, Whitelisting, the certificate and port routes, UpdateApply, the IMAP authorisation choke point, TombstoneRetention - are what a coverage run skips; the rest of the suite is what it measures.

**Proof.** `IMAP.TombstoneRetention`: 3 of 3 in the ordinary run; 2 of 2 ignored with the reason under the variable. The full Windows suite on this server, without the variable: 2,219 tests, 2,210 passed, 0 failed, 9 skipped. The coverage script that uses the mode (coverage-console.ps1, elevated, with a ten-minute `-Smoke` first) runs after this merges.
